### PR TITLE
Add progression banner globally

### DIFF
--- a/CSS/progressionBanner.css
+++ b/CSS/progressionBanner.css
@@ -1,0 +1,14 @@
+#progression-bar {
+  background:#3b2c15;
+  color:#f5f5dc;
+  padding:4px 8px;
+  text-align:center;
+  font-size:0.9rem;
+  font-family:serif;
+  display:flex;
+  gap:0.75rem;
+  justify-content:center;
+}
+#progression-bar span {
+  white-space:nowrap;
+}

--- a/Javascript/progressionBanner.js
+++ b/Javascript/progressionBanner.js
@@ -1,0 +1,26 @@
+import { loadPlayerProgressionFromStorage } from './progressionGlobal.js';
+
+// Inject a small banner showing key progression stats using window.playerProgression
+export function renderProgressionBanner() {
+  loadPlayerProgressionFromStorage();
+  const prog = window.playerProgression;
+  if (!prog) return;
+
+  let bar = document.getElementById('progression-bar');
+  if (!bar) {
+    bar = document.createElement('div');
+    bar.id = 'progression-bar';
+    bar.className = 'progression-bar';
+    document.body.prepend(bar);
+  }
+
+  bar.innerHTML = `
+    <span>Castle Lv ${prog.castleLevel}</span>
+    <span>Villages ${prog.maxVillages}</span>
+    <span>Nobles ${prog.availableNobles}/${prog.totalNobles}</span>
+    <span>Knights ${prog.availableKnights}/${prog.totalKnights}</span>
+    <span>Slots ${prog.troopSlots.used}/${prog.troopSlots.used + prog.troopSlots.available}</span>
+  `;
+}
+
+document.addEventListener('DOMContentLoaded', renderProgressionBanner);

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -29,12 +29,14 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <link rel="stylesheet" href="CSS/alliance_projects.css" />
 
   <!-- Scripts -->
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
   <script defer type="module" src="Javascript/alliance_projects.js"></script>
 </head>
 

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -39,9 +39,11 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body class="quest-board-body">

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -39,9 +39,11 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body style="background: url('Assets/alliancetreaties.png') no-repeat center center fixed; background-size: cover;">

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -38,9 +38,11 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body>

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -35,9 +35,11 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body>

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -39,9 +39,11 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body>

--- a/overview.html
+++ b/overview.html
@@ -36,9 +36,11 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body>

--- a/policies_laws.html
+++ b/policies_laws.html
@@ -35,9 +35,11 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body>

--- a/projects.html
+++ b/projects.html
@@ -35,9 +35,11 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body>

--- a/quests.html
+++ b/quests.html
@@ -35,9 +35,11 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body>

--- a/train_troops.html
+++ b/train_troops.html
@@ -35,9 +35,11 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body>

--- a/villages.html
+++ b/villages.html
@@ -33,9 +33,11 @@
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body>

--- a/wars.html
+++ b/wars.html
@@ -35,9 +35,11 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- add `progressionBanner.js` and accompanying styles
- display player progression in a banner on all major pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a7dfde2c8330b0ee96ff47bb1b61