### PR TITLE
Implement global combat tick manager

### DIFF
--- a/backend/battle_engine/__init__.py
+++ b/backend/battle_engine/__init__.py
@@ -9,6 +9,7 @@ from .engine import (
     Unit,
     TerrainType,
 )
+from .manager import WarManager, war_manager, run_combat_tick
 
 __all__ = [
     "TerrainGenerator",
@@ -18,4 +19,7 @@ __all__ = [
     "WarState",
     "Unit",
     "TerrainType",
+    "WarManager",
+    "war_manager",
+    "run_combat_tick",
 ]

--- a/backend/battle_engine/manager.py
+++ b/backend/battle_engine/manager.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .engine import BattleTickHandler, WarState
+
+
+class WarManager:
+    """Manage active wars and run combat ticks."""
+
+    def __init__(self) -> None:
+        self._active_wars: Dict[int, WarState] = {}
+        self._war_logs: Dict[int, List[dict]] = {}
+        self.tick_handler = BattleTickHandler()
+
+    def start_war(self, war: WarState) -> None:
+        self._active_wars[war.war_id] = war
+        self._war_logs[war.war_id] = []
+
+    def run_combat_tick(self) -> None:
+        """Process a tick for all active wars."""
+        finished: List[int] = []
+        for war_id, war in self._active_wars.items():
+            logs = self.tick_handler.run_tick(war)
+            self._war_logs[war_id].extend(logs)
+            if war.castle_hp <= 0 or war.tick >= 12:
+                finished.append(war_id)
+        for war_id in finished:
+            del self._active_wars[war_id]
+
+    def get_logs(self, war_id: int) -> List[dict]:
+        return self._war_logs.get(war_id, [])
+
+    def get_war(self, war_id: int) -> WarState | None:
+        return self._active_wars.get(war_id)
+
+
+# Global manager instance used by API routers
+war_manager = WarManager()
+
+
+def run_combat_tick() -> None:
+    """Entry point for the hourly tick engine."""
+    war_manager.run_combat_tick()

--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from ..battle_engine import BattleTickHandler, TerrainGenerator, WarState, Unit
+from ..battle_engine import (
+    BattleTickHandler,
+    TerrainGenerator,
+    WarState,
+    Unit,
+    WarManager,
+    war_manager,
+)
 
 router = APIRouter(tags=["battle"])
 
 # In-memory store for demo purposes
-_active_wars: dict[int, WarState] = {}
-_war_logs: dict[int, list] = {}
-
-tick_handler = BattleTickHandler()
+_manager = war_manager
 
 def _create_demo_war(war_id: int) -> WarState:
     terrain = TerrainGenerator().generate()
@@ -23,24 +27,23 @@ def _create_demo_war(war_id: int) -> WarState:
 @router.post("/api/start-battle/{war_id}")
 async def start_battle(war_id: int):
     war = _create_demo_war(war_id)
-    _active_wars[war_id] = war
-    _war_logs[war_id] = []
+    _manager.start_war(war)
     return {"status": "started", "war_id": war_id}
 
 
 @router.post("/api/run-tick/{war_id}")
 async def run_tick(war_id: int):
-    war = _active_wars.get(war_id)
+    war = _manager.get_war(war_id)
     if not war:
         return {"error": "war not found"}
-    logs = tick_handler.run_tick(war)
-    _war_logs[war_id].extend(logs)
+    logs = _manager.tick_handler.run_tick(war)
+    _manager.get_logs(war_id).extend(logs)
     return {"tick": war.tick, "castle_hp": war.castle_hp, "logs": logs}
 
 
 @router.get("/api/battle-resolution/{war_id}")
 async def battle_resolution(war_id: int):
-    war = _active_wars.get(war_id)
+    war = _manager.get_war(war_id)
     if not war:
         return {"error": "war not found"}
     return {"tick": war.tick, "castle_hp": war.castle_hp}
@@ -48,4 +51,4 @@ async def battle_resolution(war_id: int):
 
 @router.get("/api/battle-replay/{war_id}")
 async def battle_replay(war_id: int):
-    return {"logs": _war_logs.get(war_id, [])}
+    return {"logs": _manager.get_logs(war_id)}


### PR DESCRIPTION
## Summary
- add `WarManager` and global combat tick runner
- expose manager functions via `battle_engine` package
- refactor battle router to use the manager

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684385b59d2c833099e1e4f50cbd89b5