### PR TITLE
Add alliance treaties integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ the records created during onboarding.
 ✅ authGuard.js protection on restricted pages
 ✅ Global public page policy for index/login/signup/legal
 ✅ Alliance System → full suite
-✅ Military → full recruitment + war system  
+✅ Alliance Treaties diplomacy
+✅ Military → full recruitment + war system
 ✅ Market & Trade Center  
 ✅ Sovereign’s Grand Overseer (VIP 2 panel)  
 ✅ Dynamic World Map → zoom, pan, click  

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,7 @@ from .routers import (
     vip_status_router,
     titles_router,
     treaties_router,
+    alliance_treaties_router,
     spies_router,
     settings_router,
     wars,
@@ -68,6 +69,7 @@ app.include_router(villages_router.router)
 app.include_router(vip_status_router.router)
 app.include_router(titles_router.router)
 app.include_router(treaties_router.router)
+app.include_router(alliance_treaties_router.router)
 app.include_router(spies_router.router)
 app.include_router(settings_router.router)
 app.include_router(wars.router)

--- a/backend/routers/alliance_treaties_router.py
+++ b/backend/routers/alliance_treaties_router.py
@@ -1,0 +1,84 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+
+router = APIRouter(prefix="/api/alliance-treaties", tags=["alliance_treaties"])
+
+
+class TreatyCreate(BaseModel):
+    alliance_id: int = 1
+    partner_alliance_id: int
+    treaty_type: str
+
+
+class TreatyAction(BaseModel):
+    treaty_id: int
+
+
+@router.get("")
+def list_treaties(alliance_id: int = 1, db: Session = Depends(get_db)):
+    rows = db.execute(
+        text(
+            """
+            SELECT treaty_id, alliance_id, treaty_type, partner_alliance_id, status, signed_at
+            FROM alliance_treaties
+            WHERE alliance_id = :aid OR partner_alliance_id = :aid
+            ORDER BY signed_at DESC
+            """
+        ),
+        {"aid": alliance_id},
+    ).fetchall()
+    treaties = [
+        {
+            "treaty_id": r[0],
+            "alliance_id": r[1],
+            "treaty_type": r[2],
+            "partner_alliance_id": r[3],
+            "status": r[4],
+            "signed_at": r[5].isoformat() if r[5] else None,
+        }
+        for r in rows
+    ]
+    return {"treaties": treaties}
+
+
+@router.post("/create")
+def create_treaty(payload: TreatyCreate, db: Session = Depends(get_db)):
+    db.execute(
+        text(
+            """
+            INSERT INTO alliance_treaties (alliance_id, treaty_type, partner_alliance_id, status, signed_at)
+            VALUES (:aid, :type, :pid, 'proposed', now())
+            """
+        ),
+        {"aid": payload.alliance_id, "type": payload.treaty_type, "pid": payload.partner_alliance_id},
+    )
+    db.commit()
+    return {"message": "Treaty proposed"}
+
+
+@router.post("/accept")
+def accept_treaty(payload: TreatyAction, db: Session = Depends(get_db)):
+    db.execute(
+        text(
+            "UPDATE alliance_treaties SET status = 'active', signed_at = now() WHERE treaty_id = :tid"
+        ),
+        {"tid": payload.treaty_id},
+    )
+    db.commit()
+    return {"message": "Treaty accepted"}
+
+
+@router.post("/cancel")
+def cancel_treaty(payload: TreatyAction, db: Session = Depends(get_db)):
+    db.execute(
+        text("UPDATE alliance_treaties SET status = 'cancelled' WHERE treaty_id = :tid"),
+        {"tid": payload.treaty_id},
+    )
+    db.commit()
+    return {"message": "Treaty cancelled"}
+
+

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -326,6 +326,16 @@ CREATE TABLE projects_alliance (
     progress    INTEGER DEFAULT 0
 );
 
+-- Alliance Treaties
+CREATE TABLE alliance_treaties (
+    treaty_id SERIAL PRIMARY KEY,
+    alliance_id INTEGER REFERENCES alliances(alliance_id),
+    treaty_type TEXT,
+    partner_alliance_id INTEGER REFERENCES alliances(alliance_id),
+    status TEXT CHECK (status IN ('proposed','active','cancelled')) DEFAULT 'proposed',
+    signed_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
 -- Alliance Quests
 CREATE TABLE quest_alliance_catalogue (
     quest_code     TEXT PRIMARY KEY,

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -343,6 +343,18 @@ CREATE TABLE public.projects_alliance (
   CONSTRAINT projects_alliance_pkey PRIMARY KEY (project_id),
   CONSTRAINT projects_alliance_alliance_id_fkey FOREIGN KEY (alliance_id) REFERENCES public.alliances(alliance_id)
 );
+
+CREATE TABLE public.alliance_treaties (
+  treaty_id integer NOT NULL DEFAULT nextval('alliance_treaties_treaty_id_seq'::regclass),
+  alliance_id integer,
+  treaty_type text,
+  partner_alliance_id integer,
+  status text CHECK (status IN ('proposed','active','cancelled')) DEFAULT 'proposed',
+  signed_at timestamp with time zone DEFAULT now(),
+  CONSTRAINT alliance_treaties_pkey PRIMARY KEY (treaty_id),
+  CONSTRAINT alliance_treaties_alliance_id_fkey FOREIGN KEY (alliance_id) REFERENCES public.alliances(alliance_id),
+  CONSTRAINT alliance_treaties_partner_alliance_id_fkey FOREIGN KEY (partner_alliance_id) REFERENCES public.alliances(alliance_id)
+);
 CREATE TABLE public.projects_player (
   project_id integer NOT NULL DEFAULT nextval('projects_player_project_id_seq'::regclass),
   kingdom_id integer,

--- a/migrations/2025_06_10_add_alliance_treaties.sql
+++ b/migrations/2025_06_10_add_alliance_treaties.sql
@@ -1,0 +1,9 @@
+-- Migration: add alliance_treaties table
+CREATE TABLE public.alliance_treaties (
+  treaty_id SERIAL PRIMARY KEY,
+  alliance_id INTEGER REFERENCES public.alliances(alliance_id),
+  treaty_type TEXT,
+  partner_alliance_id INTEGER REFERENCES public.alliances(alliance_id),
+  status TEXT CHECK (status IN ('proposed','active','cancelled')) DEFAULT 'proposed',
+  signed_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+);

--- a/services/progression_service.py
+++ b/services/progression_service.py
@@ -30,6 +30,33 @@ except Exception:  # pragma: no cover - fallback when backend package missing
     global_game_settings = {}
 
 
+def get_active_alliance_treaties(db: Session, alliance_id: int) -> list[dict]:
+    """Return active treaties for the given alliance."""
+    try:
+        rows = db.execute(
+            text(
+                """
+                SELECT treaty_id, treaty_type, partner_alliance_id, signed_at
+                FROM alliance_treaties
+                WHERE (alliance_id = :aid OR partner_alliance_id = :aid)
+                  AND status = 'active'
+                ORDER BY signed_at DESC
+                """
+            ),
+            {"aid": alliance_id},
+        ).fetchall()
+        return [
+            {
+                "treaty_id": r[0],
+                "treaty_type": r[1],
+                "partner_alliance_id": r[2],
+                "signed_at": r[3],
+            }
+            for r in rows
+        ]
+    except Exception:
+        return []
+
 def calculate_troop_slots(db: Session, kingdom_id: int) -> int:
     """Calculate and return the total troop slots for a kingdom.
 


### PR DESCRIPTION
## Summary
- support alliance treaties DB table with migration and schema updates
- new `/api/alliance-treaties` router for CRUD operations
- expose router from API application
- helper to fetch active alliance treaties
- document feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a7e415ac8330bf03b5085abcd5c4