### PR TITLE
Implement alliance war combat logs

### DIFF
--- a/backend/battle_engine/resolver_full.py
+++ b/backend/battle_engine/resolver_full.py
@@ -64,27 +64,50 @@ def process_unit_combat(
             (remaining, remaining, other["movement_id"]),
         )
 
-        db.execute(
-            """
-            INSERT INTO combat_logs (
-                war_id, tick_number, event_type, attacker_unit_id,
-                defender_unit_id, position_x, position_y, damage_dealt,
-                morale_shift, notes
+        if war_type == "alliance":
+            db.execute(
+                """
+                INSERT INTO alliance_war_combat_logs (
+                    alliance_war_id, tick_number, event_type, attacker_unit_id,
+                    defender_unit_id, position_x, position_y, damage_dealt,
+                    morale_shift, notes
+                )
+                VALUES (%s, %s, 'attack', %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    war_id,
+                    tick,
+                    unit_id,
+                    other["movement_id"],
+                    other["position_x"],
+                    other["position_y"],
+                    casualties,
+                    0.0,
+                    "alliance",
+                ),
             )
-            VALUES (%s, %s, 'attack', %s, %s, %s, %s, %s, %s, %s)
-            """,
-            (
-                war_id,
-                tick,
-                unit_id,
-                other["movement_id"],
-                other["position_x"],
-                other["position_y"],
-                casualties,
-                0.0,
-                war_type,
-            ),
-        )
+        else:
+            db.execute(
+                """
+                INSERT INTO combat_logs (
+                    war_id, tick_number, event_type, attacker_unit_id,
+                    defender_unit_id, position_x, position_y, damage_dealt,
+                    morale_shift, notes
+                )
+                VALUES (%s, %s, 'attack', %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    war_id,
+                    tick,
+                    unit_id,
+                    other["movement_id"],
+                    other["position_x"],
+                    other["position_y"],
+                    casualties,
+                    0.0,
+                    war_type,
+                ),
+            )
 
 
 # ============================================

--- a/backend/models.py
+++ b/backend/models.py
@@ -152,7 +152,7 @@ class AllianceWarParticipant(Base):
 class AllianceWarCombatLog(Base):
     __tablename__ = 'alliance_war_combat_logs'
     combat_id = Column(Integer, primary_key=True)
-    alliance_war_id = Column(Integer, ForeignKey('alliance_wars.alliance_war_id'))
+    alliance_war_id = Column(Integer, ForeignKey('alliance_wars.alliance_war_id', ondelete='CASCADE'))
     tick_number = Column(Integer)
     event_type = Column(String)
     attacker_unit_id = Column(Integer)

--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -103,3 +103,27 @@ def battle_replay(war_id: int, db: Session = Depends(get_db)):
         }
         for l in logs
     ]}
+
+
+@router.get("/api/alliance-battle-replay/{alliance_war_id}")
+def alliance_battle_replay(alliance_war_id: int, db: Session = Depends(get_db)):
+    logs = (
+        db.query(models.AllianceWarCombatLog)
+        .filter(models.AllianceWarCombatLog.alliance_war_id == alliance_war_id)
+        .order_by(models.AllianceWarCombatLog.tick_number, models.AllianceWarCombatLog.combat_id)
+        .all()
+    )
+    return {
+        "logs": [
+            {
+                "tick": l.tick_number,
+                "event": l.event_type,
+                "attacker_unit_id": l.attacker_unit_id,
+                "defender_unit_id": l.defender_unit_id,
+                "position_x": l.position_x,
+                "position_y": l.position_y,
+                "damage_dealt": l.damage_dealt,
+            }
+            for l in logs
+        ]
+    }

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -59,8 +59,9 @@ CREATE TABLE public.alliance_war_combat_logs (
   notes text,
   timestamp timestamp without time zone DEFAULT now(),
   CONSTRAINT alliance_war_combat_logs_pkey PRIMARY KEY (combat_id),
-  CONSTRAINT alliance_war_combat_logs_alliance_war_id_fkey FOREIGN KEY (alliance_war_id) REFERENCES public.alliance_wars(alliance_war_id)
+  CONSTRAINT alliance_war_combat_logs_alliance_war_id_fkey FOREIGN KEY (alliance_war_id) REFERENCES public.alliance_wars(alliance_war_id) ON DELETE CASCADE
 );
+CREATE INDEX alliance_war_combat_logs_alliance_war_id_idx ON public.alliance_war_combat_logs(alliance_war_id);
 CREATE TABLE public.alliance_war_participants (
   alliance_war_id integer NOT NULL,
   kingdom_id integer NOT NULL,

--- a/migrations/2025_06_11_add_alliance_war_combat_logs.sql
+++ b/migrations/2025_06_11_add_alliance_war_combat_logs.sql
@@ -1,0 +1,16 @@
+CREATE TABLE public.alliance_war_combat_logs (
+  combat_id bigserial PRIMARY KEY,
+  alliance_war_id integer REFERENCES public.alliance_wars(alliance_war_id) ON DELETE CASCADE,
+  tick_number integer NOT NULL,
+  event_type text NOT NULL,
+  attacker_unit_id integer,
+  defender_unit_id integer,
+  position_x integer,
+  position_y integer,
+  damage_dealt integer DEFAULT 0,
+  morale_shift double precision DEFAULT 0,
+  notes text,
+  timestamp timestamp without time zone DEFAULT now()
+);
+
+CREATE INDEX alliance_war_combat_logs_alliance_war_id_idx ON public.alliance_war_combat_logs(alliance_war_id);


### PR DESCRIPTION
## Summary
- add `alliance_war_combat_logs` table definition with cascade delete and index
- include migration for creating combat logs table
- log alliance war combat actions to the new table
- expose API to retrieve alliance battle logs
- update ORM model for cascade rule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845aafa22988330b595a274db42aba2