### PR TITLE
Document alliance war participants table

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ the records created during onboarding.
 ✅ Lighthouse / SEO optimized
 ✅ Progression stages documented in [docs/kingdom_progression_stages.md](docs/kingdom_progression_stages.md)
 ✅ Progression gating documented in [docs/page_access_gating.md](docs/page_access_gating.md)
+✅ Alliance war participants table explained in [docs/alliance_war_participants.md](docs/alliance_war_participants.md)
 
 ---
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -144,7 +144,12 @@ class AllianceWar(Base):
 
 class AllianceWarParticipant(Base):
     __tablename__ = 'alliance_war_participants'
-    alliance_war_id = Column(Integer, ForeignKey('alliance_wars.alliance_war_id'), primary_key=True)
+    alliance_war_id = Column(
+        Integer,
+        ForeignKey('alliance_wars.alliance_war_id', ondelete='CASCADE'),
+        primary_key=True,
+        index=True,
+    )
     kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'), primary_key=True)
     role = Column(String)
 

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -742,3 +742,13 @@ CREATE TABLE war_preplans (
     preplan_jsonb JSONB,
     last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
+-- Alliance War Participants -------------------------------------------------
+CREATE TABLE alliance_war_participants (
+    alliance_war_id INTEGER REFERENCES alliance_wars(alliance_war_id) ON DELETE CASCADE,
+    kingdom_id INTEGER REFERENCES kingdoms(kingdom_id),
+    role TEXT CHECK (role IN ('attacker','defender')),
+    PRIMARY KEY (alliance_war_id, kingdom_id)
+);
+
+CREATE INDEX alliance_war_participants_alliance_war_id_idx ON alliance_war_participants(alliance_war_id);

--- a/docs/alliance_war_participants.md
+++ b/docs/alliance_war_participants.md
@@ -1,0 +1,22 @@
+# Alliance War Participants
+
+This table records which kingdoms are involved in a specific alliance war and what role they play.
+
+## Purpose
+- Track all kingdoms fighting in an alliance war.
+- Specify whether each kingdom is on the **attacker** or **defender** side.
+
+## Columns
+| Column          | Meaning                                            |
+|-----------------|----------------------------------------------------|
+| `alliance_war_id` | ID of the alliance war this kingdom is part of     |
+| `kingdom_id`      | ID of the participating kingdom                    |
+| `role`            | `'attacker'` or `'defender'` indicating the side   |
+
+## Usage
+1. **War start:** insert the kingdoms of the attacking and defending alliances.
+2. **Reinforcements:** insert additional rows when other kingdoms join mid‑war.
+3. **Battle engine:** query kingdoms by role for each war to resolve combat.
+4. **War UI:** display all participants to players and tally their contributions.
+
+Rows are automatically removed when an alliance war is deleted thanks to `ON DELETE CASCADE`. An index on `alliance_war_id` speeds up lookups.

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -67,9 +67,10 @@ CREATE TABLE public.alliance_war_participants (
   kingdom_id integer NOT NULL,
   role text CHECK (role = ANY (ARRAY['attacker'::text, 'defender'::text])),
   CONSTRAINT alliance_war_participants_pkey PRIMARY KEY (alliance_war_id, kingdom_id),
-  CONSTRAINT alliance_war_participants_alliance_war_id_fkey FOREIGN KEY (alliance_war_id) REFERENCES public.alliance_wars(alliance_war_id),
+  CONSTRAINT alliance_war_participants_alliance_war_id_fkey FOREIGN KEY (alliance_war_id) REFERENCES public.alliance_wars(alliance_war_id) ON DELETE CASCADE,
   CONSTRAINT alliance_war_participants_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id)
 );
+CREATE INDEX alliance_war_participants_alliance_war_id_idx ON public.alliance_war_participants(alliance_war_id);
 CREATE TABLE public.alliance_war_preplans (
   preplan_id integer NOT NULL DEFAULT nextval('alliance_war_preplans_preplan_id_seq'::regclass),
   alliance_war_id integer,

--- a/migrations/2025_06_12_add_alliance_war_participants.sql
+++ b/migrations/2025_06_12_add_alliance_war_participants.sql
@@ -1,0 +1,10 @@
+-- Migration: add alliance_war_participants table
+CREATE TABLE public.alliance_war_participants (
+  alliance_war_id integer REFERENCES public.alliance_wars(alliance_war_id) ON DELETE CASCADE,
+  kingdom_id integer REFERENCES public.kingdoms(kingdom_id),
+  role text CHECK (role IN ('attacker','defender')),
+  PRIMARY KEY (alliance_war_id, kingdom_id)
+);
+
+CREATE INDEX alliance_war_participants_alliance_war_id_idx
+  ON public.alliance_war_participants(alliance_war_id);


### PR DESCRIPTION
## Summary
- explain the new `alliance_war_participants` table
- reference docs in README
- apply ON DELETE CASCADE and index in `full_schema.sql`
- add matching table to `db_schema.sql`
- update ORM model and create migration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845acac2e0883308f8d68a929227467