### PR TITLE
Implement alliance tax collections table and service

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -362,6 +362,18 @@ CREATE TABLE quest_alliance_contributions (
     timestamp       TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+-- Alliance Tax Collections
+CREATE TABLE alliance_tax_collections (
+    collection_id   SERIAL PRIMARY KEY,
+    alliance_id     INTEGER REFERENCES alliances(alliance_id),
+    user_id         UUID REFERENCES users(user_id),
+    resource_type   resource_type,
+    amount_collected INTEGER,
+    collected_at    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    source          TEXT,
+    notes           TEXT
+);
+
 -- MESSAGING -----------------------------------------------------------------
 CREATE TABLE player_messages (
     message_id   SERIAL PRIMARY KEY,
@@ -610,6 +622,22 @@ CREATE POLICY access_own_alliance_contribs ON quest_alliance_contributions
     EXISTS (
       SELECT 1 FROM alliance_members m
       WHERE m.alliance_id = quest_alliance_contributions.alliance_id
+        AND m.user_id = auth.uid()
+    )
+  );
+
+ALTER TABLE alliance_tax_collections ENABLE ROW LEVEL SECURITY;
+CREATE POLICY access_own_alliance_tax ON alliance_tax_collections
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM alliance_members m
+      WHERE m.alliance_id = alliance_tax_collections.alliance_id
+        AND m.user_id = auth.uid()
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM alliance_members m
+      WHERE m.alliance_id = alliance_tax_collections.alliance_id
         AND m.user_id = auth.uid()
     )
   );

--- a/migrations/2025_06_11_add_alliance_tax_collections.sql
+++ b/migrations/2025_06_11_add_alliance_tax_collections.sql
@@ -1,0 +1,28 @@
+-- Migration: add alliance_tax_collections table
+
+CREATE TABLE public.alliance_tax_collections (
+  collection_id SERIAL PRIMARY KEY,
+  alliance_id INTEGER REFERENCES public.alliances(alliance_id),
+  user_id UUID REFERENCES public.users(user_id),
+  resource_type resource_type,
+  amount_collected INTEGER,
+  collected_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  source TEXT,
+  notes TEXT
+);
+
+ALTER TABLE public.alliance_tax_collections ENABLE ROW LEVEL SECURITY;
+CREATE POLICY access_own_alliance_tax ON public.alliance_tax_collections
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM public.alliance_members m
+      WHERE m.alliance_id = alliance_tax_collections.alliance_id
+        AND m.user_id = auth.uid()
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.alliance_members m
+      WHERE m.alliance_id = alliance_tax_collections.alliance_id
+        AND m.user_id = auth.uid()
+    )
+  );

--- a/services/tax_service.py
+++ b/services/tax_service.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Service functions for alliance tax collections."""
+
+try:
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+    text = lambda q: q  # type: ignore
+    Session = object  # type: ignore
+
+
+def collect_alliance_tax(
+    db: Session,
+    alliance_id: int,
+    user_id: str,
+    resource_type: str,
+    earned_amount: int,
+    source: str,
+    notes: str = "",
+) -> int:
+    """Apply alliance tax when a player gains resources.
+
+    Returns the net amount the player should receive after tax. The function
+    updates the alliance vault and logs the collection event.
+    """
+
+    rate_row = db.execute(
+        text(
+            "SELECT tax_rate_percent FROM alliance_tax_policies "
+            "WHERE alliance_id = :aid"
+        ),
+        {"aid": alliance_id},
+    ).fetchone()
+
+    if not rate_row:
+        return earned_amount
+
+    tax_rate = rate_row[0] or 0
+    if tax_rate <= 0:
+        return earned_amount
+
+    tax_amount = int(earned_amount * tax_rate / 100)
+    if tax_amount <= 0:
+        return earned_amount
+
+    # Deposit tax into alliance vault
+    db.execute(
+        text(
+            f"UPDATE alliance_vault SET {resource_type} = COALESCE({resource_type}, 0) + :amt "
+            "WHERE alliance_id = :aid"
+        ),
+        {"amt": tax_amount, "aid": alliance_id},
+    )
+
+    # Log collection event
+    db.execute(
+        text(
+            """
+            INSERT INTO alliance_tax_collections (
+                alliance_id, user_id, resource_type,
+                amount_collected, source, notes
+            ) VALUES (
+                :aid, :uid, :res, :amt, :src, :note
+            )
+            """
+        ),
+        {
+            "aid": alliance_id,
+            "uid": user_id,
+            "res": resource_type,
+            "amt": tax_amount,
+            "src": source,
+            "note": notes,
+        },
+    )
+
+    db.commit()
+
+    return earned_amount - tax_amount

--- a/tests/test_tax_service.py
+++ b/tests/test_tax_service.py
@@ -1,0 +1,50 @@
+from services.tax_service import collect_alliance_tax
+
+
+class DummyResult:
+    def __init__(self, row=None):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class DummyDB:
+    def __init__(self):
+        self.vault = {"gold": 0}
+        self.tax_rate = 5
+        self.records = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        params = params or {}
+        if "FROM alliance_tax_policies" in q:
+            return DummyResult((self.tax_rate,))
+        if q.startswith("UPDATE alliance_vault"):
+            self.vault["gold"] += params.get("amt", 0)
+            return DummyResult()
+        if "INSERT INTO alliance_tax_collections" in q:
+            self.records.append(
+                {
+                    "alliance_id": params.get("aid"),
+                    "user_id": params.get("uid"),
+                    "resource_type": params.get("res"),
+                    "amount_collected": params.get("amt"),
+                    "source": params.get("src"),
+                    "notes": params.get("note"),
+                }
+            )
+            return DummyResult()
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_collect_alliance_tax():
+    db = DummyDB()
+    net = collect_alliance_tax(db, 1, "u1", "gold", 1000, "income", "test")
+    assert net == 950
+    assert db.vault["gold"] == 50
+    assert len(db.records) == 1
+    assert db.records[0]["amount_collected"] == 50


### PR DESCRIPTION
## Summary
- add `alliance_tax_collections` table and RLS policy to `db_schema.sql`
- provide migration `2025_06_11_add_alliance_tax_collections.sql`
- add `services/tax_service.py` for applying alliance taxes
- unit test tax service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845aa2224c08330bca55d455ee0fe9c