### PR TITLE
Implement village creation logic

### DIFF
--- a/backend/data.py
+++ b/backend/data.py
@@ -28,3 +28,14 @@ military_state = {
         "history": [],
     }
 }
+
+# Simple kingdom progression and village tracking
+# In a real application this would be stored in the database.
+kingdom_villages_state = {
+    1: {
+        "castle_level": 1,
+        "max_villages_allowed": 1,
+        "nobles": 1,
+        "villages": [],
+    }
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from .routers import (
     diplomacy,
     leaderboard,
     buildings,
+    villages,
     wars,
 )
 from .database import engine
@@ -54,5 +55,6 @@ app.include_router(market.router)
 app.include_router(diplomacy.router)
 app.include_router(leaderboard.router)
 app.include_router(buildings.router)
+app.include_router(villages.router)
 app.include_router(wars.router)
 

--- a/backend/routers/villages.py
+++ b/backend/routers/villages.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..data import kingdom_villages_state
+
+router = APIRouter(prefix="/api/villages", tags=["villages"])
+
+
+class CreateVillagePayload(BaseModel):
+    kingdom_id: int = 1
+    village_name: str
+
+
+@router.post("/create")
+async def create_village(payload: CreateVillagePayload):
+    state = kingdom_villages_state.setdefault(payload.kingdom_id, {
+        "castle_level": 1,
+        "max_villages_allowed": 1,
+        "nobles": 0,
+        "villages": [],
+    })
+
+    castle_level = state.get("castle_level", 1)
+    max_allowed = state.get("max_villages_allowed", 1)
+    current_count = len(state.get("villages", []))
+
+    if current_count >= max_allowed:
+        raise HTTPException(status_code=400, detail="Max villages reached")
+
+    if state.get("nobles", 0) < 1:
+        raise HTTPException(status_code=400, detail="Not enough Nobles")
+
+    state["nobles"] -= 1
+    village_id = current_count + 1
+    village = {
+        "village_id": village_id,
+        "village_name": payload.village_name,
+    }
+    state["villages"].append(village)
+
+    return {
+        "message": "Village created",
+        "village": village,
+        "castle_level": castle_level,
+        "remaining_nobles": state["nobles"],
+    }


### PR DESCRIPTION
## Summary
- track kingdom villages and castle info in `data.py`
- add `/api/villages/create` endpoint to create new villages with limits
- register villages router in app
- rename router module for consistency

## Testing
- `pytest -q`
- `python3 -m py_compile backend/routers/villages.py backend/main.py backend/data.py`


------
https://chatgpt.com/codex/tasks/task_e_684496ca3be4833099e82b6746a19e9c