### PR TITLE
Fix models merge conflict, restore Alliance model

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -21,6 +21,28 @@ class PlayerMessage(Base):
     is_read = Column(Boolean, default=False)
 
 
+class Alliance(Base):
+    """Minimal alliance record used for foreign key relations."""
+
+    __tablename__ = 'alliances'
+
+    alliance_id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    leader = Column(String)
+    status = Column(String)
+    region = Column(String)
+    level = Column(Integer, default=1)
+    motd = Column(Text)
+    banner = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    military_score = Column(Integer, default=0)
+    economy_score = Column(Integer, default=0)
+    diplomacy_score = Column(Integer, default=0)
+    wars_count = Column(Integer, default=0)
+    treaties_count = Column(Integer, default=0)
+    projects_active = Column(Integer, default=0)
+
+
 class AllianceMember(Base):
     """Represents membership information for alliances."""
 


### PR DESCRIPTION
## Summary
- clean up leftover merge artifact in `backend/models.py`
- reintroduce missing `Alliance` model used by several foreign keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845ac5f52188330a2d9f0f7475453a1