### PR TITLE
Add kingdom history log service

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -33,6 +33,7 @@ from .routers import (
     wars,
     quests_router,
     projects_router,
+    kingdom_history,
 )
 from .database import engine
 from .models import Base
@@ -77,4 +78,5 @@ app.include_router(settings_router.router)
 app.include_router(wars.router)
 app.include_router(quests_router.router)
 app.include_router(projects_router.router)
+app.include_router(kingdom_history.router)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -302,3 +302,15 @@ class GameSetting(Base):
     is_active = Column(Boolean, default=True)
     last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
     updated_by = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+
+
+class KingdomHistoryLog(Base):
+    """Chronological history of important events for kingdoms."""
+
+    __tablename__ = 'kingdom_history_log'
+
+    log_id = Column(Integer, primary_key=True)
+    kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'))
+    event_type = Column(String)
+    event_details = Column(Text)
+    event_date = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/routers/kingdom_history.py
+++ b/backend/routers/kingdom_history.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from services.kingdom_history_service import log_event, fetch_history
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/api/kingdom-history", tags=["kingdom_history"])
+
+
+class HistoryPayload(BaseModel):
+    kingdom_id: int
+    event_type: str
+    event_details: str
+
+
+@router.get("")
+def history(
+    kingdom_id: int = Query(...),
+    limit: int = 50,
+    db: Session = Depends(get_db),
+):
+    """Return recent history for a kingdom."""
+    records = fetch_history(db, kingdom_id, limit)
+    return {"history": records}
+
+
+@router.post("")
+def create_history(payload: HistoryPayload, db: Session = Depends(get_db)):
+    """Insert a new history event."""
+    log_event(db, payload.kingdom_id, payload.event_type, payload.event_details)
+    return {"message": "logged"}

--- a/services/kingdom_history_service.py
+++ b/services/kingdom_history_service.py
@@ -1,0 +1,42 @@
+try:
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+    text = lambda q: q  # type: ignore
+    Session = object  # type: ignore
+
+
+def log_event(db: Session, kingdom_id: int, event_type: str, event_details: str) -> None:
+    """Insert a new kingdom history log entry."""
+    db.execute(
+        text(
+            "INSERT INTO kingdom_history_log (kingdom_id, event_type, event_details) "
+            "VALUES (:kid, :etype, :details)"
+        ),
+        {"kid": kingdom_id, "etype": event_type, "details": event_details},
+    )
+    db.commit()
+
+
+def fetch_history(db: Session, kingdom_id: int, limit: int = 50) -> list[dict]:
+    """Return recent history entries for a kingdom."""
+    rows = db.execute(
+        text(
+            "SELECT log_id, event_type, event_details, event_date "
+            "FROM kingdom_history_log "
+            "WHERE kingdom_id = :kid "
+            "ORDER BY event_date DESC "
+            "LIMIT :limit"
+        ),
+        {"kid": kingdom_id, "limit": limit},
+    ).fetchall()
+
+    return [
+        {
+            "log_id": r[0],
+            "event_type": r[1],
+            "event_details": r[2],
+            "event_date": r[3],
+        }
+        for r in rows
+    ]

--- a/tests/test_history_service.py
+++ b/tests/test_history_service.py
@@ -1,0 +1,43 @@
+from services.kingdom_history_service import log_event, fetch_history
+
+
+class DummyResult:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self):
+        self.inserts = []
+        self.select_rows = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        if q.strip().startswith("INSERT INTO kingdom_history_log"):
+            self.inserts.append(params)
+            return DummyResult()
+        if "FROM kingdom_history_log" in q:
+            return DummyResult(self.select_rows)
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_log_event_inserts():
+    db = DummyDB()
+    log_event(db, 1, "war_victory", "Defeated Rivertown")
+    assert len(db.inserts) == 1
+    assert db.inserts[0]["kid"] == 1
+    assert db.inserts[0]["etype"] == "war_victory"
+
+
+def test_fetch_history_returns_rows():
+    db = DummyDB()
+    db.select_rows = [(1, "war_victory", "Beat Rivertown", "2025-01-01")]
+    result = fetch_history(db, 1, 10)
+    assert len(result) == 1
+    assert result[0]["event_type"] == "war_victory"


### PR DESCRIPTION
## Summary
- add `KingdomHistoryLog` model
- add service for logging kingdom events and fetching history
- expose `/api/kingdom-history` endpoints
- include router in `main.py`
- test the new service

## Testing
- `python -m pytest -q` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845dc7fabd88330a0f15d47fe4908ed