### PR TITLE
Add castle progression gating for quests/projects

### DIFF
--- a/backend/data.py
+++ b/backend/data.py
@@ -28,3 +28,12 @@ military_state = {
         "history": [],
     }
 }
+
+# Simplified castle progression tracking
+castle_progression_state = {
+    1: {
+        "castle_level": 1,
+        "nobles": 0,
+        "knights": 0,
+    }
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,8 @@ from .routers import (
     leaderboard,
     buildings,
     wars,
+    quests_router,
+    projects_router,
 )
 from .database import engine
 from .models import Base
@@ -55,4 +57,6 @@ app.include_router(diplomacy.router)
 app.include_router(leaderboard.router)
 app.include_router(buildings.router)
 app.include_router(wars.router)
+app.include_router(quests_router.router)
+app.include_router(projects_router.router)
 

--- a/backend/routers/projects_router.py
+++ b/backend/routers/projects_router.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..data import castle_progression_state
+
+router = APIRouter(prefix="/api/projects", tags=["projects"])
+
+
+class ProjectPayload(BaseModel):
+    project_code: str
+    kingdom_id: int = 1
+
+
+# Placeholder catalogue with requirements
+def _get_requirements(code: str):
+    catalogue = {
+        "demo_project": {
+            "required_castle_level": 1,
+            "required_nobles": 0,
+            "required_knights": 0,
+        }
+    }
+    return catalogue.get(code, {"required_castle_level": 0, "required_nobles": 0, "required_knights": 0})
+
+
+@router.post("/start")
+async def start_project(payload: ProjectPayload):
+    req = _get_requirements(payload.project_code)
+    prog = castle_progression_state.get(payload.kingdom_id, {"castle_level": 0, "nobles": 0, "knights": 0})
+
+    if (
+        prog["castle_level"] < req["required_castle_level"]
+        or prog["nobles"] < req["required_nobles"]
+        or prog["knights"] < req["required_knights"]
+    ):
+        raise HTTPException(status_code=403, detail="Project requirements not met")
+
+    return {"message": "Project started", "project_code": payload.project_code}

--- a/backend/routers/quests_router.py
+++ b/backend/routers/quests_router.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..data import castle_progression_state
+
+router = APIRouter(prefix="/api/quests", tags=["quests"])
+
+
+class QuestPayload(BaseModel):
+    quest_code: str
+    kingdom_id: int = 1
+
+
+# Placeholder catalogue with requirements
+def _get_requirements(code: str):
+    catalogue = {
+        "demo_quest": {
+            "required_castle_level": 1,
+            "required_nobles": 0,
+            "required_knights": 0,
+        }
+    }
+    return catalogue.get(code, {"required_castle_level": 0, "required_nobles": 0, "required_knights": 0})
+
+
+@router.post("/complete")
+async def complete_quest(payload: QuestPayload):
+    req = _get_requirements(payload.quest_code)
+    prog = castle_progression_state.get(payload.kingdom_id, {"castle_level": 0, "nobles": 0, "knights": 0})
+
+    if (
+        prog["castle_level"] < req["required_castle_level"]
+        or prog["nobles"] < req["required_nobles"]
+        or prog["knights"] < req["required_knights"]
+    ):
+        raise HTTPException(status_code=403, detail="Quest requirements not met")
+
+    return {"message": "Quest completed", "quest_code": payload.quest_code}

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -170,7 +170,10 @@ CREATE TABLE project_player_catalogue (
     name         TEXT NOT NULL,
     description  TEXT,
     power_score  INTEGER DEFAULT 0,
-    cost         JSONB
+    cost         JSONB,
+    required_castle_level INTEGER DEFAULT 0,
+    required_nobles INTEGER DEFAULT 0,
+    required_knights INTEGER DEFAULT 0
 );
 
 CREATE TABLE projects_player (
@@ -187,7 +190,10 @@ CREATE TABLE quest_kingdom_catalogue (
     quest_code     TEXT PRIMARY KEY,
     name           TEXT NOT NULL,
     description    TEXT,
-    duration_hours INTEGER
+    duration_hours INTEGER,
+    required_castle_level INTEGER DEFAULT 0,
+    required_nobles INTEGER DEFAULT 0,
+    required_knights INTEGER DEFAULT 0
 );
 
 CREATE TABLE quest_kingdom_tracking (

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -294,6 +294,9 @@ CREATE TABLE public.project_player_catalogue (
   description text,
   power_score integer DEFAULT 0,
   cost jsonb,
+  required_castle_level integer DEFAULT 0,
+  required_nobles integer DEFAULT 0,
+  required_knights integer DEFAULT 0,
   CONSTRAINT project_player_catalogue_pkey PRIMARY KEY (project_code)
 );
 CREATE TABLE public.projects_alliance (
@@ -347,6 +350,9 @@ CREATE TABLE public.quest_kingdom_catalogue (
   name text NOT NULL,
   description text,
   duration_hours integer,
+  required_castle_level integer DEFAULT 0,
+  required_nobles integer DEFAULT 0,
+  required_knights integer DEFAULT 0,
   CONSTRAINT quest_kingdom_catalogue_pkey PRIMARY KEY (quest_code)
 );
 CREATE TABLE public.quest_kingdom_tracking (


### PR DESCRIPTION
## Summary
- track kingdom castle progression in `data.py`
- add routers to handle project start and quest completion with castle-level checks
- include the new routers in `backend.main`
- extend database schemas with requirement fields for quests and projects

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684496d9d9d883308fd621503b9e4be1