### PR TITLE
Integrate Alliance Vault creation

### DIFF
--- a/Javascript/alliance_vault.js
+++ b/Javascript/alliance_vault.js
@@ -45,7 +45,10 @@ async function loadVaultSummary() {
     Object.entries(data.totals).forEach(([resource, amount]) => {
       const div = document.createElement("div");
       div.classList.add("vault-resource-row");
-      div.innerHTML = `<strong>${resource}</strong>: ${amount}`;
+      const label = resource
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, c => c.toUpperCase());
+      div.innerHTML = `<strong>${label}</strong>: ${amount}`;
       container.appendChild(div);
     });
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from .routers import (
     admin,
     alliance_members,
     alliance_projects,
+    alliances,
     kingdom,
     conflicts,
     black_market,
@@ -44,6 +45,7 @@ Base.metadata.create_all(bind=engine)
 app.include_router(alliance_members.router)
 app.include_router(admin.router)
 app.include_router(alliance_projects.router)
+app.include_router(alliances.router)
 app.include_router(kingdom.router)
 app.include_router(conflicts.router)
 app.include_router(black_market.router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -20,6 +20,28 @@ class PlayerMessage(Base):
     sent_at = Column(DateTime(timezone=True), server_default=func.now())
     is_read = Column(Boolean, default=False)
 
+
+class Alliance(Base):
+    """Minimal alliance record used for foreign key relations."""
+
+    __tablename__ = 'alliances'
+
+    alliance_id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    leader = Column(String)
+    status = Column(String)
+    region = Column(String)
+    level = Column(Integer, default=1)
+    motd = Column(Text)
+    banner = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    military_score = Column(Integer, default=0)
+    economy_score = Column(Integer, default=0)
+    diplomacy_score = Column(Integer, default=0)
+    wars_count = Column(Integer, default=0)
+    treaties_count = Column(Integer, default=0)
+    projects_active = Column(Integer, default=0)
+
 class AllianceVault(Base):
     __tablename__ = 'alliance_vault'
     alliance_id = Column(Integer, primary_key=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -42,6 +42,20 @@ class Alliance(Base):
     treaties_count = Column(Integer, default=0)
     projects_active = Column(Integer, default=0)
 
+
+class AllianceMember(Base):
+    """Represents membership information for alliances."""
+
+    __tablename__ = 'alliance_members'
+
+    alliance_id = Column(Integer, ForeignKey('alliances.alliance_id'), primary_key=True)
+    user_id = Column(UUID(as_uuid=True), ForeignKey('users.user_id'), primary_key=True)
+    username = Column(String)
+    rank = Column(String)
+    contribution = Column(Integer, default=0)
+    status = Column(String)
+    crest = Column(String)
+
 class AllianceVault(Base):
     __tablename__ = 'alliance_vault'
     alliance_id = Column(Integer, ForeignKey('alliances.alliance_id'), primary_key=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -44,7 +44,7 @@ class Alliance(Base):
 
 class AllianceVault(Base):
     __tablename__ = 'alliance_vault'
-    alliance_id = Column(Integer, primary_key=True)
+    alliance_id = Column(Integer, ForeignKey('alliances.alliance_id'), primary_key=True)
     wood = Column(BigInteger, default=0)
     stone = Column(BigInteger, default=0)
     iron_ore = Column(BigInteger, default=0)

--- a/backend/routers/alliances.py
+++ b/backend/routers/alliances.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..models import Alliance, AllianceVault
+
+router = APIRouter(prefix="/api/alliances", tags=["alliances"])
+
+
+class AllianceCreate(BaseModel):
+    name: str
+    leader: str | None = None
+
+
+@router.post("/create")
+def create_alliance(payload: AllianceCreate, db: Session = Depends(get_db)):
+    alliance = Alliance(name=payload.name, leader=payload.leader)
+    db.add(alliance)
+    db.flush()  # Populate alliance_id
+
+    vault = AllianceVault(alliance_id=alliance.alliance_id)
+    db.add(vault)
+    db.commit()
+
+    return {"alliance_id": alliance.alliance_id}


### PR DESCRIPTION
## Summary
- add minimal `Alliance` model
- add endpoint to create an alliance with an initialized vault
- register alliances router
- prettify vault resource labels in JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a864bca88330bbe6a43314eb0587