### PR TITLE
Add battle DB models and DB-backed battle router

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String, Text, Boolean, BigInteger, DateTime, ForeignKey
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.sql import func
 from .database import Base
 
@@ -35,3 +35,105 @@ class AllianceVault(Base):
     flax = Column(BigInteger, default=0)
     tools = Column(BigInteger, default=0)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
+class WarsTactical(Base):
+    __tablename__ = 'wars_tactical'
+    war_id = Column(Integer, primary_key=True)
+    attacker_kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'))
+    defender_kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'))
+    phase = Column(String)
+    castle_hp = Column(Integer, default=1000)
+    battle_tick = Column(Integer, default=0)
+    war_status = Column(String)
+
+
+class UnitMovement(Base):
+    __tablename__ = 'unit_movements'
+    movement_id = Column(Integer, primary_key=True)
+    war_id = Column(Integer, ForeignKey('wars_tactical.war_id'))
+    kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'))
+    unit_type = Column(String)
+    quantity = Column(Integer)
+    position_x = Column(Integer)
+    position_y = Column(Integer)
+    stance = Column(String)
+    movement_path = Column(JSONB)
+    target_priority = Column(JSONB)
+    patrol_zone = Column(JSONB)
+    fallback_point_x = Column(Integer)
+    fallback_point_y = Column(Integer)
+    withdraw_threshold_percent = Column(Integer)
+    morale = Column(Integer)
+    status = Column(String)
+    visible_enemies = Column(JSONB, default={})
+
+
+class CombatLog(Base):
+    __tablename__ = 'combat_logs'
+    combat_id = Column(Integer, primary_key=True)
+    war_id = Column(Integer, ForeignKey('wars_tactical.war_id'))
+    tick_number = Column(Integer)
+    event_type = Column(String)
+    attacker_unit_id = Column(Integer)
+    defender_unit_id = Column(Integer)
+    position_x = Column(Integer)
+    position_y = Column(Integer)
+    damage_dealt = Column(Integer, default=0)
+    morale_shift = Column(Integer)
+    notes = Column(Text)
+    timestamp = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class BattleResolutionLog(Base):
+    __tablename__ = 'battle_resolution_logs'
+    resolution_id = Column(Integer, primary_key=True)
+    battle_type = Column(String)
+    war_id = Column(Integer, ForeignKey('wars_tactical.war_id'))
+    alliance_war_id = Column(Integer, ForeignKey('alliance_wars.alliance_war_id'))
+    winner_side = Column(String)
+    total_ticks = Column(Integer, default=0)
+    attacker_casualties = Column(Integer, default=0)
+    defender_casualties = Column(Integer, default=0)
+    loot_summary = Column(JSONB, default={})
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class WarScore(Base):
+    __tablename__ = 'war_scores'
+    war_id = Column(Integer, ForeignKey('wars_tactical.war_id'), primary_key=True)
+    attacker_score = Column(Integer, default=0)
+    defender_score = Column(Integer, default=0)
+    victor = Column(String)
+    last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
+class TerrainMap(Base):
+    __tablename__ = 'terrain_map'
+    terrain_id = Column(Integer, primary_key=True)
+    war_id = Column(Integer, ForeignKey('wars_tactical.war_id'))
+    tile_map = Column(JSONB)
+    generated_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class UnitStat(Base):
+    __tablename__ = 'unit_stats'
+    unit_type = Column(String, primary_key=True)
+    tier = Column(Integer)
+    hp = Column(Integer)
+    damage = Column(Integer)
+    defense = Column(Integer)
+    speed = Column(Integer)
+    attack_speed = Column(Integer)
+    range = Column(Integer)
+    vision = Column(Integer)
+    troop_slots = Column(Integer, default=1)
+    is_siege = Column(Boolean, default=False)
+
+
+class KingdomTroop(Base):
+    __tablename__ = 'kingdom_troops'
+    kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'), primary_key=True)
+    unit_type = Column(String, ForeignKey('unit_stats.unit_type'), primary_key=True)
+    quantity = Column(Integer, default=0)
+    last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from .. import models
 
 from ..battle_engine import (
     BattleTickHandler,
@@ -16,39 +20,86 @@ router = APIRouter(tags=["battle"])
 # In-memory store for demo purposes
 _manager = war_manager
 
-def _create_demo_war(war_id: int) -> WarState:
-    terrain = TerrainGenerator().generate()
-    war = WarState(war_id=war_id, tick=0, castle_hp=1000, terrain=terrain)
-    war.units.append(Unit(unit_id=1, kingdom_id=1, unit_type="infantry", quantity=50, x=2, y=10, stance="hold"))
-    war.units.append(Unit(unit_id=2, kingdom_id=2, unit_type="infantry", quantity=50, x=57, y=10, stance="hold"))
+def _load_war_from_db(war_id: int, db: Session) -> WarState:
+    db_war = db.query(models.WarsTactical).filter(models.WarsTactical.war_id == war_id).first()
+    if not db_war:
+        raise HTTPException(status_code=404, detail="War not found")
+    terrain_row = db.query(models.TerrainMap).filter(models.TerrainMap.war_id == war_id).first()
+    terrain = terrain_row.tile_map if terrain_row else TerrainGenerator().generate()
+    war = WarState(war_id=db_war.war_id, tick=db_war.battle_tick, castle_hp=db_war.castle_hp, terrain=terrain)
+    movements = db.query(models.UnitMovement).filter(models.UnitMovement.war_id == war_id).all()
+    for mov in movements:
+        war.units.append(Unit(
+            unit_id=mov.movement_id,
+            kingdom_id=mov.kingdom_id,
+            unit_type=mov.unit_type,
+            quantity=mov.quantity,
+            x=mov.position_x,
+            y=mov.position_y,
+            stance=mov.stance,
+        ))
     return war
 
 
 @router.post("/api/start-battle/{war_id}")
-async def start_battle(war_id: int):
-    war = _create_demo_war(war_id)
+def start_battle(war_id: int, db: Session = Depends(get_db)):
+    war = _load_war_from_db(war_id, db)
     _manager.start_war(war)
     return {"status": "started", "war_id": war_id}
 
 
 @router.post("/api/run-tick/{war_id}")
-async def run_tick(war_id: int):
+def run_tick(war_id: int, db: Session = Depends(get_db)):
     war = _manager.get_war(war_id)
     if not war:
-        return {"error": "war not found"}
+        raise HTTPException(status_code=404, detail="war not active")
     logs = _manager.tick_handler.run_tick(war)
+    db_war = db.query(models.WarsTactical).filter(models.WarsTactical.war_id == war_id).first()
+    if db_war:
+        db_war.castle_hp = war.castle_hp
+        db_war.battle_tick = war.tick
+    for log in logs:
+        db_log = models.CombatLog(
+            war_id=war_id,
+            tick_number=war.tick,
+            event_type=log.get("event"),
+            attacker_unit_id=log.get("attacker_id"),
+            defender_unit_id=log.get("defender_id"),
+            position_x=log.get("pos", (None, None))[0] if isinstance(log.get("pos"), tuple) else log.get("position_x"),
+            position_y=log.get("pos", (None, None))[1] if isinstance(log.get("pos"), tuple) else log.get("position_y"),
+            damage_dealt=log.get("damage"),
+        )
+        db.add(db_log)
+    db.commit()
     _manager.get_logs(war_id).extend(logs)
     return {"tick": war.tick, "castle_hp": war.castle_hp, "logs": logs}
 
 
 @router.get("/api/battle-resolution/{war_id}")
-async def battle_resolution(war_id: int):
-    war = _manager.get_war(war_id)
-    if not war:
-        return {"error": "war not found"}
-    return {"tick": war.tick, "castle_hp": war.castle_hp}
+def battle_resolution(war_id: int, db: Session = Depends(get_db)):
+    res = db.query(models.BattleResolutionLog).filter(models.BattleResolutionLog.war_id == war_id).first()
+    if not res:
+        raise HTTPException(status_code=404, detail="resolution not found")
+    return {
+        "winner_side": res.winner_side,
+        "total_ticks": res.total_ticks,
+        "attacker_casualties": res.attacker_casualties,
+        "defender_casualties": res.defender_casualties,
+    }
 
 
 @router.get("/api/battle-replay/{war_id}")
-async def battle_replay(war_id: int):
-    return {"logs": _manager.get_logs(war_id)}
+def battle_replay(war_id: int, db: Session = Depends(get_db)):
+    logs = db.query(models.CombatLog).filter(models.CombatLog.war_id == war_id).order_by(models.CombatLog.tick_number).all()
+    return {"logs": [
+        {
+            "tick": l.tick_number,
+            "event": l.event_type,
+            "attacker_unit_id": l.attacker_unit_id,
+            "defender_unit_id": l.defender_unit_id,
+            "position_x": l.position_x,
+            "position_y": l.position_y,
+            "damage_dealt": l.damage_dealt,
+        }
+        for l in logs
+    ]}


### PR DESCRIPTION
## Summary
- create SQLAlchemy models for key battle tables
- connect battle API routes to database

## Testing
- `python -m py_compile backend/models.py backend/routers/battle.py`


------
https://chatgpt.com/codex/tasks/task_e_6843a396c8008330bb0f79470cda080b