### PR TITLE
Add documentation and columns for projects_player table

### DIFF
--- a/FINAL_SCHEMA_DOCUMENTATION.md
+++ b/FINAL_SCHEMA_DOCUMENTATION.md
@@ -66,3 +66,19 @@ Columns:
 - `requires_alliance_level` — minimum alliance level
 - `is_active` — whether available to build
 - `max_active_instances` — cap on simultaneous active copies
+
+## Table: `public.projects_player`
+Runtime tracker of kingdom projects that players start. Each row represents one instance of a project launched from the catalogue.
+
+Columns:
+- `project_id` — serial primary key
+- `kingdom_id` — which kingdom owns the project
+- `project_code` — catalogue code of the project
+- `power_score` — contribution score used for rankings
+- `starts_at` — when construction began
+- `ends_at` — when the project completes (null = permanent)
+- `build_state` — state enum: `queued`, `building`, `completed`, `expired`
+- `is_active` — whether the modifiers are currently applied
+- `started_by` — user that initiated the build
+- `last_updated` — audit timestamp of last modification
+- `expires_at` — when temporary effects expire

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ the records created during onboarding.
 ✅ Kingdom resources usage documented in [docs/kingdom_resources.md](docs/kingdom_resources.md)
 ✅ Kingdom treaties documented in [docs/kingdom_treaties.md](docs/kingdom_treaties.md)
 ✅ Kingdom projects catalogue documented in [docs/project_player_catalogue.md](docs/project_player_catalogue.md)
+✅ Player projects table documented in [docs/projects_player.md](docs/projects_player.md)
 ✅ Alliance project catalogue documented in [docs/project_alliance_catalogue.md](docs/project_alliance_catalogue.md)
 
 

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -261,7 +261,17 @@ CREATE TABLE projects_player (
     project_code TEXT REFERENCES project_player_catalogue(project_code),
     power_score  INTEGER DEFAULT 0,
     starts_at    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    ends_at      TIMESTAMP WITH TIME ZONE
+    ends_at      TIMESTAMP WITH TIME ZONE,
+    build_state  TEXT DEFAULT 'building',
+    is_active    BOOLEAN DEFAULT TRUE,
+    started_by   UUID,
+    last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    expires_at   TIMESTAMP WITH TIME ZONE,
+    CONSTRAINT projects_player_started_by_fkey FOREIGN KEY (started_by)
+        REFERENCES users(user_id) ON DELETE SET NULL,
+    CONSTRAINT projects_player_build_state_check CHECK (
+        build_state = ANY (ARRAY['queued','building','completed','expired'])
+    )
 );
 
 -- QUESTS --------------------------------------------------------------------

--- a/docs/projects_player.md
+++ b/docs/projects_player.md
@@ -1,0 +1,67 @@
+# Player Projects
+
+The `projects_player` table tracks every instance of a project that a kingdom has started or completed. Rows are created when a player launches a project from the `project_player_catalogue`.
+
+## Table Structure
+
+| Column | Purpose / Usage |
+| --- | --- |
+| `project_id` | Unique project instance. Primary key. |
+| `kingdom_id` | The player kingdom this project belongs to. |
+| `project_code` | FK to `project_player_catalogue.project_code`. |
+| `power_score` | Contribution score used for rankings. |
+| `starts_at` | Timestamp when the project was started. |
+| `ends_at` | When the project finishes (`NULL` if permanent). |
+| `build_state` | `queued`, `building`, `completed` or `expired`. |
+| `is_active` | Whether the project effects are enabled. |
+| `started_by` | User who initiated the project. |
+| `last_updated` | Audit timestamp for modifications. |
+| `expires_at` | When temporary effects should expire. |
+
+## Usage
+
+### Displaying projects
+
+```sql
+SELECT pp.*, pc.name, pc.category, pc.modifiers
+FROM projects_player pp
+JOIN project_player_catalogue pc ON pp.project_code = pc.project_code
+WHERE pp.kingdom_id = ?
+  AND (pp.ends_at IS NULL OR pp.ends_at > now())
+ORDER BY pp.starts_at DESC;
+```
+
+Show each project's name, power score and progress. If `ends_at` has passed mark it as **Completed**.
+
+### Starting a project
+
+```sql
+INSERT INTO projects_player (kingdom_id, project_code, power_score, starts_at, ends_at)
+VALUES (?, ?, ?, now(), now() + interval 'X seconds');
+```
+
+Use the catalogue entry to determine build time, cost and modifiers.
+
+### Completion and expiration
+
+When `ends_at` is reached apply the modifiers from the catalogue. If the project is temporary use `expires_at` to disable its effects later.
+
+## Best Practices
+
+* Prevent duplicates for non-repeatable projects:
+
+```sql
+SELECT * FROM projects_player
+WHERE kingdom_id = ?
+  AND project_code = ?
+  AND ends_at > now();
+```
+
+* Respect `max_active_instances` for repeatables.
+* Sync modifiers to the kingdom upon completion.
+
+## Integration Flow Summary
+
+1. Player starts a project → insert row with start and end timestamps.
+2. On game ticks or login check `ends_at` and apply bonuses.
+3. Expire temporary projects using `expires_at` and `is_active`.

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -451,9 +451,16 @@ CREATE TABLE public.projects_player (
   power_score integer DEFAULT 0,
   starts_at timestamp with time zone DEFAULT now(),
   ends_at timestamp with time zone,
+  build_state text DEFAULT 'building',
+  is_active boolean DEFAULT true,
+  started_by uuid,
+  last_updated timestamp with time zone DEFAULT now(),
+  expires_at timestamp with time zone,
   CONSTRAINT projects_player_pkey PRIMARY KEY (project_id),
   CONSTRAINT projects_player_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id),
-  CONSTRAINT projects_player_project_code_fkey FOREIGN KEY (project_code) REFERENCES public.project_player_catalogue(project_code)
+  CONSTRAINT projects_player_project_code_fkey FOREIGN KEY (project_code) REFERENCES public.project_player_catalogue(project_code),
+  CONSTRAINT projects_player_started_by_fkey FOREIGN KEY (started_by) REFERENCES users(user_id) ON DELETE SET NULL,
+  CONSTRAINT projects_player_build_state_check CHECK (build_state = ANY (ARRAY['queued','building','completed','expired']))
 );
 CREATE TABLE public.quest_alliance_catalogue (
   quest_code text NOT NULL,

--- a/migrations/2025_06_20_add_projects_player_columns.sql
+++ b/migrations/2025_06_20_add_projects_player_columns.sql
@@ -1,0 +1,13 @@
+-- Migration: extend projects_player with build state and audit columns
+
+ALTER TABLE public.projects_player
+  ADD COLUMN IF NOT EXISTS build_state text NULL DEFAULT 'building',
+  ADD COLUMN IF NOT EXISTS is_active boolean NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS started_by uuid NULL,
+  ADD COLUMN IF NOT EXISTS last_updated timestamp with time zone NULL DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS expires_at timestamp with time zone NULL,
+  ADD CONSTRAINT projects_player_started_by_fkey FOREIGN KEY (started_by)
+    REFERENCES users (user_id) ON DELETE SET NULL,
+  ADD CONSTRAINT projects_player_build_state_check CHECK (
+    build_state = ANY (ARRAY['queued','building','completed','expired'])
+  );


### PR DESCRIPTION
## Summary
- document the player projects table
- reference the new doc in README
- describe projects_player in FINAL_SCHEMA_DOCUMENTATION
- add migration to extend projects_player
- include new columns in schema SQL files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845f58b8e248330a699bc5b3cadd893