### PR TITLE
Upgrade policies & laws catalogue

### DIFF
--- a/Javascript/policies_laws.js
+++ b/Javascript/policies_laws.js
@@ -41,7 +41,9 @@ async function loadPoliciesAndLaws() {
     // ✅ Load catalog
     const { data: catalogData, error: catalogError } = await supabase
       .from('policies_laws_catalogue')
-      .select('*');
+      .select('*')
+      .eq('is_active', true)
+      .order('unlock_at_level', { ascending: true });
 
     if (catalogError) throw catalogError;
 
@@ -53,11 +55,13 @@ async function loadPoliciesAndLaws() {
     policyContainer.innerHTML = "";
     policies.forEach(policy => {
       const card = document.createElement("div");
-      card.classList.add("policy-law-card");
+      card.classList.add("policy-card");
 
       card.innerHTML = `
         <h3>${escapeHTML(policy.name)}</h3>
         <p>${escapeHTML(policy.description)}</p>
+        <p>Category: ${escapeHTML(policy.category || '')}</p>
+        <p>Requires Castle Level: ${policy.unlock_at_level}</p>
         <p>Effect: ${escapeHTML(policy.effect_summary)}</p>
         <button class="action-btn policy-select-btn" data-id="${policy.id}">Select Policy</button>
       `;
@@ -74,13 +78,15 @@ async function loadPoliciesAndLaws() {
     lawContainer.innerHTML = "";
     laws.forEach(law => {
       const card = document.createElement("div");
-      card.classList.add("policy-law-card");
+      card.classList.add("law-card");
 
       const isActive = activeLaws.includes(law.id);
 
       card.innerHTML = `
         <h3>${escapeHTML(law.name)}</h3>
         <p>${escapeHTML(law.description)}</p>
+        <p>Category: ${escapeHTML(law.category || '')}</p>
+        <p>Requires Castle Level: ${law.unlock_at_level}</p>
         <p>Effect: ${escapeHTML(law.effect_summary)}</p>
         <label>
           <input type="checkbox" class="law-toggle" data-id="${law.id}" ${isActive ? "checked" : ""}>

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -290,7 +290,13 @@ CREATE TABLE policies_laws_catalogue (
     type           TEXT CHECK (type IN ('policy','law')),
     name           TEXT NOT NULL,
     description    TEXT,
-    effect_summary TEXT
+    effect_summary TEXT,
+    category       TEXT,
+    modifiers      JSONB DEFAULT '{}'::jsonb,
+    unlock_at_level INTEGER DEFAULT 1,
+    is_active      BOOLEAN DEFAULT TRUE,
+    created_at     TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_updated   TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
 -- ALLIANCES -----------------------------------------------------------------

--- a/docs/policies_laws_catalogue.md
+++ b/docs/policies_laws_catalogue.md
@@ -1,0 +1,32 @@
+# Policies & Laws Catalogue
+
+This table defines every policy or law that can exist in the game. The catalogue is referenced when presenting choices to players and during game logic when applying active modifiers.
+
+## Table: `public.policies_laws_catalogue`
+
+| Column | Purpose |
+| --- | --- |
+| `id` | Primary key. Unique policy or law ID. |
+| `type` | `policy` or `law`. |
+| `name` | Display name. |
+| `description` | Full description of the rule. |
+| `effect_summary` | Short text summary for the UI. |
+| `category` | Grouping such as Economy, Military, Diplomacy, Religion. |
+| `modifiers` | JSON modifiers applied to game calculations. |
+| `unlock_at_level` | Minimum castle level required. |
+| `is_active` | Admin toggle to disable a rule. |
+| `created_at` | When the row was created. |
+| `last_updated` | Last time this row changed. |
+
+## Usage
+
+Load available options for the Policies & Laws screen:
+```sql
+SELECT * FROM public.policies_laws_catalogue
+WHERE is_active = true
+ORDER BY unlock_at_level, id;
+```
+
+A player's selections are stored on the `users` table using `active_policy` and `active_laws[]`. When calculating effects, join to this catalogue and use the `modifiers` JSON to apply bonuses or penalties.
+
+Only administrators should modify this catalogue so that gameplay rules remain consistent.

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -363,6 +363,12 @@ CREATE TABLE public.policies_laws_catalogue (
   name text NOT NULL,
   description text,
   effect_summary text,
+  category text,
+  modifiers jsonb DEFAULT '{}'::jsonb,
+  unlock_at_level integer DEFAULT 1,
+  is_active boolean DEFAULT true,
+  created_at timestamp with time zone DEFAULT now(),
+  last_updated timestamp with time zone DEFAULT now(),
   CONSTRAINT policies_laws_catalogue_pkey PRIMARY KEY (id)
 );
 CREATE TABLE public.project_player_catalogue (

--- a/migrations/2025_06_19_update_policies_laws_catalogue.sql
+++ b/migrations/2025_06_19_update_policies_laws_catalogue.sql
@@ -1,0 +1,9 @@
+-- Migration: extend policies_laws_catalogue with additional fields
+
+ALTER TABLE public.policies_laws_catalogue
+  ADD COLUMN category text,
+  ADD COLUMN modifiers jsonb DEFAULT '{}'::jsonb,
+  ADD COLUMN unlock_at_level integer DEFAULT 1,
+  ADD COLUMN is_active boolean DEFAULT true,
+  ADD COLUMN created_at timestamp with time zone DEFAULT now(),
+  ADD COLUMN last_updated timestamp with time zone DEFAULT now();


### PR DESCRIPTION
## Summary
- expand `policies_laws_catalogue` with gameplay metadata
- filter active policies/laws by level and status in the UI
- document the policies & laws catalogue
- provide SQL migration for the new columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845ee6de75c8330bd4eb3a366664e5b