### PR TITLE
Implement kingdom achievement tracking

### DIFF
--- a/CSS/kingdom_achievements.css
+++ b/CSS/kingdom_achievements.css
@@ -1,0 +1,17 @@
+.kingdom-achievements ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.kingdom-achievements li {
+  padding: 0.25rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.kingdom-achievements li:last-child {
+  border-bottom: none;
+}
+
+.kingdom-achievements li.locked {
+  opacity: 0.5;
+}

--- a/Javascript/kingdom_achievements.js
+++ b/Javascript/kingdom_achievements.js
@@ -1,0 +1,74 @@
+import { supabase } from './supabaseClient.js';
+
+let currentUser = null;
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) {
+    window.location.href = 'login.html';
+    return;
+  }
+  currentUser = session.user;
+
+  const { data: userRow, error: userError } = await supabase
+    .from('users')
+    .select('kingdom_id')
+    .eq('user_id', currentUser.id)
+    .single();
+  if (userError) {
+    console.error('❌ Failed to load user kingdom:', userError);
+    return;
+  }
+
+  loadAchievements(userRow.kingdom_id);
+});
+
+async function loadAchievements(kingdomId) {
+  const list = document.getElementById('kingdom-achievements-list');
+  if (list) list.innerHTML = '<li>Loading achievements...</li>';
+
+  try {
+    const [catalogueRes, unlockedRes] = await Promise.all([
+      supabase.from('kingdom_achievement_catalogue').select('*'),
+      supabase
+        .from('kingdom_achievements')
+        .select('achievement_code, awarded_at')
+        .eq('kingdom_id', kingdomId)
+    ]);
+
+    if (catalogueRes.error) throw catalogueRes.error;
+    if (unlockedRes.error) throw unlockedRes.error;
+
+    const unlockedMap = new Map(
+      (unlockedRes.data || []).map(r => [r.achievement_code, r.awarded_at])
+    );
+
+    list.innerHTML = '';
+    catalogueRes.data.forEach(row => {
+      if (row.is_hidden && !unlockedMap.has(row.achievement_code)) {
+        return;
+      }
+      const li = document.createElement('li');
+      if (unlockedMap.has(row.achievement_code)) {
+        li.innerHTML = `<strong>${escapeHTML(row.name)}</strong> - ${escapeHTML(row.description)} (${new Date(unlockedMap.get(row.achievement_code)).toLocaleDateString()})`;
+      } else {
+        li.textContent = row.name;
+        li.classList.add('locked');
+      }
+      list.appendChild(li);
+    });
+  } catch (err) {
+    console.error('❌ Failed to load achievements:', err);
+    if (list) list.innerHTML = '<li>Failed to load achievements.</li>';
+  }
+}
+
+function escapeHTML(str) {
+  if (!str) return '';
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}

--- a/docs/kingdom_achievements.md
+++ b/docs/kingdom_achievements.md
@@ -1,0 +1,34 @@
+# Kingdom Achievements
+
+This document describes the tables that power kingdom achievements and how they are used in the game.
+
+## Table: `kingdom_achievement_catalogue`
+The catalogue is the master list of every possible kingdom achievement.
+
+| Column | Meaning |
+| --- | --- |
+| `achievement_code` | Unique string ID used to unlock the achievement. |
+| `name` | Display name shown in the UI. |
+| `description` | Description of the requirement. |
+| `category` | Grouping (`military`, `economic`, `diplomatic`, `exploration`, `infrastructure`). |
+| `reward` | JSON payload describing the reward when earned. |
+| `points` | Points awarded for ranking or bragging rights. |
+| `is_hidden` | If true, hidden until unlocked. |
+| `created_at` | Creation timestamp. |
+| `last_updated` | Timestamp of the last modification. |
+
+## Table: `kingdom_achievements`
+Records which kingdoms have unlocked which achievements.
+
+| Column | Meaning |
+| --- | --- |
+| `kingdom_id` | Player's kingdom ID. |
+| `achievement_code` | Identifier from the catalogue. |
+| `awarded_at` | When the achievement was earned. |
+
+## Usage
+1. **Checking triggers** – After relevant player actions, query `kingdom_achievements` to see if the row exists. If not, insert it, fetch the `reward` from `kingdom_achievement_catalogue`, apply it and notify the player.
+2. **Achievement page** – The `/kingdom/achievements` page queries all catalogue entries and the player's unlocked ones. Locked achievements marked `is_hidden` are not shown until earned.
+3. **Leaderboards** – Sum `points` from unlocked achievements per kingdom for ranking.
+
+Both tables are system managed. Players cannot edit them directly.

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -676,3 +676,26 @@ CREATE TABLE public.game_settings (
   last_updated timestamp with time zone DEFAULT now(),
   updated_by uuid REFERENCES public.users(user_id)
 );
+
+-- Kingdom Achievement Catalogue
+CREATE TABLE public.kingdom_achievement_catalogue (
+  achievement_code text PRIMARY KEY,
+  name text NOT NULL,
+  description text NOT NULL,
+  category text NOT NULL,
+  reward jsonb NOT NULL,
+  points integer DEFAULT 0,
+  is_hidden boolean DEFAULT false,
+  created_at timestamp with time zone DEFAULT now(),
+  last_updated timestamp with time zone DEFAULT now()
+);
+
+-- Kingdom Achievements
+CREATE TABLE public.kingdom_achievements (
+  kingdom_id integer REFERENCES public.kingdoms(kingdom_id),
+  achievement_code text REFERENCES public.kingdom_achievement_catalogue(achievement_code),
+  awarded_at timestamp with time zone DEFAULT now(),
+  CONSTRAINT kingdom_achievements_pkey PRIMARY KEY (kingdom_id, achievement_code)
+);
+
+CREATE INDEX kingdom_achievements_kingdom_id_idx ON public.kingdom_achievements(kingdom_id);

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -1,0 +1,64 @@
+<!--
+Project Name: Kingmakers Rise Frontend
+File Name: kingdom_achievements.html
+Date: June 2, 2025
+Author: Deathsgift66
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <title>Kingdom Achievements | Kingmaker's Rise</title>
+  <meta name="description" content="View the achievements unlocked by your kingdom." />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://www.kingmakersrise.com/kingdom_achievements.html" />
+
+  <!-- Assets -->
+  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="CSS/root_theme.css" />
+  <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/kingdom_achievements.css" />
+  <script type="module" src="Javascript/components/authGuard.js"></script>
+  <script type="module" src="Javascript/navDropdown.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script defer type="module" src="Javascript/kingdom_achievements.js"></script>
+</head>
+<body>
+  <!-- Inject Navbar -->
+  <div id="navbar-container"></div>
+  <script>
+    fetch('navbar.html')
+      .then(res => res.text())
+      .then(html => {
+        document.getElementById('navbar-container').innerHTML = html;
+      });
+  </script>
+
+  <header class="kr-top-banner" aria-label="Kingdom Achievements Banner">
+    Kingmaker's Rise — Kingdom Achievements
+  </header>
+
+  <main class="main-centered-container" aria-label="Kingdom Achievements Interface">
+    <section class="alliance-members-container">
+      <h2>Your Kingdom Achievements</h2>
+      <p>Track accomplishments and rewards earned by your kingdom.</p>
+
+      <div class="kingdom-achievements">
+        <ul id="kingdom-achievements-list">
+          <li>Loading achievements...</li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="site-footer">
+    <div>© 2025 Kingmaker’s Rise</div>
+    <div>
+      <a href="legal.html">View Legal Documents</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/services/kingdom_achievement_service.py
+++ b/services/kingdom_achievement_service.py
@@ -1,0 +1,80 @@
+try:
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+    text = lambda q: q  # type: ignore
+    Session = object  # type: ignore
+
+
+def award_achievement(db: Session, kingdom_id: int, achievement_code: str):
+    """Award an achievement if not already earned.
+
+    Returns the reward JSON if newly awarded, otherwise ``None``.
+    """
+    row = db.execute(
+        text(
+            "SELECT 1 FROM kingdom_achievements "
+            "WHERE kingdom_id = :kid AND achievement_code = :code"
+        ),
+        {"kid": kingdom_id, "code": achievement_code},
+    ).fetchone()
+
+    if row:
+        return None
+
+    db.execute(
+        text(
+            "INSERT INTO kingdom_achievements (kingdom_id, achievement_code) "
+            "VALUES (:kid, :code)"
+        ),
+        {"kid": kingdom_id, "code": achievement_code},
+    )
+
+    reward_row = db.execute(
+        text(
+            "SELECT reward FROM kingdom_achievement_catalogue "
+            "WHERE achievement_code = :code"
+        ),
+        {"code": achievement_code},
+    ).fetchone()
+
+    db.commit()
+
+    return reward_row[0] if reward_row else None
+
+
+def list_achievements(db: Session, kingdom_id: int):
+    """Return all achievements with unlock status for a kingdom."""
+    rows = db.execute(
+        text(
+            """
+            SELECT c.achievement_code, c.name, c.description, c.category,
+                   c.reward, c.points, c.is_hidden, a.awarded_at
+            FROM kingdom_achievement_catalogue c
+            LEFT JOIN kingdom_achievements a
+              ON c.achievement_code = a.achievement_code
+             AND a.kingdom_id = :kid
+            ORDER BY c.category, c.achievement_code
+            """
+        ),
+        {"kid": kingdom_id},
+    ).fetchall()
+
+    achievements = []
+    for r in rows:
+        if r[6] and r[7] is None:
+            # hidden and not yet unlocked
+            continue
+        achievements.append(
+            {
+                "achievement_code": r[0],
+                "name": r[1],
+                "description": r[2],
+                "category": r[3],
+                "reward": r[4],
+                "points": r[5],
+                "is_hidden": r[6],
+                "awarded_at": r[7],
+            }
+        )
+    return achievements

--- a/tests/test_kingdom_achievement_service.py
+++ b/tests/test_kingdom_achievement_service.py
@@ -1,0 +1,69 @@
+from services.kingdom_achievement_service import award_achievement, list_achievements
+
+
+class DummyResult:
+    def __init__(self, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self):
+        self.inserted = []
+        self.check_rows = []
+        self.reward = None
+        self.list_rows = []
+
+    def execute(self, query, params=None):
+        q = str(query).strip()
+        params = params or {}
+        if q.startswith("SELECT 1 FROM kingdom_achievements"):
+            return DummyResult(self.check_rows.pop(0) if self.check_rows else None)
+        if q.startswith("INSERT INTO kingdom_achievements"):
+            self.inserted.append(params)
+            return DummyResult()
+        if "SELECT reward FROM kingdom_achievement_catalogue" in q:
+            return DummyResult((self.reward,))
+        if "FROM kingdom_achievement_catalogue" in q and "LEFT JOIN" in q:
+            return DummyResult(rows=self.list_rows)
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_award_new_achievement():
+    db = DummyDB()
+    db.check_rows = [None]
+    db.reward = {"gold": 100}
+    reward = award_achievement(db, 1, "first_gold")
+    assert reward == {"gold": 100}
+    assert db.inserted[0]["kid"] == 1
+
+
+def test_award_existing_returns_none():
+    db = DummyDB()
+    db.check_rows = [(1,)]
+    reward = award_achievement(db, 1, "first_gold")
+    assert reward is None
+    assert db.inserted == []
+
+
+def test_list_achievements_filters_hidden():
+    db = DummyDB()
+    db.list_rows = [
+        ("first_gold", "First Gold", "Earn 1000", "economic", {"gold": 100}, 5, False, None),
+        ("secret", "Secret", "???", "exploration", {}, 0, True, None),
+        ("battle", "Battle", "Win", "military", {}, 10, False, "2025-01-01"),
+    ]
+    results = list_achievements(db, 1)
+    codes = [r["achievement_code"] for r in results]
+    assert "first_gold" in codes
+    assert "battle" in codes
+    assert "secret" not in codes


### PR DESCRIPTION
## Summary
- document new kingdom achievement tables and usage
- implement service helpers for awarding and listing achievements
- provide a frontend page and styles for viewing kingdom achievements
- extend DB schema with kingdom achievement tables
- add unit tests for achievement service

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845dc357ec0833088e4ae2773d8dfa3