### PR TITLE
Integrate alliance quest catalogue

### DIFF
--- a/FINAL_SCHEMA_DOCUMENTATION.md
+++ b/FINAL_SCHEMA_DOCUMENTATION.md
@@ -66,3 +66,21 @@ Columns:
 - `requires_alliance_level` — minimum alliance level
 - `is_active` — whether available to build
 - `max_active_instances` — cap on simultaneous active copies
+
+## Table: `public.quest_alliance_catalogue`
+Master catalogue of alliance quests. Each row defines a quest that alliances can undertake.
+
+Columns:
+- `quest_code` — primary key identifier
+- `name` — quest name
+- `description` — long description
+- `duration_hours` — quest duration in hours
+- `category` — quest category (combat, economic, etc.)
+- `objectives` — jsonb defining required objectives
+- `rewards` — jsonb describing rewards
+- `required_level` — minimum alliance level
+- `repeatable` — if true the quest may be repeated
+- `max_attempts` — limit on attempts when repeatable
+- `is_active` — hide quest when false
+- `created_at` — timestamp when added
+- `last_updated` — timestamp when modified

--- a/docs/quest_alliance_catalogue.md
+++ b/docs/quest_alliance_catalogue.md
@@ -1,0 +1,53 @@
+# Alliance Quest Catalogue
+
+The `quest_alliance_catalogue` table defines every quest an alliance can undertake. It acts as the master list used when displaying available quests and when creating rows in `quest_alliance_tracking`.
+
+## Purpose
+
+* Admin-managed catalogue of alliance quests.
+* Contains objectives, rewards and gating requirements.
+* Entries are referenced via `quest_code`.
+
+## Table Structure
+
+| Column | Purpose |
+| --- | --- |
+| `quest_code` | Primary key identifier for the quest. |
+| `name` | Quest name shown to players. |
+| `description` | Long description. |
+| `duration_hours` | How long the quest lasts once started. |
+| `category` | Quest type such as `combat`, `economic`, `exploration`, etc. |
+| `objectives` | JSONB detailing what must be accomplished. |
+| `rewards` | JSONB describing rewards granted. |
+| `required_level` | Minimum alliance level to unlock. |
+| `repeatable` | If `true`, quest can be repeated. |
+| `max_attempts` | Maximum attempts allowed if repeatable. `NULL` for unlimited. |
+| `is_active` | Set to `false` to hide the quest from the UI. |
+| `created_at` | Timestamp when the row was created. |
+| `last_updated` | Timestamp when last modified. |
+
+## Usage
+
+### Listing available quests
+
+```sql
+SELECT *
+FROM public.quest_alliance_catalogue
+WHERE is_active = true
+  AND required_level <= (SELECT level FROM alliances WHERE alliance_id = :alliance_id);
+```
+
+### Starting a quest
+
+```sql
+INSERT INTO public.quest_alliance_tracking (alliance_id, quest_code, status, progress, ends_at)
+VALUES (:alliance_id, :quest_code, 'active', 0,
+        now() + (SELECT duration_hours * interval '1 hour'
+                  FROM public.quest_alliance_catalogue WHERE quest_code = :quest_code));
+```
+
+### Progress and completion
+
+While active, players contribute resources or complete objectives. Progress is tracked in `quest_alliance_tracking`. Once objectives are met, rewards from the catalogue are processed and the quest marked `completed`.
+
+Only administrators modify this catalogue. Quests should never be deleted—set `is_active` to `false` instead.


### PR DESCRIPTION
## Summary
- filter available quests by alliance level and active status
- show quest objectives, rewards and repeatability in UI
- document `quest_alliance_catalogue` table
- describe alliance quest catalogue in final schema docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845f61f78e88330b53ca7cc9d91c8fd