### PR TITLE
Implement modifier aggregation service and UI display

### DIFF
--- a/Javascript/overview.js
+++ b/Javascript/overview.js
@@ -35,12 +35,14 @@ async function loadOverview() {
   const resourcesContainer = document.getElementById("overview-resources");
   const militaryContainer = document.getElementById("overview-military");
   const questsContainer = document.getElementById("overview-quests");
+  const modifiersContainer = document.getElementById("overview-modifiers");
 
   // Placeholders while loading
   summaryContainer.innerHTML = "<p>Loading summary...</p>";
   resourcesContainer.innerHTML = "<p>Loading resources...</p>";
   militaryContainer.innerHTML = "<p>Loading military overview...</p>";
   questsContainer.innerHTML = "<p>Loading quests...</p>";
+  if (modifiersContainer) modifiersContainer.innerHTML = "<p>Loading modifiers...</p>";
 
   try {
     const [kingdomRes, prog] = await Promise.all([
@@ -96,15 +98,39 @@ async function loadOverview() {
 
     // ✅ Military Panel
     militaryContainer.innerHTML = ``;
-    if (data.troops) {
+  if (data.troops) {
       const p = document.createElement('p');
       p.innerHTML = `<strong>Total Troops:</strong> ${data.troops.total}`;
       const p2 = document.createElement('p');
       p2.innerHTML = `<strong>Slots Used:</strong> ${data.troops.slots.used} / ${data.troops.slots.base}`;
       militaryContainer.appendChild(p);
       militaryContainer.appendChild(p2);
-    } else {
+  } else {
       militaryContainer.innerHTML = "<p>No military data found.</p>";
+  }
+
+    // ✅ Modifiers Panel
+    if (modifiersContainer) {
+      try {
+        const res = await fetch('/api/progression/modifiers');
+        const mods = await res.json();
+        if (!res.ok) throw new Error('Failed');
+        modifiersContainer.innerHTML = '';
+        for (const [cat, vals] of Object.entries(mods)) {
+          const h4 = document.createElement('h4');
+          h4.textContent = cat.replace(/_/g, ' ');
+          modifiersContainer.appendChild(h4);
+          const ul = document.createElement('ul');
+          for (const [k,v] of Object.entries(vals)) {
+            const li = document.createElement('li');
+            li.textContent = `${k}: ${v}`;
+            ul.appendChild(li);
+          }
+          modifiersContainer.appendChild(ul);
+        }
+      } catch (e) {
+        modifiersContainer.innerHTML = '<p>Failed to load modifiers.</p>';
+      }
     }
 
     // ✅ Quests Panel (placeholder)

--- a/backend/routers/progression_router.py
+++ b/backend/routers/progression_router.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 
 from ..database import get_db
-from services.progression_service import calculate_troop_slots
+from services.progression_service import calculate_troop_slots, get_total_modifiers
 
 router = APIRouter(prefix="/api/progression", tags=["progression"])
 
@@ -259,4 +259,14 @@ def progression_summary(user_id: str = Depends(get_user_id)):
             "available": max(0, mil["base_slots"] - used),
         },
     }
+
+
+@router.get("/modifiers")
+def get_modifiers(
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """Return all active modifiers for the player's kingdom."""
+    kid = get_kingdom_id(db, user_id)
+    return get_total_modifiers(db, kid)
 

--- a/overview.html
+++ b/overview.html
@@ -115,6 +115,12 @@ Author: Deathsgift66
           <!-- JS will populate -->
         </ul>
       </div>
+      <div class="panel-card">
+        <h3>Active Modifiers</h3>
+        <div id="overview-modifiers">
+          <!-- JS will populate -->
+        </div>
+      </div>
     </div>
 
   </section>

--- a/tests/test_progression_service.py
+++ b/tests/test_progression_service.py
@@ -14,6 +14,7 @@ from backend.progression_service import (
     nobles,
     knights,
 )
+from services.progression_service import get_total_modifiers
 
 
 def setup_function():
@@ -51,3 +52,31 @@ def test_knight_management():
 
     with pytest.raises(ValueError):
         promote_knight("missing")
+
+
+def test_get_total_modifiers_default():
+    class DummyResult:
+        def __init__(self, row=None, rows=None):
+            self._row = row
+            self._rows = rows or []
+
+        def fetchone(self):
+            return self._row
+
+        def fetchall(self):
+            return self._rows
+
+    class DummyDB:
+        def execute(self, *args, **kwargs):
+            return DummyResult()
+
+    db = DummyDB()
+    mods = get_total_modifiers(db, 1)
+    assert mods == {
+        "resource_bonus": {},
+        "troop_bonus": {},
+        "combat_bonus": {},
+        "defense_bonus": {},
+        "economic_bonus": {},
+        "production_bonus": {},
+    }


### PR DESCRIPTION
## Summary
- aggregate kingdom modifiers across techs, temples, projects and regions
- expose new `/api/progression/modifiers` endpoint
- show active modifiers on overview page
- fetch modifiers in overview.js
- test new service logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844df2a56988330a418bcbd650c4807