### PR TITLE
Add comprehensive kingdom setup

### DIFF
--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -80,14 +80,33 @@ function bindEvents(profileExists) {
           user_id: currentUser.id,
           username: currentUser.user_metadata.username,
           display_name: currentUser.user_metadata.display_name,
-          email: currentUser.email
+          kingdom_name: kingdomName,
+          email: currentUser.email,
+          profile_bio: '',
+          profile_picture_url: '',
+          region,
+          kingdom_id: null,
+          alliance_id: null,
+          alliance_role: null,
+          active_policy: null,
+          active_laws: [],
+          is_admin: false,
+          is_banned: false,
+          is_deleted: false,
+          setup_complete: false
         });
         if (userErr && userErr.code !== '23505') throw userErr;
       }
 
       const { data: kingdomData, error: kErr } = await supabase
         .from('kingdoms')
-        .insert({ user_id: currentUser.id, kingdom_name: kingdomName, region })
+        .insert({
+          user_id: currentUser.id,
+          kingdom_name: kingdomName,
+          region,
+          prestige_score: 0,
+          avatar_url: ''
+        })
         .select('kingdom_id')
         .single();
       if (kErr) throw kErr;

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ records using Supabase row level security.
 
 ---
 
+## Database Setup
+
+The `full_schema.sql` file contains the complete table definitions used by the
+game. To initialize a local database run:
+
+```bash
+psql -f full_schema.sql
+```
+
+This will create all tables referenced by the frontend.
+
+---
+
 ## 📝 License
 
 Proprietary — Kingmaker’s Rise Project.  


### PR DESCRIPTION
## Summary
- fill all user columns when creating a kingdom
- include extra kingdom fields on creation
- document how to init database schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68450a9a1ae48330b41d880c610703ed