### PR TITLE
Add dynamic region support

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -35,6 +35,15 @@ CREATE TABLE kingdoms (
     created_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+CREATE TABLE region_catalogue (
+    region_code TEXT PRIMARY KEY,
+    name TEXT,
+    description TEXT,
+    resource_bonus JSONB DEFAULT '{}'::jsonb,
+    troop_bonus INTEGER DEFAULT 0
+);
+
+
 CREATE TABLE kingdom_resources (
     kingdom_id INTEGER PRIMARY KEY REFERENCES kingdoms(kingdom_id),
     wood BIGINT DEFAULT 0,

--- a/migrations/2025_06_08_add_regions.sql
+++ b/migrations/2025_06_08_add_regions.sql
@@ -1,0 +1,21 @@
+-- Migration: Add regions support
+
+-- Ensure kingdoms has region column
+ALTER TABLE public.kingdoms
+  ADD COLUMN IF NOT EXISTS region text;
+
+-- Catalogue of available regions
+CREATE TABLE public.region_catalogue (
+  region_code text PRIMARY KEY,
+  name text,
+  description text,
+  resource_bonus jsonb DEFAULT '{}',
+  troop_bonus integer DEFAULT 0
+);
+
+-- Sample starter regions
+INSERT INTO public.region_catalogue (region_code, name, description, resource_bonus, troop_bonus) VALUES
+  ('north', 'Northlands', 'Cold and rugged with hardy people.', '{"wood":50}', 2),
+  ('south', 'Southlands', 'Fertile fields and warm climate.', '{"food":100}', 1),
+  ('east', 'Eastreach', 'Rich trade routes and culture.', '{"gold":20}', 3),
+  ('west', 'Westvale', 'Frontier lands full of stone.', '{"stone":50}', 0);

--- a/play.html
+++ b/play.html
@@ -64,11 +64,8 @@ Author: Deathsgift66
         <input type="text" id="kingdom-name-input" placeholder="Kingdom Name" />
         <select id="region-select">
           <option value="">Select Region</option>
-          <option value="North">North</option>
-          <option value="South">South</option>
-          <option value="East">East</option>
-          <option value="West">West</option>
         </select>
+        <div id="region-info" class="region-info"></div>
         <input type="text" id="village-name-input" placeholder="First Village Name" />
         <button id="create-kingdom-btn">Create Kingdom</button>
       </div>

--- a/services/progression_service.py
+++ b/services/progression_service.py
@@ -16,10 +16,12 @@ def calculate_troop_slots(db: Session, kingdom_id: int) -> int:
     result = db.execute(
         text(
             """
-            SELECT base_slots, castle_bonus_slots, noble_bonus_slots,
-                   knight_bonus_slots
-            FROM kingdom_troop_slots
-            WHERE kingdom_id = :kid
+            SELECT kts.base_slots, kts.castle_bonus_slots, kts.noble_bonus_slots,
+                   kts.knight_bonus_slots, COALESCE(rc.troop_bonus, 0)
+            FROM kingdom_troop_slots kts
+            JOIN kingdoms k ON k.kingdom_id = kts.kingdom_id
+            LEFT JOIN region_catalogue rc ON rc.region_code = k.region
+            WHERE kts.kingdom_id = :kid
             """
         ),
         {"kid": kingdom_id},
@@ -28,9 +30,9 @@ def calculate_troop_slots(db: Session, kingdom_id: int) -> int:
     if not result:
         return 0
 
-    base_slots, castle_bonus, noble_bonus, knight_bonus = result
+    base_slots, castle_bonus, noble_bonus, knight_bonus, region_bonus = result
 
-    total_slots = base_slots + castle_bonus + noble_bonus + knight_bonus
+    total_slots = base_slots + castle_bonus + noble_bonus + knight_bonus + region_bonus
 
     return total_slots
 


### PR DESCRIPTION
## Summary
- create `region_catalogue` and seed regions
- show region dropdown dynamically and display details on setup
- store region bonuses when creating a kingdom
- display player's region in overview page
- include region troop bonus in progression calculations

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844dd9929ec83308197b1a12533d129