### PR TITLE
Fix authGuard import path and message script

### DIFF
--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -4,7 +4,7 @@ File Name: authGuard.js
 Date: June 2, 2025
 Author: Deathsgift66
 */
-import { supabase } from './supabaseClient.js';
+import { supabase } from '../supabaseClient.js';
 
 const requireAdmin = false;
 const minVip = 0;

--- a/account_settings.html
+++ b/account_settings.html
@@ -34,7 +34,7 @@ Author: Deathsgift66
 
   <!-- Scripts -->
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer src="Javascript/account_settings.js"></script>
 </head>
 

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -38,7 +38,7 @@ Author: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" defer src="Javascript/admin_alerts.js"></script>
 </head>
 

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -39,7 +39,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -38,7 +38,7 @@ Author: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <!-- JavaScript -->
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" defer src="Javascript/alliance_home.js"></script>
 </head>

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -27,7 +27,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/alliance_members.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" defer src="Javascript/alliance_members.js"></script>
 </head>
 

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -33,7 +33,7 @@ Author: Deathsgift66
 
   <!-- Scripts -->
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/alliance_projects.js"></script>
 </head>
 

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -40,7 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body class="quest-board-body">

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -40,7 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body style="background: url('Assets/alliancetreaties.png') no-repeat center center fixed; background-size: cover;">

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -39,7 +39,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/audit_log.html
+++ b/audit_log.html
@@ -40,7 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/battle_live.html
+++ b/battle_live.html
@@ -40,7 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/battle_replay.html
+++ b/battle_replay.html
@@ -40,7 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/battle_resolution.html
+++ b/battle_resolution.html
@@ -40,7 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/black_market.html
+++ b/black_market.html
@@ -40,7 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/buildings.html
+++ b/buildings.html
@@ -40,7 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/changelog.html
+++ b/changelog.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/compose.html
+++ b/compose.html
@@ -39,7 +39,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body style="background: url('Assets/play_background.png') no-repeat center center fixed; background-size: cover;">

--- a/conflicts.html
+++ b/conflicts.html
@@ -40,7 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/donate_vip.html
+++ b/donate_vip.html
@@ -40,7 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -40,7 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/legal.html
+++ b/legal.html
@@ -39,7 +39,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/market.html
+++ b/market.html
@@ -38,7 +38,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/message.html
+++ b/message.html
@@ -29,14 +29,14 @@ Author: Deathsgift66
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/message.css" />
   <script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-  <script defer type="module" src="Javascript/message.js"></script>
+  <script defer type="module" src="Javascript/messages.js"></script>
 
   <!-- Global Assets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/messages.html
+++ b/messages.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/news.html
+++ b/news.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/notifications.html
+++ b/notifications.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/overview.html
+++ b/overview.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/play.html
+++ b/play.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/player_management.html
+++ b/player_management.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/policies_laws.html
+++ b/policies_laws.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/preplan_editor.html
+++ b/preplan_editor.html
@@ -28,7 +28,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 <body>
 <div id="navbar-container"></div>

--- a/profile.html
+++ b/profile.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/projects.html
+++ b/projects.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/quest_alliance.html
+++ b/quest_alliance.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/quests.html
+++ b/quests.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/research.html
+++ b/research.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/resources.html
+++ b/resources.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/seasonal_effects.html
+++ b/seasonal_effects.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/temples.html
+++ b/temples.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/town_criers.html
+++ b/town_criers.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/trade_logs.html
+++ b/trade_logs.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/train_troops.html
+++ b/train_troops.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/treaty_web.html
+++ b/treaty_web.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/tutorial.html
+++ b/tutorial.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/village.html
+++ b/village.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/village_master.html
+++ b/village_master.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/villages.html
+++ b/villages.html
@@ -34,7 +34,7 @@
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/wars.html
+++ b/wars.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>

--- a/world_map.html
+++ b/world_map.html
@@ -36,7 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/authGuard.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- fix relative import path for supabase in `authGuard.js`
- adjust HTML pages to load the moved `authGuard` module
- correct single message page to use `messages.js`

## Testing
- `npm test` *(fails: command not found)*
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843bf891e90833088b577be4790aeb0