### PR TITLE
Refactor CSS root imports

### DIFF
--- a/CSS/admin_alerts.css
+++ b/CSS/admin_alerts.css
@@ -4,9 +4,9 @@ File Name: admin_alerts.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
+@import url("./root_theme.css");
 
 
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
 
 
 body {

--- a/CSS/alliance_home.css
+++ b/CSS/alliance_home.css
@@ -4,7 +4,7 @@ File Name: alliance_home.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
 

--- a/CSS/alliance_members.css
+++ b/CSS/alliance_members.css
@@ -4,7 +4,7 @@ File Name: alliance_members.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
 

--- a/CSS/alliance_projects.css
+++ b/CSS/alliance_projects.css
@@ -4,7 +4,7 @@ File Name: alliance_projects.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/alliance_quests.css
+++ b/CSS/alliance_quests.css
@@ -4,7 +4,7 @@ File Name: alliance_quests.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
 

--- a/CSS/alliance_treaties.css
+++ b/CSS/alliance_treaties.css
@@ -4,22 +4,11 @@ File Name: alliance_treaties.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
 
 /* Variables */
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
-
 /* Base */
 body {
   margin: 0;

--- a/CSS/alliance_vault.css
+++ b/CSS/alliance_vault.css
@@ -4,18 +4,7 @@ File Name: alliance_vault.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/alliance_wars.css
+++ b/CSS/alliance_wars.css
@@ -4,22 +4,11 @@ File Name: alliance_wars.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
 
 /* Variables */
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
-
 /* Base */
 body {
   margin: 0;

--- a/CSS/audit_log.css
+++ b/CSS/audit_log.css
@@ -4,20 +4,9 @@ File Name: audit_log.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
 
 /* Base */
 body {

--- a/CSS/battle_live.css
+++ b/CSS/battle_live.css
@@ -4,18 +4,7 @@ File Name: battle_live.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/battle_replay.css
+++ b/CSS/battle_replay.css
@@ -4,20 +4,9 @@ File Name: battle_replay.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
 
 /* Base */
 body {

--- a/CSS/battle_resolution.css
+++ b/CSS/battle_resolution.css
@@ -4,20 +4,9 @@ File Name: battle_resolution.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
 
 body {
   margin: 0;

--- a/CSS/black_market.css
+++ b/CSS/black_market.css
@@ -4,20 +4,9 @@ File Name: black_market.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
 
 body {
   margin: 0;

--- a/CSS/buildings.css
+++ b/CSS/buildings.css
@@ -4,20 +4,9 @@ File Name: buildings.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
 
 body {
   margin: 0;

--- a/CSS/changelog.css
+++ b/CSS/changelog.css
@@ -4,18 +4,7 @@ File Name: changelog.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/conflicts.css
+++ b/CSS/conflicts.css
@@ -4,20 +4,9 @@ File Name: conflicts.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
 
 body {
   margin: 0;

--- a/CSS/diplomacy_center.css
+++ b/CSS/diplomacy_center.css
@@ -4,18 +4,7 @@ File Name: diplomacy_center.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/donate_vip.css
+++ b/CSS/donate_vip.css
@@ -4,20 +4,9 @@ File Name: donate_vip.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
 
 body {
   margin: 0;

--- a/CSS/forgot_password.css
+++ b/CSS/forgot_password.css
@@ -4,16 +4,7 @@ File Name: forgot_password.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.6);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/index.css
+++ b/CSS/index.css
@@ -4,20 +4,9 @@ File Name: index.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
 
 body {
   margin: 0;

--- a/CSS/kingdom_military.css
+++ b/CSS/kingdom_military.css
@@ -4,20 +4,9 @@ File Name: kingdom_military.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
 
 body {
   margin: 0;

--- a/CSS/leaderboard.css
+++ b/CSS/leaderboard.css
@@ -4,18 +4,7 @@ File Name: leaderboard.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/legal.css
+++ b/CSS/legal.css
@@ -4,20 +4,9 @@ File Name: legal.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
 
 body {
   margin: 0;

--- a/CSS/login.css
+++ b/CSS/login.css
@@ -4,19 +4,9 @@ File Name: login.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.6);
-}
 
 body {
   margin: 0;

--- a/CSS/market.css
+++ b/CSS/market.css
@@ -4,20 +4,9 @@ File Name: market.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
+@import url("./root_theme.css");
 
 
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
 
 body {
   margin: 0;

--- a/CSS/message.css
+++ b/CSS/message.css
@@ -4,18 +4,7 @@ File Name: message.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/messages.css
+++ b/CSS/messages.css
@@ -4,18 +4,7 @@ File Name: messages.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/news.css
+++ b/CSS/news.css
@@ -4,18 +4,7 @@ File Name: news.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/notifications.css
+++ b/CSS/notifications.css
@@ -4,18 +4,7 @@ File Name: notifications.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/overview.css
+++ b/CSS/overview.css
@@ -4,18 +4,7 @@ File Name: overview.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/play.css
+++ b/CSS/play.css
@@ -4,18 +4,7 @@ File Name: play.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/player_management.css
+++ b/CSS/player_management.css
@@ -4,18 +4,7 @@ File Name: player_management.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/policies_laws.css
+++ b/CSS/policies_laws.css
@@ -4,18 +4,7 @@ File Name: policies_laws.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/profile.css
+++ b/CSS/profile.css
@@ -4,18 +4,7 @@ File Name: profile.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/projects_kingdom.css
+++ b/CSS/projects_kingdom.css
@@ -4,18 +4,7 @@ File Name: projects_kingdom.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/quest_alliance.css
+++ b/CSS/quest_alliance.css
@@ -4,18 +4,7 @@ File Name: quest_alliance.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/quests.css
+++ b/CSS/quests.css
@@ -4,18 +4,7 @@ File Name: quests.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/research.css
+++ b/CSS/research.css
@@ -4,18 +4,7 @@ File Name: research.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/resources.css
+++ b/CSS/resources.css
@@ -4,18 +4,7 @@ File Name: resources.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/root_theme.css
+++ b/CSS/root_theme.css
@@ -10,7 +10,7 @@ Author: Deathsgift66
    Based on final layout (e.g., kingdom_military.html)
 ------------------------------------------------------------- */
 
-@import url('https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700&family=IM+Fell+English+SC&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Cinzel+Decorative:wght@700&family=IM+Fell+English&family=IM+Fell+English+SC&display=swap');
 
 :root {
   /* ------------------- COLOR SYSTEM ------------------- */
@@ -171,6 +171,10 @@ Author: Deathsgift66
   background: var(--btn-hover-bg);
   color: var(--btn-hover-text);
 }
+.btn:focus {
+  outline: 2px dashed var(--gold);
+  outline-offset: 2px;
+}
 
 /* -----------------------------------------------
    Form Elements Base
@@ -185,6 +189,12 @@ select {
   padding: var(--input-padding);
   font-family: var(--font-body);
   font-size: var(--font-md);
+}
+input:focus,
+textarea:focus,
+select:focus {
+  outline: 2px dashed var(--gold);
+  outline-offset: 2px;
 }
 
 /* -----------------------------------------------
@@ -211,6 +221,10 @@ tr:hover {
   background: var(--table-row-hover);
   color: var(--ink);
 }
+a:focus {
+  outline: 2px dashed var(--gold);
+  outline-offset: 2px;
+}
 
 /* -----------------------------------------------
    Responsive & Utility
@@ -221,10 +235,6 @@ tr:hover {
 .full-height { height: 100%; }
 .flex { display: flex; }
 .grid { display: grid; }
-.gap { gap: var(--gap-default); }
-.p-1 { padding: var(--padding-sm); }
-.p-2 { padding: var(--padding-md); }
-.p-3 { padding: var(--padding-lg); }
 
 /* Banner */
 header.kr-top-banner {
@@ -256,6 +266,19 @@ header.kr-top-banner {
   text-decoration: none;
   color: var(--gold);
 }
+.site-footer a:focus {
+  outline: 2px dashed var(--gold);
+  outline-offset: 2px;
+}
 .site-footer a:hover {
   text-decoration: underline;
+}
+
+@media (max-width: 600px) {
+  header.kr-top-banner {
+    font-size: 1.5rem;
+  }
+  .btn {
+    padding: 0.5rem 1rem;
+  }
 }

--- a/CSS/seasonal_effects.css
+++ b/CSS/seasonal_effects.css
@@ -4,18 +4,7 @@ File Name: seasonal_effects.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/signup.css
+++ b/CSS/signup.css
@@ -4,18 +4,7 @@ File Name: signup.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/temples.css
+++ b/CSS/temples.css
@@ -4,18 +4,7 @@ File Name: temples.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #eae0d5;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/town_criers.css
+++ b/CSS/town_criers.css
@@ -4,18 +4,7 @@ File Name: town_criers.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/trade_logs.css
+++ b/CSS/trade_logs.css
@@ -4,18 +4,7 @@ File Name: trade_logs.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/train_troops.css
+++ b/CSS/train_troops.css
@@ -4,18 +4,7 @@ File Name: train_troops.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/treaty_web.css
+++ b/CSS/treaty_web.css
@@ -4,18 +4,7 @@ File Name: treaty_web.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/tutorial.css
+++ b/CSS/tutorial.css
@@ -4,18 +4,7 @@ File Name: tutorial.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/village.css
+++ b/CSS/village.css
@@ -4,18 +4,7 @@ File Name: village.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/village_master.css
+++ b/CSS/village_master.css
@@ -4,18 +4,7 @@ File Name: village_master.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/villages.css
+++ b/CSS/villages.css
@@ -1,15 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0,0,0,0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/wars.css
+++ b/CSS/wars.css
@@ -4,18 +4,7 @@ File Name: wars.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;

--- a/CSS/world_map.css
+++ b/CSS/world_map.css
@@ -4,18 +4,7 @@ File Name: world_map.css
 Date: June 2, 2025
 Author: Deathsgift66
 */
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap');
-
-:root {
-  --parchment: #fbf0d9;
-  --parchment-dark: #f5e7c4;
-  --stone-bg: #2e2b27;
-  --stone-panel: #3b3631;
-  --ink: #1e1208;
-  --gold: #bfa24b;
-  --accent: #6a5acd;
-  --shadow: rgba(0, 0, 0, 0.4);
-}
+@import url("./root_theme.css");
 
 body {
   margin: 0;


### PR DESCRIPTION
## Summary
- centralize fonts in `root_theme.css`
- remove duplicated `:root` variables from individual styles
- add focus styles and a small responsive media query
- clean out unused utility classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843bacdceb08330b42fb3064bc519d2