### PR TITLE
Add placeholder API server and router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/404.html
+++ b/404.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Not Found</title>
+  <link rel="stylesheet" href="CSS/style.css">
+</head>
+<body>
+  <h1>404 - Page Not Found</h1>
+  <p>The page you are looking for does not exist.</p>
+  <a href="index.html">Return Home</a>
+</body>
+</html>

--- a/CSS/style.css
+++ b/CSS/style.css
@@ -1,0 +1,1 @@
+body{font-family:Arial,sans-serif;text-align:center;margin-top:50px;}a{color:#007bff;text-decoration:none;}

--- a/Javascript/router.js
+++ b/Javascript/router.js
@@ -1,0 +1,33 @@
+// Simple client-side router for single-page navigation
+export function initRouter() {
+  document.body.addEventListener('click', async (e) => {
+    const target = e.target.closest('a');
+    if (!target) return;
+    const href = target.getAttribute('href');
+    if (href && !href.startsWith('http') && !href.startsWith('#')) {
+      e.preventDefault();
+      await navigate(href);
+    }
+  });
+
+  const initialPath = window.location.pathname.replace(/^\//, '') || 'index.html';
+  navigate(initialPath);
+}
+
+export async function navigate(path) {
+  const container = document.getElementById('app');
+  if (!container) {
+    window.location.href = path;
+    return;
+  }
+  try {
+    const res = await fetch(path);
+    if (!res.ok) throw new Error('Network response was not ok');
+    container.innerHTML = await res.text();
+    window.history.pushState({}, '', path);
+  } catch (err) {
+    const res = await fetch('404.html');
+    container.innerHTML = await res.text();
+    window.history.pushState({}, '', path);
+  }
+}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Auth is handled via **Supabase Client** → included in `supabaseClient.js`.
 
 - HTML5 + CSS3 + Javascript (ES Modules)
 - FastAPI backend (expected)
+- Node.js Express server for local development (placeholder API)
 - Supabase for auth + data
 - SPA-ready → Netlify optimized
 - No framework (Vanilla + Modules) → lean, fast
@@ -53,3 +54,4 @@ Pre-Alpha build — **feature-complete** FrontEnd.
 ---
 
 # 🚀 GLORY TO THE KINGDOM!
+\n### Local API Server\nRun `npm install` then `npm start` to launch a local server with placeholder API routes.

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
 </head>
 
 <body>
+<div id="app">
 
 <!-- Hero Section -->
 <section class="hero-section" aria-label="Hero Banner">
@@ -102,6 +103,8 @@
     <a href="legal.html">and more</a>
   </div>
 </footer>
+</div>
+<script defer type="module" src="Javascript/router.js"></script>
 
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "kingmakers-rise-frontend",
+  "version": "1.0.0",
+  "description": "Static frontend with placeholder API server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname)));
+
+app.all('/api/*', (req, res) => {
+  res.json({ message: 'Placeholder API endpoint', path: req.path });
+});
+
+app.use((req, res) => {
+  res.status(404).sendFile(path.join(__dirname, '404.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- provide minimal placeholder API server with Express
- add simple client-side router and container to `index.html`
- include basic 404 page and styling
- document the dev server in README

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68433881abf483308cd3ea4627db2b81