### PR TITLE
Enforce single kingdom per user

### DIFF
--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -81,6 +81,18 @@ function bindEvents(profileExists) {
     createBtn.disabled = true;
 
     try {
+      const { data: existing, error: existErr } = await supabase
+        .from('kingdoms')
+        .select('kingdom_id')
+        .eq('user_id', currentUser.id)
+        .maybeSingle();
+      if (existErr) throw existErr;
+      if (existing) {
+        showToast('You already have a kingdom.');
+        createBtn.disabled = false;
+        return;
+      }
+
       if (!profileExists) {
         const { error: userErr } = await supabase.from('users').insert({
           user_id: currentUser.id,

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Auth is handled via **Supabase Client** → included in `supabaseClient.js`.
 New sign-ups automatically create the associated profile and starter kingdom
 records using Supabase row level security.
 
+A unique constraint on `kingdoms.user_id` ensures each player can only
+own a single kingdom.
+
 See [docs/onboarding_setup.md](docs/onboarding_setup.md) for a breakdown of
 the records created during onboarding.
 

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -289,7 +289,8 @@ CREATE TABLE public.kingdoms (
   region text,
   created_at timestamp with time zone DEFAULT now(),
   CONSTRAINT kingdoms_pkey PRIMARY KEY (kingdom_id),
-  CONSTRAINT kingdoms_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(user_id)
+  CONSTRAINT kingdoms_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(user_id),
+  CONSTRAINT kingdoms_user_id_key UNIQUE (user_id)
 );
 CREATE TABLE public.notifications (
   notification_id integer NOT NULL DEFAULT nextval('notifications_notification_id_seq'::regclass),

--- a/migrations/2025_06_09_unique_user_kingdom.sql
+++ b/migrations/2025_06_09_unique_user_kingdom.sql
@@ -1,0 +1,3 @@
+-- Migration: enforce single kingdom per user
+ALTER TABLE public.kingdoms
+  ADD CONSTRAINT kingdoms_user_id_key UNIQUE (user_id);


### PR DESCRIPTION
## Summary
- enforce single kingdom per user via migration and schema update
- document the single-kingdom rule in README
- check for existing kingdom in play.js before creating a new one

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a14c02b88330962b3e4b9d07380c