### PR TITLE
Add kingdom history log feature

### DIFF
--- a/CSS/kingdom_history.css
+++ b/CSS/kingdom_history.css
@@ -1,0 +1,50 @@
+/*
+Project Name: Kingmakers Rise Frontend
+File Name: kingdom_history.css
+Date: June 2, 2025
+Author: Deathsgift66
+*/
+@import url('./root_theme.css');
+
+body {
+  margin: 0;
+  font-family: 'IM Fell English', serif;
+  background: url('../Assets/history_bg.png') no-repeat center center fixed;
+  background-size: cover;
+  color: var(--parchment);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.main-centered-container {
+  width: auto;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  width: 100%;
+}
+
+.history-item {
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid var(--gold);
+  border-radius: 8px;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 2px 8px var(--shadow);
+}
+
+.history-item .date {
+  font-family: 'Cinzel', serif;
+  color: var(--gold);
+  margin-bottom: 0.25rem;
+}

--- a/Javascript/kingdom_history.js
+++ b/Javascript/kingdom_history.js
@@ -1,0 +1,61 @@
+/*
+Project Name: Kingmakers Rise Frontend
+File Name: kingdom_history.js
+Date: June 2, 2025
+Author: Deathsgift66
+*/
+
+import { supabase } from './supabaseClient.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadHistory();
+});
+
+async function loadHistory() {
+  const listEl = document.getElementById('history-list');
+  listEl.innerHTML = '<li>Loading history...</li>';
+
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    const { data: userData, error: userError } = await supabase
+      .from('users')
+      .select('kingdom_id')
+      .eq('user_id', user.id)
+      .single();
+
+    if (userError) throw userError;
+
+    const res = await fetch(`/api/kingdom-history?kingdom_id=${userData.kingdom_id}&limit=50`);
+    const result = await res.json();
+
+    listEl.innerHTML = '';
+
+    if (!result.history || result.history.length === 0) {
+      listEl.innerHTML = '<li>No history found.</li>';
+      return;
+    }
+
+    result.history.forEach(entry => {
+      const item = document.createElement('li');
+      item.classList.add('history-item');
+      item.innerHTML = `
+        <div class="date">[${new Date(entry.event_date).toLocaleString()}]</div>
+        <div class="detail">${escapeHTML(entry.event_details)}</div>
+      `;
+      listEl.appendChild(item);
+    });
+  } catch (err) {
+    console.error('Error loading history:', err);
+    listEl.innerHTML = '<li>Failed to load history.</li>';
+  }
+}
+
+function escapeHTML(str) {
+  if (!str) return '';
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,6 +33,7 @@ from .routers import (
     wars,
     quests_router,
     projects_router,
+    kingdom_history,
 )
 from .database import engine
 from .models import Base
@@ -77,4 +78,5 @@ app.include_router(settings_router.router)
 app.include_router(wars.router)
 app.include_router(quests_router.router)
 app.include_router(projects_router.router)
+app.include_router(kingdom_history.router)
 

--- a/backend/routers/kingdom_history.py
+++ b/backend/routers/kingdom_history.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from services.kingdom_history_service import log_event, fetch_history
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/api/kingdom-history", tags=["kingdom_history"])
+
+
+class HistoryPayload(BaseModel):
+    kingdom_id: int
+    event_type: str
+    event_details: str
+
+
+@router.get("")
+def kingdom_history(
+    kingdom_id: int = Query(...),
+    limit: int = 50,
+    db: Session = Depends(get_db),
+):
+    """Return kingdom history entries."""
+    logs = fetch_history(db, kingdom_id, limit)
+    return {"history": logs}
+
+
+@router.post("")
+def create_history(payload: HistoryPayload, db: Session = Depends(get_db)):
+    """Insert a kingdom history log entry."""
+    log_event(db, payload.kingdom_id, payload.event_type, payload.event_details)
+    return {"message": "logged"}

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -783,3 +783,21 @@ CREATE TABLE game_settings (
     last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_by UUID REFERENCES users(user_id)
 );
+
+-- Kingdom History Log -------------------------------------------------------
+CREATE TABLE kingdom_history_log (
+    log_id SERIAL PRIMARY KEY,
+    kingdom_id INTEGER REFERENCES kingdoms(kingdom_id),
+    event_type TEXT NOT NULL,
+    event_details TEXT NOT NULL,
+    event_date TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+ALTER TABLE kingdom_history_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY access_own_kingdom_history ON kingdom_history_log
+  FOR SELECT USING (
+    auth.uid() = (
+      SELECT user_id FROM kingdoms k
+      WHERE k.kingdom_id = kingdom_history_log.kingdom_id
+    )
+  );

--- a/docs/kingdom_history_log.md
+++ b/docs/kingdom_history_log.md
@@ -1,0 +1,34 @@
+# Kingdom History Log
+
+This table stores a chronological history of important events for each player's kingdom. It acts like an activity feed or journal so players can review what has happened over time.
+
+## Table Structure
+
+| Column | Meaning |
+| --- | --- |
+| `log_id` | Unique row ID |
+| `kingdom_id` | Which kingdom the event belongs to |
+| `event_type` | Short code describing the event |
+| `event_details` | Human readable details displayed to the player |
+| `event_date` | Timestamp when the event occurred |
+
+## Usage
+
+Insert a row whenever a significant event occurs:
+
+```sql
+INSERT INTO kingdom_history_log (kingdom_id, event_type, event_details)
+VALUES (5, 'war_victory', 'Defeated Kingdom of Rivertown');
+```
+
+Fetch recent history for display:
+
+```sql
+SELECT event_type, event_details, event_date
+FROM kingdom_history_log
+WHERE kingdom_id = 5
+ORDER BY event_date DESC
+LIMIT 50;
+```
+
+Rows should never be updated or deleted except when a player removes their account.

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -676,3 +676,11 @@ CREATE TABLE public.game_settings (
   last_updated timestamp with time zone DEFAULT now(),
   updated_by uuid REFERENCES public.users(user_id)
 );
+
+CREATE TABLE public.kingdom_history_log (
+  log_id serial PRIMARY KEY,
+  kingdom_id integer REFERENCES public.kingdoms(kingdom_id),
+  event_type text NOT NULL,
+  event_details text NOT NULL,
+  event_date timestamp with time zone DEFAULT now()
+);

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -1,0 +1,82 @@
+<!--
+Project Name: Kingmakers Rise Frontend
+File Name: kingdom_history.html
+Date: June 2, 2025
+Author: Deathsgift66
+-->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <title>Kingdom History | Kingmaker's Rise</title>
+  <meta name="description" content="Review your kingdom's story and major events in Kingmaker's Rise." />
+  <meta property="og:title" content="Kingdom History | Kingmaker's Rise" />
+  <meta property="og:description" content="Review your kingdom's story and major events in Kingmaker's Rise." />
+  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta property="og:url" content="https://www.kingmakersrise.com/kingdom_history.html" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Kingdom History | Kingmaker's Rise" />
+  <meta name="twitter:description" content="Review your kingdom's story and major events in Kingmaker's Rise." />
+  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+  <meta name="keywords" content="Kingmaker's Rise, kingdom history, log, events" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://www.kingmakersrise.com/kingdom_history.html" />
+
+  <!-- Page-Specific Assets -->
+  <link rel="stylesheet" href="CSS/kingdom_history.css" />
+  <script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script defer type="module" src="Javascript/kingdom_history.js"></script>
+
+  <!-- Global Assets -->
+  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="CSS/root_theme.css" />
+  <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <script type="module" src="Javascript/navDropdown.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
+</head>
+
+<body>
+
+<!-- Navbar -->
+<div id="navbar-container"></div>
+<script>
+  fetch('navbar.html')
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('navbar-container').innerHTML = html;
+    });
+</script>
+
+<!-- Page Banner -->
+<header class="kr-top-banner" aria-label="Kingdom History Banner">
+  Kingmaker's Rise — Kingdom History
+</header>
+
+<!-- Main Centered Layout -->
+<main class="main-centered-container" aria-label="Kingdom History Interface">
+
+  <!-- History Panel -->
+  <section class="alliance-members-container">
+    <h2>Kingdom History</h2>
+    <p>A chronological record of your kingdom's major events.</p>
+    <ul id="history-list" class="history-list">
+      <!-- JS populates -->
+    </ul>
+  </section>
+
+</main>
+
+<!-- Footer -->
+<footer class="site-footer">
+  <div>© 2025 Kingmaker’s Rise</div>
+  <div>
+    <a href="legal.html">View Legal Documents</a>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/services/kingdom_history_service.py
+++ b/services/kingdom_history_service.py
@@ -1,0 +1,42 @@
+try:
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+    text = lambda q: q  # type: ignore
+    Session = object  # type: ignore
+
+
+def log_event(db: Session, kingdom_id: int, event_type: str, event_details: str) -> None:
+    """Insert a new kingdom history log entry."""
+    db.execute(
+        text(
+            "INSERT INTO kingdom_history_log (kingdom_id, event_type, event_details) "
+            "VALUES (:kid, :etype, :details)"
+        ),
+        {"kid": kingdom_id, "etype": event_type, "details": event_details},
+    )
+    db.commit()
+
+
+def fetch_history(db: Session, kingdom_id: int, limit: int = 50) -> list[dict]:
+    """Fetch history log entries for a kingdom ordered by newest first."""
+    rows = db.execute(
+        text(
+            "SELECT log_id, event_type, event_details, event_date "
+            "FROM kingdom_history_log "
+            "WHERE kingdom_id = :kid "
+            "ORDER BY event_date DESC "
+            "LIMIT :limit"
+        ),
+        {"kid": kingdom_id, "limit": limit},
+    ).fetchall()
+
+    return [
+        {
+            "log_id": r[0],
+            "event_type": r[1],
+            "event_details": r[2],
+            "event_date": r[3],
+        }
+        for r in rows
+    ]

--- a/tests/test_kingdom_history_service.py
+++ b/tests/test_kingdom_history_service.py
@@ -1,0 +1,41 @@
+from services.kingdom_history_service import log_event, fetch_history
+
+class DummyResult:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+
+    def fetchall(self):
+        return self._rows
+
+class DummyDB:
+    def __init__(self):
+        self.inserts = []
+        self.select_rows = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        params = params or {}
+        if q.strip().startswith("INSERT INTO kingdom_history_log"):
+            self.inserts.append(params)
+            return DummyResult()
+        if "FROM kingdom_history_log" in q:
+            return DummyResult(self.select_rows)
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+def test_log_event_inserts():
+    db = DummyDB()
+    log_event(db, 1, "build_complete", "Built Barracks")
+    assert len(db.inserts) == 1
+    assert db.inserts[0]["kid"] == 1
+    assert db.inserts[0]["etype"] == "build_complete"
+
+
+def test_fetch_history_returns_rows():
+    db = DummyDB()
+    db.select_rows = [(1, "war_victory", "Defeated", "2025-01-01")]
+    logs = fetch_history(db, 1, 10)
+    assert len(logs) == 1
+    assert logs[0]["event_type"] == "war_victory"


### PR DESCRIPTION
## Summary
- define `kingdom_history_log` table in SQL schemas
- implement service helpers and API router
- expose new `kingdom_history` endpoint in FastAPI app
- add frontend page, script and styles for viewing kingdom history
- document table usage in `docs/kingdom_history_log.md`
- add unit tests for service logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845dcc1e8688330a2f43aa74514ee8a