### PR TITLE
Fix public pages accessible without auth

### DIFF
--- a/Javascript/apiBase.js
+++ b/Javascript/apiBase.js
@@ -2,6 +2,7 @@ const API_BASE_URL = window.API_BASE_URL || 'https://kingmakers-backend.onrender
 
 // Global public pages — bypass auth check
 const PUBLIC_PAGES = [
+  '', // root path
   'index.html',
   'signup.html',
   'signin.html',

--- a/legal.html
+++ b/legal.html
@@ -39,7 +39,6 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
 </head>
 


### PR DESCRIPTION
## Summary
- allow root URL to bypass auth check
- remove auth guard from legal page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844b0c6cc60833094050f52f6ce449f