### PR TITLE
Add FastAPI runner main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+import uvicorn
+from backend.main import app
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- create a simple `main.py` entrypoint to run the API server via uvicorn

## Testing
- `python -m py_compile main.py backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68436110b41483308cad664fa5f80c15