### PR TITLE
Integrate region catalogue table

### DIFF
--- a/Javascript/overview.js
+++ b/Javascript/overview.js
@@ -119,14 +119,15 @@ async function loadOverview() {
         .select('region')
         .eq('user_id', currentUser.id)
         .single();
-      let regionName = krec?.region || 'Unspecified';
-      if (regionName) {
+      let regionCode = krec?.region || 'Unspecified';
+      let regionName = regionCode;
+      if (regionCode) {
         const { data: rdata } = await supabase
           .from('region_catalogue')
-          .select('name')
-          .eq('region_code', regionName)
+          .select('region_name')
+          .eq('region_code', regionCode)
           .single();
-        regionName = rdata?.name || regionName;
+        regionName = rdata?.region_name || regionCode;
       }
       if (regionEl) regionEl.innerHTML = `<strong>Region:</strong> ${escapeHTML(regionName)}`;
     } catch (e) {

--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -146,7 +146,7 @@ function bindEvents(profileExists) {
         .from('kingdom_troop_slots')
         .insert({
           kingdom_id: kingdomId,
-          base_slots: 20 + (regionData.troop_bonus || 0)
+          base_slots: 20 + (regionData.troop_bonus?.base_slots || 0)
         });
 
       await supabase
@@ -208,7 +208,7 @@ async function loadRegions() {
     regionMap[r.region_code] = r;
     const opt = document.createElement('option');
     opt.value = r.region_code;
-    opt.textContent = r.region_name || r.name || r.region_code;
+    opt.textContent = r.region_name || r.region_code;
     regionEl.appendChild(opt);
   });
 
@@ -223,12 +223,16 @@ async function loadRegions() {
     if (r.resource_bonus && Object.keys(r.resource_bonus).length > 0) {
       html += '<ul>';
       for (const [res, amt] of Object.entries(r.resource_bonus)) {
-        html += `<li>${escapeHTML(res)}: +${amt}</li>`;
+        html += `<li>${escapeHTML(res)}: ${amt > 0 ? '+' : ''}${amt}%</li>`;
       }
       html += '</ul>';
     }
-    if (r.troop_bonus) {
-      html += `<p>Troop Slots Bonus: ${r.troop_bonus}</p>`;
+    if (r.troop_bonus && Object.keys(r.troop_bonus).length > 0) {
+      html += '<ul>';
+      for (const [stat, val] of Object.entries(r.troop_bonus)) {
+        html += `<li>${escapeHTML(stat)}: ${val > 0 ? '+' : ''}${val}%</li>`;
+      }
+      html += '</ul>';
     }
     infoEl.innerHTML = html;
   });

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -37,10 +37,10 @@ CREATE TABLE kingdoms (
 
 CREATE TABLE region_catalogue (
     region_code TEXT PRIMARY KEY,
-    name TEXT,
+    region_name TEXT,
     description TEXT,
     resource_bonus JSONB DEFAULT '{}'::jsonb,
-    troop_bonus INTEGER DEFAULT 0
+    troop_bonus JSONB DEFAULT '{}'::jsonb
 );
 
 

--- a/docs/kingdoms.md
+++ b/docs/kingdoms.md
@@ -9,7 +9,7 @@ The `kingdoms` table stores the master record for every player kingdom in the ga
 | `kingdom_id` | Primary key, unique kingdom ID |
 | `user_id` | FK to `users.user_id` — owner of this kingdom |
 | `kingdom_name` | Player-chosen name of the kingdom |
-| `region` | Region of the world this kingdom belongs to |
+| `region` | Region code referencing `region_catalogue.region_code` |
 | `created_at` | When this kingdom was created |
 | `prestige_score` | Overall ranking score (used for leaderboards) |
 | `avatar_url` | URL to avatar image |

--- a/docs/onboarding_setup.md
+++ b/docs/onboarding_setup.md
@@ -5,7 +5,7 @@ When a player signs up and completes the onboarding flow (`play.html` & `play.js
 1. **users** – A profile row with `setup_complete` marked `true` and the generated `kingdom_id`.
 2. **kingdoms** – The core kingdom record containing the chosen name and region.
 3. **villages** – The first village associated with the kingdom.
-4. **kingdom_resources** – Resource ledger populated with the region's bonus values.
-5. **kingdom_troop_slots** – Starting troop slot count of `20` plus any regional bonus.
+4. **kingdom_resources** – Resource ledger populated with the region's `resource_bonus` values.
+5. **kingdom_troop_slots** – Starting troop slot count of `20`. Regional `troop_bonus` values modify troop stats rather than slot count.
 
 Additional tables such as `kingdom_castle_progression` are initialized lazily on first access by the progression API.

--- a/docs/region_catalogue.md
+++ b/docs/region_catalogue.md
@@ -1,0 +1,46 @@
+# Region Catalogue
+
+This table defines all playable regions in **Kingmakers Rise**. It acts as a static lookup referenced by `kingdoms.region`.
+
+| Column | Purpose |
+| --- | --- |
+| `region_code` | Short code primary key used by `kingdoms.region` |
+| `region_name` | Display name for the region |
+| `description` | Lore / flavour text |
+| `resource_bonus` | JSONB object of resource production modifiers |
+| `troop_bonus` | JSONB object of troop stat modifiers |
+
+## Example Queries
+
+### List regions for selection
+```sql
+SELECT region_code, region_name, description, resource_bonus, troop_bonus
+FROM public.region_catalogue
+ORDER BY region_name ASC;
+```
+
+### Fetch a kingdom's region details
+```sql
+SELECT r.region_name, r.description, r.resource_bonus, r.troop_bonus
+FROM public.region_catalogue r
+JOIN public.kingdoms k ON k.region = r.region_code
+WHERE k.kingdom_id = ?;
+```
+
+Both bonus columns store percentage modifiers. For example:
+```json
+{
+    "wood": 10,
+    "stone": -5,
+    "gold": 15
+}
+```
+```json
+{
+    "infantry_hp": 5,
+    "archer_damage": 10,
+    "cavalry_speed": -10
+}
+```
+
+These values are applied dynamically during resource production and troop combat calculations.

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -333,6 +333,19 @@ CREATE TABLE public.kingdoms (
   CONSTRAINT kingdoms_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(user_id),
   CONSTRAINT kingdoms_user_id_key UNIQUE (user_id)
 );
+
+CREATE TABLE public.region_catalogue (
+  region_code text PRIMARY KEY,
+  region_name text,
+  description text,
+  resource_bonus jsonb DEFAULT '{}',
+  troop_bonus jsonb DEFAULT '{}'
+);
+INSERT INTO public.region_catalogue (region_code, region_name, description, resource_bonus, troop_bonus) VALUES
+  ('north', 'Northlands', 'Cold and rugged with hardy people.', '{"wood":50}', '{"infantry_hp":2}'),
+  ('south', 'Southlands', 'Fertile fields and warm climate.', '{"food":100}', '{"cavalry_speed":1}'),
+  ('east', 'Eastreach', 'Rich trade routes and culture.', '{"gold":20}', '{"archer_damage":3}'),
+  ('west', 'Westvale', 'Frontier lands full of stone.', '{"stone":50}', '{}');
 CREATE TABLE public.notifications (
   notification_id integer NOT NULL DEFAULT nextval('notifications_notification_id_seq'::regclass),
   user_id uuid,

--- a/migrations/2025_06_08_add_regions.sql
+++ b/migrations/2025_06_08_add_regions.sql
@@ -7,15 +7,15 @@ ALTER TABLE public.kingdoms
 -- Catalogue of available regions
 CREATE TABLE public.region_catalogue (
   region_code text PRIMARY KEY,
-  name text,
+  region_name text,
   description text,
   resource_bonus jsonb DEFAULT '{}',
-  troop_bonus integer DEFAULT 0
+  troop_bonus jsonb DEFAULT '{}'
 );
 
 -- Sample starter regions
-INSERT INTO public.region_catalogue (region_code, name, description, resource_bonus, troop_bonus) VALUES
-  ('north', 'Northlands', 'Cold and rugged with hardy people.', '{"wood":50}', 2),
-  ('south', 'Southlands', 'Fertile fields and warm climate.', '{"food":100}', 1),
-  ('east', 'Eastreach', 'Rich trade routes and culture.', '{"gold":20}', 3),
-  ('west', 'Westvale', 'Frontier lands full of stone.', '{"stone":50}', 0);
+INSERT INTO public.region_catalogue (region_code, region_name, description, resource_bonus, troop_bonus) VALUES
+  ('north', 'Northlands', 'Cold and rugged with hardy people.', '{"wood":50}', '{"infantry_hp":2}'),
+  ('south', 'Southlands', 'Fertile fields and warm climate.', '{"food":100}', '{"cavalry_speed":1}'),
+  ('east', 'Eastreach', 'Rich trade routes and culture.', '{"gold":20}', '{"archer_damage":3}'),
+  ('west', 'Westvale', 'Frontier lands full of stone.', '{"stone":50}', '{}');

--- a/services/progression_service.py
+++ b/services/progression_service.py
@@ -71,7 +71,7 @@ def calculate_troop_slots(db: Session, kingdom_id: int) -> int:
                    kts.slots_from_tech,
                    kts.slots_from_projects,
                    kts.slots_from_events,
-                   COALESCE(rc.troop_bonus, 0)
+                   COALESCE((rc.troop_bonus ->> 'base_slots')::integer, 0)
             FROM kingdom_troop_slots kts
             JOIN kingdoms k ON k.kingdom_id = kts.kingdom_id
             LEFT JOIN region_catalogue rc ON rc.region_code = k.region
@@ -90,7 +90,7 @@ def calculate_troop_slots(db: Session, kingdom_id: int) -> int:
         tech_bonus,
         project_bonus,
         event_bonus,
-        region_bonus,
+        region_slots,
     ) = result
 
     total_slots = (
@@ -99,7 +99,7 @@ def calculate_troop_slots(db: Session, kingdom_id: int) -> int:
         + tech_bonus
         + project_bonus
         + event_bonus
-        + region_bonus
+        + region_slots
     )
 
     return total_slots
@@ -231,7 +231,7 @@ def get_total_modifiers(db: Session, kingdom_id: int) -> dict:
                     total,
                     {
                         "resource_bonus": resources or {},
-                        "troop_bonus": {"base_slots": troop or 0},
+                        "troop_bonus": troop or {},
                     },
                 )
     except Exception:


### PR DESCRIPTION
## Summary
- document new `region_catalogue` table
- update onboarding docs and kingdom reference
- support JSON troop/resource bonuses on region table
- adjust JS pages for new region fields
- revise progression service for JSON troop bonuses
- include table definition in schemas and migration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68460559708c8330a557243acc84e24e