### PR TITLE
Implement battle resolution logs

### DIFF
--- a/migrations/2025_06_14_add_battle_resolution_logs.sql
+++ b/migrations/2025_06_14_add_battle_resolution_logs.sql
@@ -1,0 +1,12 @@
+CREATE TABLE public.battle_resolution_logs (
+  resolution_id serial PRIMARY KEY,
+  battle_type text NOT NULL CHECK (battle_type = ANY (ARRAY['kingdom','alliance'])),
+  war_id integer REFERENCES public.wars_tactical(war_id),
+  alliance_war_id integer REFERENCES public.alliance_wars(alliance_war_id),
+  winner_side text NOT NULL CHECK (winner_side = ANY (ARRAY['attacker','defender','draw'])),
+  total_ticks integer DEFAULT 0,
+  attacker_casualties integer DEFAULT 0,
+  defender_casualties integer DEFAULT 0,
+  loot_summary jsonb DEFAULT '{}'::jsonb,
+  created_at timestamp without time zone DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- log full battle results with casualties and loot
- compute casualty totals when wars end
- create migration for `battle_resolution_logs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d6954e608330bc92e917bb912182