### PR TITLE
Adjust region select label

### DIFF
--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -171,7 +171,7 @@ async function loadRegions() {
     regionMap[r.region_code] = r;
     const opt = document.createElement('option');
     opt.value = r.region_code;
-    opt.textContent = r.name || r.region_code;
+    opt.textContent = r.region_name || r.name || r.region_code;
     regionEl.appendChild(opt);
   });
 


### PR DESCRIPTION
## Summary
- show `region_name` instead of code when populating region select in `play` page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684500fc94e48330bccc9f5c9f1a7200