### PR TITLE
Add username login support

### DIFF
--- a/login.html
+++ b/login.html
@@ -50,7 +50,7 @@ Author: Deathsgift66
   <p class="login-subtitle">Enter the Realm</p>
 
   <form id="login-form" class="login-form">
-    <input type="email" id="email" name="email" placeholder="Your Royal Email" required />
+    <input type="text" id="login-id" name="login-id" placeholder="Email or Ruler Name" required />
     <input type="password" id="password" name="password" placeholder="Secret Passphrase" required />
     <button type="submit" class="royal-button">Enter the Realm</button>
   </form>


### PR DESCRIPTION
## Summary
- enhance login page to accept email or ruler name
- look up email by username if needed and log in

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684479e54b3c8330b33bced710fc96fc