### PR TITLE
Add password complexity popup

### DIFF
--- a/Javascript/account_settings.js
+++ b/Javascript/account_settings.js
@@ -87,6 +87,11 @@ document.getElementById('account-form').addEventListener('submit', async (e) => 
     // Update Password if entered
     const newPassword = document.getElementById('new_password').value;
     if (newPassword) {
+      if (!validatePasswordComplexity(newPassword)) {
+        throw new Error(
+          "Password should contain at least one character of each: abcdefghijklmnopqrstuvwxyz, ABCDEFGHIJKLMNOPQRSTUVWXYZ, 0123456789, !@#$%^&*()_+-=[]{};':\"|<>?,./`~."
+        );
+      }
       const { error: pwError } = await supabase.auth.updateUser({ password: newPassword });
       if (pwError) throw new Error('Failed to update password: ' + pwError.message);
     }
@@ -118,4 +123,18 @@ if (logoutBtn) {
   });
 } else {
   console.warn('⚠️ Logout button not found in DOM');
+}
+
+// ✅ Helper: Password Complexity
+function validatePasswordComplexity(password) {
+  const lower = /[a-z]/;
+  const upper = /[A-Z]/;
+  const digit = /[0-9]/;
+  const special = /[!@#$%^&*()_+\-=[\]{};':"\\|<>?,./`~]/;
+  return (
+    lower.test(password) &&
+    upper.test(password) &&
+    digit.test(password) &&
+    special.test(password)
+  );
 }

--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -55,6 +55,13 @@ async function handleSignup() {
     return;
   }
 
+  if (!validatePasswordComplexity(password)) {
+    showToast(
+      "Password should contain at least one character of each: abcdefghijklmnopqrstuvwxyz, ABCDEFGHIJKLMNOPQRSTUVWXYZ, 0123456789, !@#$%^&*()_+-=[]{};':\"|<>?,./`~."
+    );
+    return;
+  }
+
   if (password !== confirmPassword) {
     showToast("Passwords do not match.");
     return;
@@ -131,6 +138,20 @@ async function handleSignup() {
 function validateEmail(email) {
   const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return regex.test(email);
+}
+
+// ✅ Helper: Password Complexity
+function validatePasswordComplexity(password) {
+  const lower = /[a-z]/;
+  const upper = /[A-Z]/;
+  const digit = /[0-9]/;
+  const special = /[!@#$%^&*()_+\-=[\]{};':"\\|<>?,./`~]/;
+  return (
+    lower.test(password) &&
+    upper.test(password) &&
+    digit.test(password) &&
+    special.test(password)
+  );
 }
 
 // ✅ Helper: Toast


### PR DESCRIPTION
## Summary
- add front-end password complexity validation for signup and account settings
- show popup if password lacks lowercase, uppercase, number or special char

## Testing
- `pytest -q` *(fails: `pytest` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844c531301083309199ebf2b367fd3e