### PR TITLE
Integrate SQLAlchemy database support

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,18 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://postgres:postgres@localhost/postgres')
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,36 @@
 from fastapi import FastAPI
-from .routers import admin, alliance_members, alliance_projects, kingdom, conflicts, black_market, news, alliance_wars, notifications, battle, alliance_quests, changelog, kingdom_military, alliance_vault, audit_log, donate_vip, messages, player_management, market, diplomacy, leaderboard, buildings, wars
+from .routers import (
+    admin,
+    alliance_members,
+    alliance_projects,
+    kingdom,
+    conflicts,
+    black_market,
+    news,
+    alliance_wars,
+    notifications,
+    battle,
+    alliance_quests,
+    changelog,
+    kingdom_military,
+    alliance_vault,
+    audit_log,
+    donate_vip,
+    messages,
+    player_management,
+    market,
+    diplomacy,
+    leaderboard,
+    buildings,
+    wars,
+)
+from .database import engine
+from .models import Base
 
 app = FastAPI(title="Kingmaker's Rise API")
+
+# Ensure tables exist
+Base.metadata.create_all(bind=engine)
 
 app.include_router(alliance_members.router)
 app.include_router(admin.router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, Integer, String, Text, Boolean, BigInteger, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+from .database import Base
+
+class User(Base):
+    __tablename__ = 'users'
+    user_id = Column(UUID(as_uuid=True), primary_key=True)
+    username = Column(String, unique=True, nullable=False)
+    display_name = Column(String, nullable=False)
+    email = Column(String, unique=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+
+class PlayerMessage(Base):
+    __tablename__ = 'player_messages'
+    message_id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+    recipient_id = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+    message = Column(Text)
+    sent_at = Column(DateTime(timezone=True), server_default=func.now())
+    is_read = Column(Boolean, default=False)
+
+class AllianceVault(Base):
+    __tablename__ = 'alliance_vault'
+    alliance_id = Column(Integer, primary_key=True)
+    wood = Column(BigInteger, default=0)
+    stone = Column(BigInteger, default=0)
+    iron_ore = Column(BigInteger, default=0)
+    gold = Column(BigInteger, default=0)
+    gems = Column(BigInteger, default=0)
+    food = Column(BigInteger, default=0)
+    coal = Column(BigInteger, default=0)
+    livestock = Column(BigInteger, default=0)
+    clay = Column(BigInteger, default=0)
+    flax = Column(BigInteger, default=0)
+    tools = Column(BigInteger, default=0)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -1,16 +1,30 @@
 from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from ..database import get_db
+from ..models import AllianceVault
 
 router = APIRouter(prefix="/api/alliance-vault", tags=["alliance_vault"])
 
 
-class VaultAction(BaseModel):
+class VaultTransaction(BaseModel):
+    alliance_id: int = 1
+    resource: str
     amount: int
 
 
 @router.get("/summary")
-async def summary():
-    return {"summary": {}}
+def summary(alliance_id: int = 1, db: Session = Depends(get_db)):
+    vault = db.query(AllianceVault).filter_by(alliance_id=alliance_id).first()
+    if not vault:
+        raise HTTPException(status_code=404, detail="Vault not found")
+    resources = [
+        'wood', 'stone', 'iron_ore', 'gold', 'gems',
+        'food', 'coal', 'livestock', 'clay', 'flax', 'tools'
+    ]
+    totals = {r: getattr(vault, r) for r in resources}
+    return {"totals": totals}
 
 
 @router.get("/custom-board")
@@ -19,13 +33,29 @@ async def custom_board():
 
 
 @router.post("/deposit")
-async def deposit(payload: VaultAction):
-    return {"message": "Deposited", "amount": payload.amount}
+def deposit(payload: VaultTransaction, db: Session = Depends(get_db)):
+    vault = db.query(AllianceVault).filter_by(alliance_id=payload.alliance_id).first()
+    if not vault:
+        vault = AllianceVault(alliance_id=payload.alliance_id)
+        db.add(vault)
+    if not hasattr(vault, payload.resource):
+        raise HTTPException(status_code=400, detail="Invalid resource")
+    setattr(vault, payload.resource, getattr(vault, payload.resource) + payload.amount)
+    db.commit()
+    return {"message": "Deposited"}
 
 
 @router.post("/withdraw")
-async def withdraw(payload: VaultAction):
-    return {"message": "Withdrawn", "amount": payload.amount}
+def withdraw(payload: VaultTransaction, db: Session = Depends(get_db)):
+    vault = db.query(AllianceVault).filter_by(alliance_id=payload.alliance_id).first()
+    if not vault or not hasattr(vault, payload.resource):
+        raise HTTPException(status_code=404, detail="Resource not found")
+    current = getattr(vault, payload.resource)
+    if current < payload.amount:
+        raise HTTPException(status_code=400, detail="Insufficient amount")
+    setattr(vault, payload.resource, current - payload.amount)
+    db.commit()
+    return {"message": "Withdrawn"}
 
 
 @router.get("/history")

--- a/backend/routers/messages.py
+++ b/backend/routers/messages.py
@@ -1,5 +1,8 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from ..database import get_db
+from ..models import User, PlayerMessage
 
 router = APIRouter(prefix="/api/messages", tags=["messages"])
 
@@ -7,9 +10,21 @@ router = APIRouter(prefix="/api/messages", tags=["messages"])
 class MessagePayload(BaseModel):
     recipient: str
     content: str
+    sender_id: str | None = None
 
 
 @router.post("/send")
-async def send_message(payload: MessagePayload):
-    return {"message": "sent", "recipient": payload.recipient}
+def send_message(payload: MessagePayload, db: Session = Depends(get_db)):
+    recipient = db.query(User).filter(User.username == payload.recipient).first()
+    if not recipient:
+        raise HTTPException(status_code=404, detail="Recipient not found")
+    message = PlayerMessage(
+        recipient_id=recipient.user_id,
+        user_id=payload.sender_id,
+        message=payload.content,
+    )
+    db.add(message)
+    db.commit()
+    db.refresh(message)
+    return {"message": "sent", "message_id": message.message_id}
 


### PR DESCRIPTION
## Summary
- add database connection helper
- create ORM models for users, player messages and alliance vault
- create tables on startup
- enable alliance vault and messaging endpoints to use the database

## Testing
- `python3 -m py_compile backend/main.py backend/database.py backend/models.py backend/routers/messages.py backend/routers/alliance_vault.py`

------
https://chatgpt.com/codex/tasks/task_e_684397a590788330948f4f0be76b7e33