### PR TITLE
Fix signup user insert error

### DIFF
--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -106,7 +106,6 @@ async function handleSignup() {
         user_id: user.id,
         username: payload.username,
         display_name: payload.display_name,
-        kingdom_name: payload.kingdom_name,
         email: payload.email,
         setup_complete: false
       });


### PR DESCRIPTION
## Summary
- remove invalid `kingdom_name` field from users insert in signup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c9c27dac83309c82fa6643911346