### PR TITLE
Add Render deployment file

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: kingmakers-rise-backend
+    runtime: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn backend.main:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
## Summary
- add minimal `render.yaml` for deploying FastAPI backend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684362742f4c8330b3b93e2eddc89466