### PR TITLE
Document alliance war preplans

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ the records created during onboarding.
 ✅ Lighthouse / SEO optimized
 ✅ Progression stages documented in [docs/kingdom_progression_stages.md](docs/kingdom_progression_stages.md)
 ✅ Progression gating documented in [docs/page_access_gating.md](docs/page_access_gating.md)
+✅ Alliance war pre-plan storage documented in [docs/alliance_war_preplans.md](docs/alliance_war_preplans.md)
 
 ---
 

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -742,3 +742,11 @@ CREATE TABLE war_preplans (
     preplan_jsonb JSONB,
     last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
+CREATE TABLE alliance_war_preplans (
+    preplan_id SERIAL PRIMARY KEY,
+    alliance_war_id INTEGER REFERENCES alliance_wars(alliance_war_id) ON DELETE CASCADE,
+    kingdom_id INTEGER REFERENCES kingdoms(kingdom_id),
+    preplan_jsonb JSONB NOT NULL,
+    last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);

--- a/docs/alliance_war_preplans.md
+++ b/docs/alliance_war_preplans.md
@@ -1,0 +1,46 @@
+# Alliance War Pre-Plans
+
+This table stores each participating kingdom's submitted pre-plan for an alliance war. Pre-plans are edited during the Pre-Planning Phase before live combat begins and are read by the battle engine to initialize units when the war starts.
+
+## Table Structure
+
+| Column | Meaning |
+| --- | --- |
+| `preplan_id` | Unique row ID |
+| `alliance_war_id` | Which alliance war this preplan is for |
+| `kingdom_id` | Which kingdom this preplan belongs to |
+| `preplan_jsonb` | The actual preplan data (JSONB) containing troop positions, orders, fallback points and priorities |
+| `last_updated` | Timestamp of the last edit |
+
+## Usage
+
+### Loading an existing plan
+```sql
+SELECT preplan_jsonb
+FROM alliance_war_preplans
+WHERE alliance_war_id = :war_id
+  AND kingdom_id = :kingdom_id;
+```
+If no record exists the client should create an empty plan.
+
+### Saving a plan
+```sql
+INSERT INTO alliance_war_preplans
+  (alliance_war_id, kingdom_id, preplan_jsonb, last_updated)
+VALUES
+  (:war_id, :kingdom_id, :jsonb_data, now())
+ON CONFLICT (alliance_war_id, kingdom_id) DO UPDATE
+  SET preplan_jsonb = EXCLUDED.preplan_jsonb,
+      last_updated = now();
+```
+
+### Loading all plans for battle start
+```sql
+SELECT kingdom_id, preplan_jsonb
+FROM alliance_war_preplans
+WHERE alliance_war_id = :war_id;
+```
+
+Foreign keys reference `alliance_wars` and `kingdoms` and should cascade on delete so pre-plans are cleaned up if the war is removed. Indexes on `alliance_war_id` and `(alliance_war_id, kingdom_id)` are recommended for fast lookups.
+
+In short, this table represents "each kingdom's submitted war plan for an alliance war".

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -77,9 +77,11 @@ CREATE TABLE public.alliance_war_preplans (
   preplan_jsonb jsonb NOT NULL,
   last_updated timestamp without time zone DEFAULT now(),
   CONSTRAINT alliance_war_preplans_pkey PRIMARY KEY (preplan_id),
-  CONSTRAINT alliance_war_preplans_alliance_war_id_fkey FOREIGN KEY (alliance_war_id) REFERENCES public.alliance_wars(alliance_war_id),
+  CONSTRAINT alliance_war_preplans_alliance_war_id_fkey FOREIGN KEY (alliance_war_id) REFERENCES public.alliance_wars(alliance_war_id) ON DELETE CASCADE,
   CONSTRAINT alliance_war_preplans_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id)
 );
+CREATE INDEX alliance_war_preplans_alliance_war_id_idx ON public.alliance_war_preplans(alliance_war_id);
+CREATE UNIQUE INDEX alliance_war_preplans_unique_idx ON public.alliance_war_preplans(alliance_war_id, kingdom_id);
 CREATE TABLE public.alliance_war_scores (
   alliance_war_id integer NOT NULL,
   attacker_score integer DEFAULT 0,


### PR DESCRIPTION
## Summary
- document how alliance war pre-plans are stored
- reference the new documentation in the README
- add `alliance_war_preplans` table to `db_schema.sql`
- expand `alliance_war_preplans` in `full_schema.sql` with cascade delete and indexes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ad27564083308f313dbf0d6cb98d