### PR TITLE
Add alliance emblem support

### DIFF
--- a/CSS/alliance_home.css
+++ b/CSS/alliance_home.css
@@ -51,6 +51,17 @@ section h2 {
   font-size: 1.1rem;
 }
 
+.alliance-visuals {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.alliance-visuals img {
+  max-width: 100%;
+  height: auto;
+  display: inline-block;
+}
+
 /* Progress Bars */
 .project-bar {
   margin-bottom: 1rem;

--- a/Javascript/alliance_home.js
+++ b/Javascript/alliance_home.js
@@ -62,7 +62,8 @@ async function loadAllianceData(userId) {
     document.getElementById('alliance-level')?.textContent = alliance.level ?? '--';
     document.getElementById('alliance-region')?.textContent = alliance.region ?? 'Unspecified';
     document.getElementById('alliance-motd')?.textContent = alliance.motd ?? 'No message set.';
-    document.getElementById('alliance-banner-img')?.setAttribute('src', alliance.banner || '../images/default-banner.png');
+    document.getElementById('alliance-banner-img')?.setAttribute('src', alliance.banner || 'Assets/banner.png');
+    document.getElementById('alliance-emblem-img')?.setAttribute('src', alliance.emblem_url || 'Assets/avatars/default_avatar_emperor.png');
 
     // Scores
     document.getElementById('military-score')?.textContent = alliance.military_score ?? '--';

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -64,6 +64,10 @@ Author: Deathsgift66
     <!-- Alliance Details -->
     <section class="alliance-details" aria-labelledby="overview-heading">
       <h2 id="overview-heading">Alliance Overview</h2>
+      <div class="alliance-visuals">
+        <img id="alliance-emblem-img" src="Assets/avatars/default_avatar_emperor.png" alt="Alliance Emblem" />
+        <img id="alliance-banner-img" src="Assets/banner.png" alt="Alliance Banner" />
+      </div>
       <p><strong>Name:</strong> <span id="alliance-name">Loading...</span></p>
       <p><strong>Leader:</strong> <span id="alliance-leader">Loading...</span></p>
       <p><strong>Members:</strong> <span id="alliance-members">Loading...</span></p>

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -265,6 +265,7 @@ CREATE TABLE alliances (
     level       INTEGER DEFAULT 1,
     motd        TEXT,
     banner      TEXT,
+    emblem_url  TEXT,
     created_at  TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     military_score INTEGER DEFAULT 0,
     economy_score  INTEGER DEFAULT 0,

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -114,6 +114,7 @@ CREATE TABLE public.alliances (
   level integer DEFAULT 1,
   motd text,
   banner text,
+  emblem_url text,
   created_at timestamp with time zone DEFAULT now(),
   military_score integer DEFAULT 0,
   economy_score integer DEFAULT 0,


### PR DESCRIPTION
## Summary
- extend `alliances` table with `emblem_url`
- display emblem and banner images on the Alliance Home page
- show new emblem field in frontend logic
- add minimal styling for alliance visuals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b081172c83308587cea6dd05e84d