### PR TITLE
Integrate combat log API

### DIFF
--- a/Javascript/battle_live.js
+++ b/Javascript/battle_live.js
@@ -65,7 +65,7 @@ async function loadCombatLogs() {
 // =============================================
 export async function triggerNextTick() {
   try {
-    const response = await fetch(`/api/battle/next_tick`, {
+    const response = await fetch(`/api/battle/next_tick?war_id=${warId}`, {
       method: 'POST'
     });
     const data = await response.json();

--- a/Javascript/battle_replay.js
+++ b/Javascript/battle_replay.js
@@ -8,6 +8,9 @@ Author: Deathsgift66
 
 import { supabase } from './supabaseClient.js';
 
+const urlParams = new URLSearchParams(window.location.search);
+const warId = parseInt(urlParams.get('war_id'), 10) || 0;
+
 let currentStep = 0;
 let replayInterval = null;
 let timelineSteps = [];
@@ -62,7 +65,7 @@ async function loadBattleReplay() {
   rewardsSection.innerHTML = "<p>Loading rewards...</p>";
 
   try {
-    const res = await fetch("/api/battle-replay");
+    const res = await fetch(`/api/battle-replay/${warId}`);
     const data = await res.json();
 
     // Populate timeline


### PR DESCRIPTION
## Summary
- expose new battle API endpoints for terrain, units and combat logs
- support triggering next tick via `/api/battle/next_tick`
- update live and replay scripts to pass `war_id`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services')*

------
https://chatgpt.com/codex/tasks/task_e_6845d9e066f08330be9c9ecd4e1abdaf