### PR TITLE
Implement progression summary and global data loader

### DIFF
--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -5,6 +5,7 @@ Date: June 2, 2025
 Author: Deathsgift66
 */
 import { supabase } from '../supabaseClient.js';
+import { fetchAndStorePlayerProgression, loadPlayerProgressionFromStorage } from '../progressionGlobal.js';
 
 const requireAdmin = false;
 const minVip = 0;
@@ -66,7 +67,7 @@ const requirePermission = null; // e.g. "manage_projects"
     }
 
     // Store for page use
-    window.user = {
+  window.user = {
       id: user.id,
       is_admin: userData.is_admin,
       vip_level: userData.vip_level,
@@ -74,6 +75,11 @@ const requirePermission = null; // e.g. "manage_projects"
       alliance_role: alliance?.alliance_role || null,
       permissions: alliance?.permissions || []
     };
+
+    loadPlayerProgressionFromStorage();
+    if (!window.playerProgression) {
+      await fetchAndStorePlayerProgression(user.id);
+    }
 
     const logoutBtn = document.getElementById("logout-btn");
     if (logoutBtn) {

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -6,6 +6,7 @@ Author: Deathsgift66
 */
 
 import { supabase } from './supabaseClient.js';
+import { fetchAndStorePlayerProgression } from './progressionGlobal.js';
 
 // Initialize Supabase Client
 
@@ -74,6 +75,7 @@ loginForm.addEventListener('submit', async (e) => {
       showMessage('error', error.message);
     } else {
       showMessage('success', 'Login successful! Redirecting...');
+      await fetchAndStorePlayerProgression(data.user.id);
       setTimeout(() => {
         window.location.href = 'play.html';
       }, 1200);

--- a/Javascript/progressionGlobal.js
+++ b/Javascript/progressionGlobal.js
@@ -1,0 +1,43 @@
+/*
+Project Name: Kingmakers Rise Frontend
+File Name: progressionGlobal.js
+Created: 2025-06-02
+Author: Deathsgift66 (modified by Codex)
+*/
+
+// Utility to fetch player progression summary and store globally
+export async function fetchAndStorePlayerProgression(userId) {
+  try {
+    const res = await fetch('/api/progression/summary', {
+      headers: { 'X-User-ID': userId }
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to fetch progression');
+
+    window.playerProgression = {
+      castleLevel: data.castle_level,
+      maxVillages: data.max_villages,
+      availableNobles: data.nobles_available,
+      totalNobles: data.nobles_total,
+      availableKnights: data.knights_available,
+      totalKnights: data.knights_total,
+      troopSlots: data.troop_slots
+    };
+    sessionStorage.setItem('playerProgression', JSON.stringify(window.playerProgression));
+  } catch (err) {
+    console.error('Failed to load player progression', err);
+  }
+}
+
+// Load progression from sessionStorage if available
+export function loadPlayerProgressionFromStorage() {
+  const stored = sessionStorage.getItem('playerProgression');
+  if (stored) {
+    try {
+      window.playerProgression = JSON.parse(stored);
+    } catch (err) {
+      console.error('Failed to parse stored progression', err);
+      sessionStorage.removeItem('playerProgression');
+    }
+  }
+}

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -47,6 +47,27 @@ async def overview():
     return {"overview": "data"}
 
 
+@router.get("/summary")
+async def kingdom_summary():
+    state = get_state()
+    resources = {
+        "gold": 1000,
+        "food": 500,
+        "wood": 300,
+    }
+    return {
+        "resources": resources,
+        "troops": {
+            "total": state["used_slots"],
+            "slots": {
+                "base": state["base_slots"],
+                "used": state["used_slots"],
+                "available": max(0, state["base_slots"] - state["used_slots"]),
+            },
+        },
+    }
+
+
 @router.post("/start_research")
 async def start_research(payload: ResearchPayload):
     return {"message": "Research started", "research": payload.research}


### PR DESCRIPTION
## Summary
- add a new global `progressionGlobal.js` helper
- fetch and store player progression on login and on auth guard
- update overview page JS to use progression data and new `/api/kingdom/summary` endpoint
- implement `/api/progression/summary` and `/api/kingdom/summary` backend endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a12c0bfc8330b7f2152361b94520