### PR TITLE
Add quest alliance contributions table documentation

### DIFF
--- a/FINAL_SCHEMA_DOCUMENTATION.md
+++ b/FINAL_SCHEMA_DOCUMENTATION.md
@@ -130,3 +130,17 @@ Columns:
 - `last_updated` — audit timestamp
 
 
+## Table: `public.quest_alliance_contributions`
+Tracks every resource, item or event players contribute toward alliance quests. Used for progress tracking, leaderboards and audits.
+
+Columns:
+- `contribution_id` — serial primary key
+- `alliance_id` — owning alliance
+- `player_name` — display name when contributed
+- `resource_type` — resource or item type
+- `amount` — amount contributed
+- `timestamp` — when the contribution happened
+- `quest_code` — quest this contribution applies to
+- `user_id` — player UUID
+- `contribution_type` — contribution category such as `resource` or `item`
+

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ the records created during onboarding.
 ✅ Player projects table documented in [docs/projects_player.md](docs/projects_player.md)
 ✅ Alliance project catalogue documented in [docs/project_alliance_catalogue.md](docs/project_alliance_catalogue.md)
 ✅ Alliance projects runtime table documented in [docs/projects_alliance.md](docs/projects_alliance.md)
+✅ Alliance quest contributions documented in [docs/quest_alliance_contributions.md](docs/quest_alliance_contributions.md)
 
 
 ✅ VIP status system documented in [docs/vip_status.md](docs/vip_status.md)

--- a/backend/models.py
+++ b/backend/models.py
@@ -415,3 +415,19 @@ class KingdomHistoryLog(Base):
     event_type = Column(String)
     event_details = Column(Text)
     event_date = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class QuestAllianceContribution(Base):
+    """Transaction log of player contributions toward alliance quests."""
+
+    __tablename__ = 'quest_alliance_contributions'
+
+    contribution_id = Column(Integer, primary_key=True)
+    alliance_id = Column(Integer, ForeignKey('alliances.alliance_id'))
+    player_name = Column(String)
+    resource_type = Column(String)
+    amount = Column(Integer)
+    timestamp = Column(DateTime(timezone=True), server_default=func.now())
+    quest_code = Column(String, ForeignKey('quest_alliance_catalogue.quest_code'))
+    user_id = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+    contribution_type = Column(String, default='resource')

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -471,7 +471,10 @@ CREATE TABLE quest_alliance_contributions (
     player_name     TEXT,
     resource_type   resource_type,
     amount          INTEGER,
-    timestamp       TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    timestamp       TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    quest_code      TEXT REFERENCES quest_alliance_catalogue(quest_code),
+    user_id         UUID REFERENCES users(user_id),
+    contribution_type TEXT DEFAULT 'resource'
 );
 
 -- Alliance Tax Collections

--- a/docs/quest_alliance_contributions.md
+++ b/docs/quest_alliance_contributions.md
@@ -1,0 +1,64 @@
+# Alliance Quest Contributions
+
+This table logs every resource, item or special action players contribute toward alliance quests. Each entry represents a single transaction so progress can be audited and displayed in leaderboards.
+
+## Table Structure
+
+| Column | Purpose |
+| --- | --- |
+| `contribution_id` | Serial primary key |
+| `alliance_id` | Which alliance received the contribution |
+| `player_name` | Display name at the time of contribution |
+| `resource_type` | Resource enum or item type |
+| `amount` | Amount contributed |
+| `timestamp` | When the contribution occurred |
+| `quest_code` | Quest being contributed toward |
+| `user_id` | Player UUID for joins and ranking |
+| `contribution_type` | `resource`, `item`, `event`, `manual` |
+
+### Example Insert
+
+```sql
+INSERT INTO public.quest_alliance_contributions (
+  alliance_id,
+  player_name,
+  resource_type,
+  amount,
+  timestamp,
+  quest_code,
+  user_id,
+  contribution_type
+) VALUES (
+  1,
+  'PlayerOne',
+  'wood',
+  500,
+  now(),
+  'QST_BLD_001',
+  '00000000-0000-0000-0000-000000000001',
+  'resource'
+);
+```
+
+### Contribution Log Query
+
+Fetch recent contributions for a quest:
+
+```sql
+SELECT player_name, resource_type, amount, timestamp
+FROM public.quest_alliance_contributions
+WHERE alliance_id = :alliance_id
+  AND quest_code = :quest_code
+ORDER BY timestamp ASC;
+```
+
+### Leaderboard Query
+
+```sql
+SELECT user_id, player_name, SUM(amount) AS total_contributed
+FROM public.quest_alliance_contributions
+WHERE alliance_id = :alliance_id
+  AND quest_code = :quest_code
+GROUP BY user_id, player_name
+ORDER BY total_contributed DESC;
+```

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -499,8 +499,13 @@ CREATE TABLE public.quest_alliance_contributions (
   resource_type USER-DEFINED,
   amount integer,
   timestamp timestamp with time zone DEFAULT now(),
+  quest_code text,
+  user_id uuid,
+  contribution_type text DEFAULT 'resource',
   CONSTRAINT quest_alliance_contributions_pkey PRIMARY KEY (contribution_id),
-  CONSTRAINT quest_alliance_contributions_alliance_id_fkey FOREIGN KEY (alliance_id) REFERENCES public.alliances(alliance_id)
+  CONSTRAINT quest_alliance_contributions_alliance_id_fkey FOREIGN KEY (alliance_id) REFERENCES public.alliances(alliance_id),
+  CONSTRAINT quest_alliance_contributions_quest_code_fkey FOREIGN KEY (quest_code) REFERENCES public.quest_alliance_catalogue(quest_code),
+  CONSTRAINT quest_alliance_contributions_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(user_id)
 );
 CREATE TABLE public.quest_alliance_tracking (
   alliance_id integer NOT NULL,


### PR DESCRIPTION
## Summary
- document alliance quest contributions table
- reference new doc from README
- expand schema SQL definitions with extra columns
- include model for quest alliance contributions in backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6845f75cc7848330aefc33482105c0f5