### PR TITLE
Restrict admin pages and navbar

### DIFF
--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -38,6 +38,7 @@ Author: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <script type="module" src="Javascript/navDropdown.js"></script>
+  <script>window.requireAdmin = true;</script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
   <script type="module" defer src="Javascript/admin_alerts.js"></script>

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -39,6 +39,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
+  <script>window.requireAdmin = true;</script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
 </head>

--- a/audit_log.html
+++ b/audit_log.html
@@ -40,6 +40,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
+  <script>window.requireAdmin = true;</script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
 </head>

--- a/navbar.html
+++ b/navbar.html
@@ -68,11 +68,11 @@ Author: Deathsgift66
       <a href="index.html">Home</a>
       <a href="legal.html">Legal</a>
       <a href="changelog.html">Changelog</a>
-      <div class="menu-section-header">Admin</div>
-      <a href="admin_dashboard.html">Dashboard</a>
-      <a href="admin_alerts.html">Alerts</a>
-      <a href="player_management.html">Player Management</a>
-      <a href="audit_log.html">Audit Log</a>
+      <div class="menu-section-header admin-only">Admin</div>
+      <a class="admin-only" href="admin_dashboard.html">Dashboard</a>
+      <a class="admin-only" href="admin_alerts.html">Alerts</a>
+      <a class="admin-only" href="player_management.html">Player Management</a>
+      <a class="admin-only" href="audit_log.html">Audit Log</a>
       <div class="menu-section-header">Misc</div>
       <a href="play.html">Play Now</a>
     </div>

--- a/player_management.html
+++ b/player_management.html
@@ -36,6 +36,7 @@ Author: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
+  <script>window.requireAdmin = true;</script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script src="Javascript/apiBase.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- add global overrides to `authGuard.js` and hide admin nav items when not admin
- ensure admin navbar links have `admin-only` class
- enforce admin requirement on admin pages via `window.requireAdmin = true`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450761067c8330a1b0c116f15f34e6