### PR TITLE
Add progression enforcement utilities

### DIFF
--- a/docs/progression_system.md
+++ b/docs/progression_system.md
@@ -2,7 +2,15 @@
 
 This subsystem tracks castle experience, nobles and knights. Progress is stored
 in PostgreSQL tables accessed through SQLAlchemy. The helper functions in
-`services/progression_service.py` aggregate troop slot bonuses for a kingdom.
+`services/progression_service.py` aggregate troop slot bonuses for a kingdom and
+provide reusable validation helpers.
+
+* `calculate_troop_slots(kid)` – aggregate base and bonus slots
+* `check_progression_requirements(kid, castle, nobles, knights)` – raise an
+  HTTP 403 error if the given kingdom does not meet the required castle level or
+  unit counts
+* `check_troop_slots(kid, troops_requested)` – raise an HTTP 400 error when a
+  troop training request would exceed the available slots
 
 ## Castle Progression
 - Experience points are gained through various actions.

--- a/services/progression_service.py
+++ b/services/progression_service.py
@@ -1,5 +1,6 @@
 """Utility service functions related to progression."""
 
+from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -32,3 +33,68 @@ def calculate_troop_slots(db: Session, kingdom_id: int) -> int:
     total_slots = base_slots + castle_bonus + noble_bonus + knight_bonus
 
     return total_slots
+
+
+def check_progression_requirements(
+    db: Session,
+    kingdom_id: int,
+    required_castle_level: int = 0,
+    required_nobles: int = 0,
+    required_knights: int = 0,
+) -> None:
+    """Validate castle level, noble and knight requirements.
+
+    Raises ``HTTPException`` with status code 403 if any requirement is unmet.
+    """
+
+    # Castle level defaults to 1 if no record exists yet
+    castle_record = db.execute(
+        text(
+            "SELECT castle_level FROM kingdom_castle_progression WHERE kingdom_id = :kid"
+        ),
+        {"kid": kingdom_id},
+    ).fetchone()
+    castle_level = castle_record[0] if castle_record else 1
+
+    if castle_level < required_castle_level:
+        raise HTTPException(status_code=403, detail="Castle level too low")
+
+    nobles = db.execute(
+        text("SELECT COUNT(*) FROM kingdom_nobles WHERE kingdom_id = :kid"),
+        {"kid": kingdom_id},
+    ).fetchone()[0]
+    if nobles < required_nobles:
+        raise HTTPException(status_code=403, detail="Not enough nobles")
+
+    knights = db.execute(
+        text("SELECT COUNT(*) FROM kingdom_knights WHERE kingdom_id = :kid"),
+        {"kid": kingdom_id},
+    ).fetchone()[0]
+    if knights < required_knights:
+        raise HTTPException(status_code=403, detail="Not enough knights")
+
+
+def check_troop_slots(db: Session, kingdom_id: int, troops_requested: int) -> None:
+    """Ensure the kingdom has enough free troop slots for a request."""
+
+    record = db.execute(
+        text(
+            """
+            SELECT base_slots, castle_bonus_slots, noble_bonus_slots,
+                   knight_bonus_slots, used_slots
+            FROM kingdom_troop_slots
+            WHERE kingdom_id = :kid
+            """
+        ),
+        {"kid": kingdom_id},
+    ).fetchone()
+
+    if not record:
+        total_slots = 0
+        used_slots = 0
+    else:
+        base, castle_bonus, noble_bonus, knight_bonus, used_slots = record
+        total_slots = base + castle_bonus + noble_bonus + knight_bonus
+
+    if used_slots + troops_requested > total_slots:
+        raise HTTPException(status_code=400, detail="Not enough troop slots")


### PR DESCRIPTION
## Summary
- implement `check_progression_requirements` and `check_troop_slots`
- document new helpers in progression system docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ad43abdc8330bdee8d31a645bf58