### PR TITLE
Integrate audit log table

### DIFF
--- a/Javascript/account_settings.js
+++ b/Javascript/account_settings.js
@@ -101,6 +101,19 @@ document.getElementById('account-form').addEventListener('submit', async (e) => 
     // Final confirmation
     alert('✅ Changes saved successfully!');
     document.getElementById('new_password').value = ''; // Clear password field
+    try {
+      await fetch('/api/audit-log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_id: user.id,
+          action: 'update_profile',
+          details: 'Updated account settings'
+        })
+      });
+    } catch (err) {
+      console.error('Audit log failed:', err);
+    }
   } catch (err) {
     console.error('❌ Error during save:', err);
     alert(err.message);

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ the records created during onboarding.
 ✅ Sovereign’s Grand Overseer (VIP 2 panel)  
 ✅ Dynamic World Map → zoom, pan, click  
 ✅ Quests + Projects System  
-✅ Admin Dashboard → full logs + actions  
-✅ Seasonal Effects → dynamic  
+✅ Admin Dashboard → full logs + actions
+✅ Comprehensive audit log of player and admin activity
+✅ Seasonal Effects → dynamic
 ✅ GDPR / Legal Ready → legal.html + linked PDFs  
 ✅ Lighthouse / SEO optimized
 ✅ Progression stages documented in [docs/kingdom_progression_stages.md](docs/kingdom_progression_stages.md)

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,5 +1,10 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from .progression_router import get_user_id
+from services.audit_service import log_action
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
@@ -15,17 +20,32 @@ class BulkAction(BaseModel):
 
 
 @router.post("/flag")
-async def flag_player(payload: PlayerAction):
+async def flag_player(
+    payload: PlayerAction,
+    admin_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    log_action(db, admin_id, "flag_user", f"Flagged user {payload.player_id}")
     return {"message": "Flagged", "player_id": payload.player_id}
 
 
 @router.post("/freeze")
-async def freeze_player(payload: PlayerAction):
+async def freeze_player(
+    payload: PlayerAction,
+    admin_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    log_action(db, admin_id, "freeze_user", f"Froze user {payload.player_id}")
     return {"message": "Frozen", "player_id": payload.player_id}
 
 
 @router.post("/ban")
-async def ban_player(payload: PlayerAction):
+async def ban_player(
+    payload: PlayerAction,
+    admin_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    log_action(db, admin_id, "ban_user", f"Banned user {payload.player_id}")
     return {"message": "Banned", "player_id": payload.player_id}
 
 
@@ -35,11 +55,26 @@ async def list_players(search: str | None = None):
 
 
 @router.post("/bulk_action")
-async def bulk_action(payload: BulkAction):
+async def bulk_action(
+    payload: BulkAction,
+    admin_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    log_action(
+        db,
+        admin_id,
+        "bulk_admin_action",
+        f"{payload.action} on {len(payload.player_ids)} players",
+    )
     return {"message": "Bulk action executed", "action": payload.action}
 
 
 @router.post("/player_action")
-async def player_action(payload: PlayerAction):
+async def player_action(
+    payload: PlayerAction,
+    admin_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    log_action(db, admin_id, "admin_action", payload.alert_id or "")
     return {"message": "Action executed", "action": payload.alert_id}
 

--- a/backend/routers/alliance_members.py
+++ b/backend/routers/alliance_members.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 
 from ..database import get_db
 from ..models import AllianceMember
+from services.audit_service import log_action
 
 router = APIRouter(prefix="/api/alliance_members", tags=["alliance_members"])
 
@@ -62,6 +63,12 @@ def join(payload: JoinPayload, db: Session = Depends(get_db)):
     )
     db.add(member)
     db.commit()
+    log_action(
+        db,
+        payload.user_id,
+        "join_alliance",
+        f"Joined Alliance ID {payload.alliance_id}",
+    )
     return {"message": "Joined"}
 
 
@@ -75,6 +82,12 @@ def leave(payload: MemberAction, db: Session = Depends(get_db)):
     if member:
         db.delete(member)
         db.commit()
+        log_action(
+            db,
+            payload.user_id,
+            "leave_alliance",
+            f"Left Alliance ID {payload.alliance_id}",
+        )
     return {"message": "Left"}
 
 

--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from ..database import get_db
 from ..models import AllianceVault, AllianceVaultTransactionLog, User
+from services.audit_service import log_action
 
 router = APIRouter(prefix="/api/alliance-vault", tags=["alliance_vault"])
 
@@ -56,6 +57,12 @@ def deposit(payload: VaultTransaction, db: Session = Depends(get_db)):
     )
     db.add(log)
     db.commit()
+    log_action(
+        db,
+        payload.user_id,
+        "deposit_vault",
+        f"Deposited {payload.amount} {payload.resource} into Alliance Vault ID {payload.alliance_id}",
+    )
     return {"message": "Deposited"}
 
 
@@ -78,6 +85,12 @@ def withdraw(payload: VaultTransaction, db: Session = Depends(get_db)):
     )
     db.add(log)
     db.commit()
+    log_action(
+        db,
+        payload.user_id,
+        "withdraw_vault",
+        f"Withdrew {payload.amount} {payload.resource} from Alliance Vault ID {payload.alliance_id}",
+    )
     return {"message": "Withdrawn"}
 
 

--- a/backend/routers/audit_log.py
+++ b/backend/routers/audit_log.py
@@ -1,9 +1,33 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from services.audit_service import fetch_logs, log_action
+from pydantic import BaseModel
 
 router = APIRouter(prefix="/api/audit-log", tags=["audit_log"])
 
 
+class LogPayload(BaseModel):
+    user_id: str | None = None
+    action: str
+    details: str
+
+
 @router.get("")
-async def audit_log():
-    return {"logs": []}
+def audit_log(
+    user_id: str | None = Query(None),
+    limit: int = 100,
+    db: Session = Depends(get_db),
+):
+    """Return audit logs, optionally filtered by player."""
+    logs = fetch_logs(db, user_id=user_id, limit=limit)
+    return {"logs": logs}
+
+
+@router.post("")
+def create_log(payload: LogPayload, db: Session = Depends(get_db)):
+    """Insert a new audit log entry."""
+    log_action(db, payload.user_id, payload.action, payload.details)
+    return {"message": "logged"}
 

--- a/backend/routers/wars.py
+++ b/backend/routers/wars.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from ..database import get_db
 from .progression_router import get_user_id, get_kingdom_id
+from services.audit_service import log_action
 
 router = APIRouter(prefix="/api/wars", tags=["wars"])
 
@@ -26,5 +27,6 @@ async def declare_war(
     ).fetchone()[0]
     if knights == 0:
         raise HTTPException(status_code=403, detail="No knights available")
+    log_action(db, user_id, "start_war", f"Declared war on {payload.target}")
     return {"message": "War declared", "target": payload.target}
 

--- a/profile.html
+++ b/profile.html
@@ -35,6 +35,7 @@ Author: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/audit_log.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
 </head>
@@ -87,6 +88,21 @@ Author: Deathsgift66
       <div id="profile-customization-content" class="custom-scrollbar">
         <!-- JS will populate customization controls -->
       </div>
+    </div>
+
+    <!-- Recent Activity -->
+    <div class="recent-actions">
+      <h3>Recent Activity</h3>
+      <table class="audit-log-table">
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Action</th>
+            <th>Details</th>
+          </tr>
+        </thead>
+        <tbody id="recent-log-body" aria-live="polite"></tbody>
+      </table>
     </div>
 
   </section>

--- a/services/audit_service.py
+++ b/services/audit_service.py
@@ -1,0 +1,54 @@
+try:
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+    text = lambda q: q  # type: ignore
+    Session = object  # type: ignore
+
+
+def log_action(db: Session, user_id: str | None, action: str, details: str) -> None:
+    """Insert a new audit log entry."""
+    db.execute(
+        text(
+            "INSERT INTO audit_log (user_id, action, details) "
+            "VALUES (:uid, :act, :det)"
+        ),
+        {"uid": user_id, "act": action, "det": details},
+    )
+    db.commit()
+
+
+def fetch_logs(db: Session, user_id: str | None = None, limit: int = 100) -> list[dict]:
+    """Fetch audit log entries, optionally filtered by user."""
+    if user_id:
+        rows = db.execute(
+            text(
+                "SELECT log_id, user_id, action, details, created_at "
+                "FROM audit_log "
+                "WHERE user_id = :uid "
+                "ORDER BY created_at DESC "
+                "LIMIT :limit"
+            ),
+            {"uid": user_id, "limit": limit},
+        ).fetchall()
+    else:
+        rows = db.execute(
+            text(
+                "SELECT log_id, user_id, action, details, created_at "
+                "FROM audit_log "
+                "ORDER BY created_at DESC "
+                "LIMIT :limit"
+            ),
+            {"limit": limit},
+        ).fetchall()
+
+    return [
+        {
+            "log_id": r[0],
+            "user_id": r[1],
+            "action": r[2],
+            "details": r[3],
+            "created_at": r[4],
+        }
+        for r in rows
+    ]

--- a/tests/test_audit_service.py
+++ b/tests/test_audit_service.py
@@ -1,0 +1,43 @@
+from services.audit_service import log_action, fetch_logs
+
+
+class DummyResult:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self):
+        self.inserts = []
+        self.select_rows = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        if q.strip().startswith("INSERT INTO audit_log"):
+            self.inserts.append(params)
+            return DummyResult()
+        if "FROM audit_log" in q:
+            return DummyResult(self.select_rows)
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_log_action_inserts():
+    db = DummyDB()
+    log_action(db, "u1", "create_kingdom", "Created kingdom")
+    assert len(db.inserts) == 1
+    assert db.inserts[0]["uid"] == "u1"
+    assert db.inserts[0]["act"] == "create_kingdom"
+
+
+def test_fetch_logs_returns_rows():
+    db = DummyDB()
+    db.select_rows = [(1, "u1", "start_war", "vs 2", "2025-01-01")]
+    logs = fetch_logs(db, "u1", 10)
+    assert len(logs) == 1
+    assert logs[0]["action"] == "start_war"


### PR DESCRIPTION
## Summary
- add service for inserting and querying audit log entries
- expose audit log API for reading and creating logs
- log admin actions, alliance joins/leaves, vault transactions and wars
- log profile updates from the settings page
- show recent activity on the profile page
- document audit log in README
- add unit tests for audit service

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d5ab76bc83308d5c42e7d3fd6f5b