### PR TITLE
Implement castle progression frontend

### DIFF
--- a/Javascript/progression.js
+++ b/Javascript/progression.js
@@ -1,0 +1,135 @@
+/*
+Project Name: Kingmakers Rise Frontend
+File Name: progression.js
+Date: June 2, 2025
+Author: Deathsgift66
+*/
+// Castle and Nobility Progression API Helpers
+
+// =========================
+// API CALL FUNCTIONS
+// =========================
+export async function getCastleProgression() {
+  const res = await fetch('/api/progression/castle');
+  if (!res.ok) {
+    throw new Error('Failed to fetch castle progression');
+  }
+  return res.json();
+}
+
+export async function upgradeCastle() {
+  const res = await fetch('/api/progression/castle/upgrade', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' }
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to upgrade castle');
+  }
+  return res.json();
+}
+
+export async function viewNobles() {
+  const res = await fetch('/api/progression/nobles');
+  if (!res.ok) {
+    throw new Error('Failed to fetch nobles');
+  }
+  return res.json();
+}
+
+export async function viewKnights() {
+  const res = await fetch('/api/progression/knights');
+  if (!res.ok) {
+    throw new Error('Failed to fetch knights');
+  }
+  return res.json();
+}
+
+// =========================
+// OPTIONAL DOM INTEGRATION
+// =========================
+document.addEventListener('DOMContentLoaded', async () => {
+  // Castle Progression
+  const castleEl = document.getElementById('castle-progress');
+  if (castleEl) {
+    try {
+      const data = await getCastleProgression();
+      castleEl.innerHTML = `
+        <p><strong>Level:</strong> ${data.level}</p>
+        <p><strong>XP:</strong> ${data.experience} / ${data.next_level_xp}</p>
+      `;
+    } catch (err) {
+      console.error('❌', err);
+      castleEl.innerHTML = '<p>Failed to load castle data.</p>';
+    }
+  }
+
+  // Nobles
+  const noblesEl = document.getElementById('noble-list');
+  if (noblesEl) {
+    try {
+      const data = await viewNobles();
+      noblesEl.innerHTML = '';
+      const nobles = data.nobles || [];
+      if (nobles.length === 0) {
+        noblesEl.innerHTML = '<li>No nobles found.</li>';
+      } else {
+        nobles.forEach(n => {
+          const li = document.createElement('li');
+          li.textContent = n.name;
+          noblesEl.appendChild(li);
+        });
+      }
+    } catch (err) {
+      console.error('❌', err);
+      noblesEl.innerHTML = '<li>Failed to load nobles.</li>';
+    }
+  }
+
+  // Knights
+  const knightsEl = document.getElementById('knight-list');
+  if (knightsEl) {
+    try {
+      const data = await viewKnights();
+      knightsEl.innerHTML = '';
+      const knights = data.knights || [];
+      if (knights.length === 0) {
+        knightsEl.innerHTML = '<li>No knights found.</li>';
+      } else {
+        knights.forEach(k => {
+          const li = document.createElement('li');
+          li.textContent = k.name;
+          knightsEl.appendChild(li);
+        });
+      }
+    } catch (err) {
+      console.error('❌', err);
+      knightsEl.innerHTML = '<li>Failed to load knights.</li>';
+    }
+  }
+
+  // Upgrade Castle Button
+  const upgradeBtn = document.getElementById('upgrade-castle-btn');
+  if (upgradeBtn) {
+    upgradeBtn.addEventListener('click', async () => {
+      upgradeBtn.disabled = true;
+      try {
+        const result = await upgradeCastle();
+        alert(result.message || 'Castle upgraded!');
+        if (castleEl) {
+          const data = await getCastleProgression();
+          castleEl.innerHTML = `
+            <p><strong>Level:</strong> ${data.level}</p>
+            <p><strong>XP:</strong> ${data.experience} / ${data.next_level_xp}</p>
+          `;
+        }
+      } catch (err) {
+        console.error('❌', err);
+        alert('Failed to upgrade castle.');
+      } finally {
+        upgradeBtn.disabled = false;
+      }
+    });
+  }
+});
+

--- a/overview.html
+++ b/overview.html
@@ -30,6 +30,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/overview.css" />
   <script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script defer type="module" src="Javascript/overview.js"></script>
+  <script defer type="module" src="Javascript/progression.js"></script>
 
   <!-- Global Assets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -92,6 +93,25 @@ Author: Deathsgift66
         <div id="overview-quests">
           <!-- JS will populate -->
         </div>
+      </div>
+      <div class="panel-card">
+        <h3>Castle Progression</h3>
+        <div id="castle-progress">
+          <!-- JS will populate -->
+        </div>
+        <button class="action-btn" id="upgrade-castle-btn">Upgrade Castle</button>
+      </div>
+      <div class="panel-card">
+        <h3>Nobles</h3>
+        <ul id="noble-list">
+          <!-- JS will populate -->
+        </ul>
+      </div>
+      <div class="panel-card">
+        <h3>Knights</h3>
+        <ul id="knight-list">
+          <!-- JS will populate -->
+        </ul>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add `progression.js` with API helpers for castle progression
- add castle progression widgets on Overview page
- connect new script to Overview page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684496e15db083309c871cd4755a3057