### PR TITLE
Add troop slot logic

### DIFF
--- a/Javascript/kingdom_military.js
+++ b/Javascript/kingdom_military.js
@@ -115,7 +115,7 @@ async function loadRecruitableUnits() {
           await loadTrainingQueue();
         } catch (err) {
           console.error("❌ Error recruiting units:", err);
-          alert("Recruitment failed.");
+          alert(err.message || "Recruitment failed.");
         }
       });
     });

--- a/Javascript/train_troops.js
+++ b/Javascript/train_troops.js
@@ -186,7 +186,7 @@ async function trainTroop(unitId) {
 
   } catch (err) {
     console.error("❌ Error training troop:", err);
-    showToast("Failed to train troop.");
+    showToast(err.message || "Failed to train troop.");
   }
 }
 

--- a/backend/data.py
+++ b/backend/data.py
@@ -1,0 +1,30 @@
+# Simple in-memory data store for the demo API
+
+# Recruitable units for all kingdoms
+recruitable_units = [
+    {
+        "id": 1,
+        "name": "Swordsman",
+        "type": "Infantry",
+        "training_time": 60,
+        "cost": {"gold": 10, "food": 5},
+    },
+    {
+        "id": 2,
+        "name": "Archer",
+        "type": "Ranged",
+        "training_time": 45,
+        "cost": {"gold": 8, "wood": 5},
+    },
+]
+
+# Kingdom military state keyed by kingdom_id
+military_state = {
+    1: {
+        "base_slots": 20,
+        "used_slots": 0,
+        "morale": 100,
+        "queue": [],
+        "history": [],
+    }
+}

--- a/backend/routers/kingdom_military.py
+++ b/backend/routers/kingdom_military.py
@@ -1,35 +1,79 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+
+from ..data import military_state, recruitable_units
 
 router = APIRouter(prefix="/api/kingdom_military", tags=["kingdom_military"])
 
 
 class RecruitPayload(BaseModel):
-    unit: str
-    amount: int
+    unit_id: int
+    quantity: int
+
+
+def get_state():
+    # For this demo there is only kingdom_id 1
+    return military_state.setdefault(1, {
+        "base_slots": 20,
+        "used_slots": 0,
+        "morale": 100,
+        "queue": [],
+        "history": [],
+    })
 
 
 @router.get("/summary")
 async def summary():
-    return {"summary": {}}
+    state = get_state()
+    base = state["base_slots"]
+    used = state["used_slots"]
+    usable = max(0, base - used)
+
+    return {
+        "total_troops": used,
+        "base_slots": base,
+        "used_slots": used,
+        "morale": state["morale"],
+        "usable_slots": usable,
+    }
 
 
 @router.get("/recruitable")
 async def recruitable():
-    return {"units": []}
+    return {"units": recruitable_units}
 
 
 @router.post("/recruit")
 async def recruit(payload: RecruitPayload):
-    return {"message": "Recruiting", "unit": payload.unit}
+    state = get_state()
+
+    if payload.quantity <= 0:
+        raise HTTPException(status_code=400, detail="Invalid quantity")
+
+    if state["used_slots"] + payload.quantity > state["base_slots"]:
+        raise HTTPException(status_code=400, detail="Not enough troop slots")
+
+    unit = next((u for u in recruitable_units if u["id"] == payload.unit_id), None)
+    if not unit:
+        raise HTTPException(status_code=404, detail="Unit not found")
+
+    state["used_slots"] += payload.quantity
+    state["queue"].append({
+        "unit_name": unit["name"],
+        "quantity": payload.quantity,
+    })
+
+    return {"message": "Training queued"}
 
 
 @router.get("/queue")
 async def queue():
-    return {"queue": []}
+    state = get_state()
+    return {"queue": state["queue"]}
 
 
 @router.get("/history")
 async def history():
-    return {"history": []}
+    state = get_state()
+    return {"history": state["history"]}
 

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -135,6 +135,14 @@ CREATE TABLE training_history (
     completed_at TIMESTAMP WITH TIME ZONE
 );
 
+-- MILITARY SLOTS ------------------------------------------------------------
+CREATE TABLE kingdom_troop_slots (
+    kingdom_id INTEGER PRIMARY KEY REFERENCES kingdoms(kingdom_id),
+    base_slots INTEGER DEFAULT 20,
+    used_slots INTEGER DEFAULT 0,
+    morale     INTEGER DEFAULT 100
+);
+
 -- TECHNOLOGY & RESEARCH -----------------------------------------------------
 CREATE TABLE tech_catalogue (
     tech_code        TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add new `kingdom_troop_slots` table in schema
- implement in-memory data store
- wire troop slot logic into API endpoints
- surface backend errors in JS

## Testing
- `python -m py_compile backend/routers/kingdom_military.py backend/routers/kingdom.py backend/data.py`

------
https://chatgpt.com/codex/tasks/task_e_68438193fd948330b914fd21584c807b