### PR TITLE
Integrate kingdom_treaties table

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ the records created during onboarding.
 ✅ Alliance war participant list documented in [docs/alliance_war_participants.md](docs/alliance_war_participants.md)
 ✅ Alliance war master record documented in [docs/alliance_wars.md](docs/alliance_wars.md)
 ✅ Kingdom resources usage documented in [docs/kingdom_resources.md](docs/kingdom_resources.md)
+✅ Kingdom treaties documented in [docs/kingdom_treaties.md](docs/kingdom_treaties.md)
 
 
 ---

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -348,6 +348,16 @@ CREATE TABLE alliance_treaties (
     signed_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+-- Kingdom Treaties
+CREATE TABLE kingdom_treaties (
+    treaty_id SERIAL PRIMARY KEY,
+    kingdom_id INTEGER REFERENCES kingdoms(kingdom_id),
+    treaty_type TEXT,
+    partner_kingdom_id INTEGER REFERENCES kingdoms(kingdom_id),
+    status TEXT CHECK (status IN ('proposed','active','cancelled')) DEFAULT 'proposed',
+    signed_at TIMESTAMP WITH TIME ZONE
+);
+
 -- Alliance Quests
 CREATE TABLE quest_alliance_catalogue (
     quest_code     TEXT PRIMARY KEY,

--- a/docs/kingdom_treaties.md
+++ b/docs/kingdom_treaties.md
@@ -1,0 +1,56 @@
+# Kingdom Treaties
+
+The `kingdom_treaties` table stores diplomatic agreements between two player kingdoms.
+A row represents a single treaty proposal or active pact.
+
+## Table Structure
+
+| Column | Meaning / Usage |
+| --- | --- |
+| `treaty_id` | Unique treaty ID. Primary key. |
+| `kingdom_id` | The player kingdom initiating the treaty. |
+| `treaty_type` | Type of treaty (`Non-Aggression Pact`, `Defense Pact`, etc.). |
+| `partner_kingdom_id` | The other kingdom in the treaty. |
+| `status` | `proposed`, `active` or `cancelled`. |
+| `signed_at` | Timestamp when activated or cancelled. |
+
+## Usage
+
+### Proposing a treaty
+```sql
+INSERT INTO public.kingdom_treaties (kingdom_id, partner_kingdom_id, treaty_type, status)
+VALUES (?, ?, 'Non-Aggression Pact', 'proposed');
+```
+
+### Accepting a proposal
+```sql
+UPDATE public.kingdom_treaties
+SET status = 'active', signed_at = now()
+WHERE treaty_id = ?;
+```
+
+### Cancelling a treaty
+```sql
+UPDATE public.kingdom_treaties
+SET status = 'cancelled', signed_at = now()
+WHERE treaty_id = ?;
+```
+
+### Displaying on the diplomacy page
+```sql
+-- Active treaties
+SELECT * FROM public.kingdom_treaties
+WHERE (kingdom_id = ? OR partner_kingdom_id = ?) AND status = 'active';
+
+-- Incoming proposals
+SELECT * FROM public.kingdom_treaties
+WHERE partner_kingdom_id = ? AND status = 'proposed';
+
+-- Outgoing proposals
+SELECT * FROM public.kingdom_treaties
+WHERE kingdom_id = ? AND status = 'proposed';
+```
+
+Keep rows for history by marking them `cancelled` instead of deleting.
+Avoid duplicate active treaties of the same type between the same pair of kingdoms.
+

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -370,6 +370,17 @@ CREATE TABLE public.alliance_treaties (
   CONSTRAINT alliance_treaties_alliance_id_fkey FOREIGN KEY (alliance_id) REFERENCES public.alliances(alliance_id),
   CONSTRAINT alliance_treaties_partner_alliance_id_fkey FOREIGN KEY (partner_alliance_id) REFERENCES public.alliances(alliance_id)
 );
+CREATE TABLE public.kingdom_treaties (
+  treaty_id integer NOT NULL DEFAULT nextval('kingdom_treaties_treaty_id_seq'::regclass),
+  kingdom_id integer,
+  treaty_type text,
+  partner_kingdom_id integer,
+  status text CHECK (status IN ('proposed','active','cancelled')) DEFAULT 'proposed',
+  signed_at timestamp with time zone,
+  CONSTRAINT kingdom_treaties_pkey PRIMARY KEY (treaty_id),
+  CONSTRAINT kingdom_treaties_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id),
+  CONSTRAINT kingdom_treaties_partner_kingdom_id_fkey FOREIGN KEY (partner_kingdom_id) REFERENCES public.kingdoms(kingdom_id)
+);
 CREATE TABLE public.projects_player (
   project_id integer NOT NULL DEFAULT nextval('projects_player_project_id_seq'::regclass),
   kingdom_id integer,

--- a/migrations/2025_06_16_add_kingdom_treaties.sql
+++ b/migrations/2025_06_16_add_kingdom_treaties.sql
@@ -1,0 +1,9 @@
+-- Migration: add kingdom_treaties table
+CREATE TABLE public.kingdom_treaties (
+  treaty_id SERIAL PRIMARY KEY,
+  kingdom_id INTEGER REFERENCES public.kingdoms(kingdom_id),
+  treaty_type TEXT,
+  partner_kingdom_id INTEGER REFERENCES public.kingdoms(kingdom_id),
+  status TEXT CHECK (status IN ('proposed','active','cancelled')) DEFAULT 'proposed',
+  signed_at TIMESTAMP WITH TIME ZONE
+);

--- a/services/kingdom_treaty_service.py
+++ b/services/kingdom_treaty_service.py
@@ -1,0 +1,142 @@
+try:
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+    text = lambda q: q  # type: ignore
+    Session = object  # type: ignore
+
+
+def propose_treaty(
+    db: Session,
+    kingdom_id: int,
+    partner_kingdom_id: int,
+    treaty_type: str,
+) -> None:
+    """Insert a proposed treaty if no active treaty of the same type exists."""
+    exists = db.execute(
+        text(
+            """
+            SELECT 1 FROM kingdom_treaties
+             WHERE ((kingdom_id = :kid AND partner_kingdom_id = :pid)
+                    OR (kingdom_id = :pid AND partner_kingdom_id = :kid))
+               AND treaty_type = :type
+               AND status = 'active'
+            """
+        ),
+        {"kid": kingdom_id, "pid": partner_kingdom_id, "type": treaty_type},
+    ).fetchone()
+    if exists:
+        raise ValueError("Active treaty already exists")
+
+    db.execute(
+        text(
+            """
+            INSERT INTO kingdom_treaties (kingdom_id, partner_kingdom_id, treaty_type, status)
+            VALUES (:kid, :pid, :type, 'proposed')
+            """
+        ),
+        {"kid": kingdom_id, "pid": partner_kingdom_id, "type": treaty_type},
+    )
+    db.commit()
+
+
+def accept_treaty(db: Session, treaty_id: int) -> None:
+    """Set a treaty to active and record the timestamp."""
+    db.execute(
+        text(
+            "UPDATE kingdom_treaties SET status = 'active', signed_at = now() WHERE treaty_id = :tid"
+        ),
+        {"tid": treaty_id},
+    )
+    db.commit()
+
+
+def cancel_treaty(db: Session, treaty_id: int) -> None:
+    """Cancel a treaty."""
+    db.execute(
+        text(
+            "UPDATE kingdom_treaties SET status = 'cancelled', signed_at = now() WHERE treaty_id = :tid"
+        ),
+        {"tid": treaty_id},
+    )
+    db.commit()
+
+
+def list_active_treaties(db: Session, kingdom_id: int) -> list[dict]:
+    """Return active treaties for the kingdom."""
+    rows = db.execute(
+        text(
+            """
+            SELECT treaty_id, kingdom_id, treaty_type, partner_kingdom_id, status, signed_at
+              FROM kingdom_treaties
+             WHERE (kingdom_id = :kid OR partner_kingdom_id = :kid)
+               AND status = 'active'
+             ORDER BY signed_at DESC
+            """
+        ),
+        {"kid": kingdom_id},
+    ).fetchall()
+    return [
+        {
+            "treaty_id": r[0],
+            "kingdom_id": r[1],
+            "treaty_type": r[2],
+            "partner_kingdom_id": r[3],
+            "status": r[4],
+            "signed_at": r[5],
+        }
+        for r in rows
+    ]
+
+
+def list_incoming_proposals(db: Session, kingdom_id: int) -> list[dict]:
+    """Return treaties proposed to the kingdom."""
+    rows = db.execute(
+        text(
+            """
+            SELECT treaty_id, kingdom_id, treaty_type, partner_kingdom_id, status, signed_at
+              FROM kingdom_treaties
+             WHERE partner_kingdom_id = :kid AND status = 'proposed'
+             ORDER BY treaty_id DESC
+            """
+        ),
+        {"kid": kingdom_id},
+    ).fetchall()
+    return [
+        {
+            "treaty_id": r[0],
+            "kingdom_id": r[1],
+            "treaty_type": r[2],
+            "partner_kingdom_id": r[3],
+            "status": r[4],
+            "signed_at": r[5],
+        }
+        for r in rows
+    ]
+
+
+def list_outgoing_proposals(db: Session, kingdom_id: int) -> list[dict]:
+    """Return treaties this kingdom has proposed."""
+    rows = db.execute(
+        text(
+            """
+            SELECT treaty_id, kingdom_id, treaty_type, partner_kingdom_id, status, signed_at
+              FROM kingdom_treaties
+             WHERE kingdom_id = :kid AND status = 'proposed'
+             ORDER BY treaty_id DESC
+            """
+        ),
+        {"kid": kingdom_id},
+    ).fetchall()
+    return [
+        {
+            "treaty_id": r[0],
+            "kingdom_id": r[1],
+            "treaty_type": r[2],
+            "partner_kingdom_id": r[3],
+            "status": r[4],
+            "signed_at": r[5],
+        }
+        for r in rows
+    ]
+

--- a/tests/test_kingdom_treaty_service.py
+++ b/tests/test_kingdom_treaty_service.py
@@ -1,0 +1,80 @@
+from services.kingdom_treaty_service import (
+    propose_treaty,
+    accept_treaty,
+    cancel_treaty,
+    list_active_treaties,
+    list_incoming_proposals,
+    list_outgoing_proposals,
+)
+
+
+class DummyResult:
+    def __init__(self, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self):
+        self.queries = []
+        self.row = None
+        self.rows = []
+        self.commits = 0
+
+    def execute(self, query, params=None):
+        q = str(query).strip()
+        self.queries.append((q, params))
+        if "SELECT 1 FROM kingdom_treaties" in q:
+            return DummyResult(row=self.row)
+        if q.startswith("SELECT treaty_id"):
+            return DummyResult(rows=self.rows)
+        return DummyResult()
+
+    def commit(self):
+        self.commits += 1
+
+
+def test_propose_treaty_inserts():
+    db = DummyDB()
+    propose_treaty(db, 1, 2, "Non-Aggression Pact")
+    assert any("INSERT INTO kingdom_treaties" in q for q, _ in db.queries)
+    assert db.commits == 1
+
+
+def test_propose_existing_raises():
+    db = DummyDB()
+    db.row = (1,)
+    try:
+        propose_treaty(db, 1, 2, "Non-Aggression Pact")
+    except ValueError:
+        assert True
+    else:
+        assert False
+
+
+def test_accept_and_cancel():
+    db = DummyDB()
+    accept_treaty(db, 5)
+    cancel_treaty(db, 5)
+    q_strings = " ".join(q for q, _ in db.queries)
+    assert "UPDATE kingdom_treaties SET status = 'active'" in q_strings
+    assert "UPDATE kingdom_treaties SET status = 'cancelled'" in q_strings
+    assert db.commits == 2
+
+
+def test_list_functions():
+    db = DummyDB()
+    db.rows = [(1, 1, "Pact", 2, "active", "2025-01-01")]
+    active = list_active_treaties(db, 1)
+    incoming = list_incoming_proposals(db, 1)
+    outgoing = list_outgoing_proposals(db, 1)
+    assert active[0]["treaty_id"] == 1
+    assert incoming[0]["treaty_id"] == 1
+    assert outgoing[0]["treaty_id"] == 1
+


### PR DESCRIPTION
## Summary
- add new `kingdom_treaties` migration
- document treaty usage
- include `kingdom_treaties` schema
- implement `kingdom_treaty_service`
- test treaty service helpers
- reference docs in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845e54c19d88330844549a3f71b7981