### PR TITLE
Document and model alliance project catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ the records created during onboarding.
 ✅ Kingdom resources usage documented in [docs/kingdom_resources.md](docs/kingdom_resources.md)
 ✅ Kingdom treaties documented in [docs/kingdom_treaties.md](docs/kingdom_treaties.md)
 
+✅ Alliance project catalogue documented in [docs/project_alliance_catalogue.md](docs/project_alliance_catalogue.md)
+
 ✅ VIP status system documented in [docs/vip_status.md](docs/vip_status.md)
 
 ✅ Kingdom troops table documented in [docs/kingdom_troops.md](docs/kingdom_troops.md)

--- a/backend/models.py
+++ b/backend/models.py
@@ -108,6 +108,31 @@ class AllianceVaultTransactionLog(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
 
+class ProjectAllianceCatalogue(Base):
+    __tablename__ = 'project_alliance_catalogue'
+
+    project_code = Column(String, primary_key=True)
+    project_name = Column(String, nullable=False)
+    description = Column(Text)
+    category = Column(String)
+    effect_summary = Column(Text)
+    is_repeatable = Column(Boolean, default=False)
+    required_tech = Column(JSONB)
+    prerequisites = Column(JSONB)
+    unlocks = Column(JSONB)
+    resource_costs = Column(JSONB)
+    build_time_seconds = Column(Integer)
+    project_duration_seconds = Column(Integer)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    user_id = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+    modifiers = Column(JSONB)
+    requires_alliance_level = Column(Integer, default=0)
+    is_active = Column(Boolean, default=True)
+    max_active_instances = Column(Integer)
+    expires_at = Column(DateTime(timezone=True))
+
+
 class WarsTactical(Base):
     __tablename__ = 'wars_tactical'
     war_id = Column(Integer, primary_key=True)

--- a/backend/routers/alliance_projects.py
+++ b/backend/routers/alliance_projects.py
@@ -1,5 +1,9 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
 from pydantic import BaseModel
+
+from ..database import get_db
+from ..models import Alliance, ProjectAllianceCatalogue
 
 router = APIRouter(prefix="/api/alliance-projects", tags=["alliance_projects"])
 
@@ -10,8 +14,32 @@ class ProjectPayload(BaseModel):
 
 
 @router.get("")
-async def list_projects():
-    return {"projects": []}
+def list_projects(alliance_id: int = 1, db: Session = Depends(get_db)):
+    alliance = db.query(Alliance).filter(Alliance.alliance_id == alliance_id).first()
+    if not alliance:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+
+    rows = (
+        db.query(ProjectAllianceCatalogue)
+        .filter(ProjectAllianceCatalogue.is_active.is_(True))
+        .filter(ProjectAllianceCatalogue.requires_alliance_level <= alliance.level)
+        .all()
+    )
+
+    return {
+        "projects": [
+            {
+                "project_code": r.project_code,
+                "project_name": r.project_name,
+                "description": r.description,
+                "effect_summary": r.effect_summary,
+                "resource_costs": r.resource_costs,
+                "build_time_seconds": r.build_time_seconds,
+                "modifiers": r.modifiers,
+            }
+            for r in rows
+        ]
+    }
 
 
 @router.post("/start")

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -358,6 +358,29 @@ CREATE TABLE alliance_vault (
     updated_at        TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+CREATE TABLE project_alliance_catalogue (
+    project_code TEXT PRIMARY KEY,
+    project_name TEXT NOT NULL,
+    description  TEXT,
+    category TEXT,
+    effect_summary TEXT,
+    is_repeatable BOOLEAN DEFAULT FALSE,
+    required_tech TEXT[],
+    prerequisites TEXT[],
+    unlocks TEXT[],
+    resource_costs JSONB,
+    build_time_seconds INTEGER,
+    project_duration_seconds INTEGER,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    user_id UUID REFERENCES users(user_id),
+    modifiers JSONB,
+    requires_alliance_level INTEGER DEFAULT 0,
+    is_active BOOLEAN DEFAULT TRUE,
+    max_active_instances INTEGER,
+    expires_at TIMESTAMP WITH TIME ZONE
+);
+
 CREATE TABLE projects_alliance (
     project_id  SERIAL PRIMARY KEY,
     alliance_id INTEGER REFERENCES alliances(alliance_id),

--- a/docs/project_alliance_catalogue.md
+++ b/docs/project_alliance_catalogue.md
@@ -1,0 +1,59 @@
+# Alliance Project Catalogue
+
+The `project_alliance_catalogue` table defines every Alliance Project available in the game. It is static data maintained by admins and referenced whenever an alliance chooses a project to start.
+
+## Table Structure
+
+| Column | Purpose |
+| --- | --- |
+| `project_code` | Short unique string identifier (primary key). |
+| `project_name` | Name shown to players. |
+| `description` | Detailed description. |
+| `category` | Project category such as `Military`, `Economic`, `Diplomatic`, `Special`. |
+| `effect_summary` | Short summary for the UI. |
+| `is_repeatable` | Can this project be repeated? |
+| `required_tech` | Array of tech codes required to unlock. |
+| `prerequisites` | Array of other projects that must be completed first. |
+| `unlocks` | Array of projects or abilities unlocked by completing this project. |
+| `resource_costs` | Resources required to build (jsonb). |
+| `build_time_seconds` | Time to build in seconds. |
+| `project_duration_seconds` | If temporary, how long the modifiers last. |
+| `created_at` | Audit timestamp when created. |
+| `last_updated` | Audit timestamp when last modified. |
+| `user_id` | Admin user who created/edited the entry. |
+| `modifiers` | Bonuses/effects applied when completed (jsonb). |
+| `requires_alliance_level` | Minimum alliance level required. |
+| `is_active` | Whether this project is currently available. |
+| `max_active_instances` | Maximum active instances allowed. |
+| `expires_at` | Pre-set expiry date if applicable. |
+
+## Usage
+
+### Listing available projects
+
+```sql
+SELECT *
+FROM project_alliance_catalogue
+WHERE is_active = true
+  AND requires_alliance_level <= :alliance_level;
+```
+
+### Starting a project
+
+1. Validate `required_tech` and `prerequisites` for the alliance.
+2. Deduct `resource_costs` from `alliance_vault`.
+3. Insert a row into `projects_alliance` with `starts_at` and `ends_at` calculated from `build_time_seconds`.
+
+### Completion and effects
+
+When a project completes, merge the `modifiers` into the alliance or member stats. If `project_duration_seconds` is set, track an expiry time and remove the effects later.
+
+`is_repeatable` and `max_active_instances` should be enforced so that unique projects cannot be stacked beyond their limits.
+
+## Best Practices
+
+* Only admins may modify this catalogue.
+* Validate prerequisites before starting a project.
+* Log starts and completions in alliance history.
+* Periodically clean up expired projects.
+* Use `effect_summary` in the UI, but rely on the `modifiers` JSON for calculations.

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -383,6 +383,30 @@ CREATE TABLE public.project_player_catalogue (
   required_knights integer DEFAULT 0,
   CONSTRAINT project_player_catalogue_pkey PRIMARY KEY (project_code)
 );
+CREATE TABLE public.project_alliance_catalogue (
+  project_code text NOT NULL,
+  project_name text NOT NULL,
+  description text,
+  category text,
+  effect_summary text,
+  is_repeatable boolean DEFAULT false,
+  required_tech text[],
+  prerequisites text[],
+  unlocks text[],
+  resource_costs jsonb,
+  build_time_seconds integer,
+  project_duration_seconds integer,
+  created_at timestamp with time zone DEFAULT now(),
+  last_updated timestamp with time zone DEFAULT now(),
+  user_id uuid,
+  modifiers jsonb,
+  requires_alliance_level integer DEFAULT 0,
+  is_active boolean DEFAULT true,
+  max_active_instances integer,
+  expires_at timestamp with time zone,
+  CONSTRAINT project_alliance_catalogue_pkey PRIMARY KEY (project_code),
+  CONSTRAINT project_alliance_catalogue_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(user_id)
+);
 CREATE TABLE public.projects_alliance (
   project_id integer NOT NULL DEFAULT nextval('projects_alliance_project_id_seq'::regclass),
   alliance_id integer,

--- a/tests/test_alliance_projects_router.py
+++ b/tests/test_alliance_projects_router.py
@@ -1,0 +1,40 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.database import Base
+from backend.models import Alliance, ProjectAllianceCatalogue, User
+from backend.routers.alliance_projects import list_projects
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def create_user(db):
+    user = User(
+        user_id='00000000-0000-0000-0000-000000000001',
+        username='tester',
+        display_name='Tester',
+        email='t@example.com',
+        password_hash='x'
+    )
+    db.add(user)
+    db.commit()
+    return user.user_id
+
+
+def test_list_projects_filters_by_level():
+    Session = setup_db()
+    db = Session()
+    create_user(db)
+    db.add(Alliance(alliance_id=1, name='A', level=2))
+    db.add(ProjectAllianceCatalogue(project_code='p1', project_name='One', requires_alliance_level=1))
+    db.add(ProjectAllianceCatalogue(project_code='p2', project_name='Two', requires_alliance_level=5))
+    db.commit()
+
+    res = list_projects(1, db)
+    assert len(res["projects"]) == 1
+    assert res["projects"][0]["project_code"] == 'p1'


### PR DESCRIPTION
## Summary
- document `project_alliance_catalogue` table
- add table creation in schema files
- expose project catalogue through `/api/alliance-projects`
- create SQLAlchemy model for alliance projects
- test basic filtering of catalogue entries
- reference new doc from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845efcefecc8330b8d2b30dffd2191e