### PR TITLE
Integrate terrain_map schema

### DIFF
--- a/FINAL_SCHEMA_DOCUMENTATION.md
+++ b/FINAL_SCHEMA_DOCUMENTATION.md
@@ -158,3 +158,18 @@ Columns:
 - `attempt_count` — how many times the quest has been completed
 - `started_by` — user who started the quest
 
+## Table: `public.terrain_map`
+Stores the full battlefield grid for each war so replays and live battles use the same layout.
+
+Columns:
+- `terrain_id` — serial primary key
+- `war_id` — FK to `wars_tactical.war_id`
+- `tile_map` — JSONB tile grid
+- `generated_at` — timestamp when created
+- `map_width` — number of tiles horizontally
+- `map_height` — number of tiles vertically
+- `map_seed` — RNG seed used for generation
+- `map_version` — version of the tile format
+- `generated_by` — user/admin who generated the map
+- `map_name` — optional display name
+- `last_updated` — audit timestamp

--- a/Javascript/battle_live.js
+++ b/Javascript/battle_live.js
@@ -28,6 +28,9 @@ async function loadTerrain() {
   try {
     const response = await fetch(`/api/battle/terrain/${warId}`);
     const data = await response.json();
+    mapWidth = data.map_width;
+    mapHeight = data.map_height;
+    currentMapColumns = mapWidth;
     renderBattleMap(data.tile_map);
   } catch (err) {
     console.error('Error loading terrain:', err);
@@ -82,19 +85,18 @@ function refreshBattle() {
   loadUnits();
   loadCombatLogs();
 }
-
+let mapWidth = 60;
+let mapHeight = 20;
 let currentMapColumns = 60;
 
 function renderBattleMap(tileMap) {
   const battleMap = document.getElementById('battle-map');
   battleMap.innerHTML = '';
 
-  const rows = tileMap.length;
-  currentMapColumns = tileMap[0]?.length || 0;
-  battleMap.style.gridTemplateColumns = `repeat(${currentMapColumns}, 1fr)`;
+  battleMap.style.gridTemplateColumns = `repeat(${mapWidth}, 1fr)`;
 
-  for (let row = 0; row < rows; row++) {
-    for (let col = 0; col < currentMapColumns; col++) {
+  for (let row = 0; row < mapHeight; row++) {
+    for (let col = 0; col < mapWidth; col++) {
       const tile = document.createElement('div');
       tile.className = 'tile';
       const type = tileMap[row][col];
@@ -116,7 +118,7 @@ function renderUnits(units) {
   }
 
   units.forEach(unit => {
-    const index = unit.position_y * currentMapColumns + unit.position_x;
+    const index = unit.position_y * mapWidth + unit.position_x;
     if (!tiles[index]) return;
     const unitDiv = document.createElement('div');
     unitDiv.className = 'unit-icon';

--- a/backend/battle_engine/engine.py
+++ b/backend/battle_engine/engine.py
@@ -33,6 +33,8 @@ class WarState:
     war_id: int
     tick: int
     castle_hp: int
+    map_width: int
+    map_height: int
     units: List[Unit] = field(default_factory=list)
     terrain: List[List[TerrainType]] = field(default_factory=list)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -316,6 +316,15 @@ class TerrainMap(Base):
     war_id = Column(Integer, ForeignKey('wars_tactical.war_id'))
     tile_map = Column(JSONB)
     generated_at = Column(DateTime(timezone=True), server_default=func.now())
+    map_width = Column(Integer)
+    map_height = Column(Integer)
+    map_seed = Column(Integer)
+    map_version = Column(Integer, default=1)
+    generated_by = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+    map_name = Column(String)
+    last_updated = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
 
 
 class UnitStat(Base):

--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -33,10 +33,14 @@ def _load_war_from_db(war_id: int, db: Session) -> WarState:
         db.query(models.TerrainMap).filter(models.TerrainMap.war_id == war_id).first()
     )
     terrain = terrain_row.tile_map if terrain_row else TerrainGenerator().generate()
+    width = terrain_row.map_width if terrain_row else TerrainGenerator.WIDTH
+    height = terrain_row.map_height if terrain_row else TerrainGenerator.HEIGHT
     war = WarState(
         war_id=db_war.war_id,
         tick=db_war.battle_tick,
         castle_hp=db_war.castle_hp,
+        map_width=width,
+        map_height=height,
         terrain=terrain,
     )
     movements = (
@@ -117,7 +121,11 @@ def get_battle_terrain(war_id: int, db: Session = Depends(get_db)):
     )
     if not terrain_row:
         raise HTTPException(status_code=404, detail="terrain not found")
-    return {"tile_map": terrain_row.tile_map}
+    return {
+        "tile_map": terrain_row.tile_map,
+        "map_width": terrain_row.map_width,
+        "map_height": terrain_row.map_height,
+    }
 
 
 @router.get("/api/battle/units/{war_id}")

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -859,7 +859,14 @@ CREATE TABLE terrain_map (
     terrain_id SERIAL PRIMARY KEY,
     war_id INTEGER REFERENCES wars_tactical(war_id),
     tile_map JSONB,
-    generated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    generated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    map_width INTEGER,
+    map_height INTEGER,
+    map_seed INTEGER,
+    map_version INTEGER DEFAULT 1,
+    generated_by UUID REFERENCES users(user_id),
+    map_name TEXT,
+    last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
 CREATE TABLE combat_logs (

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -576,6 +576,13 @@ CREATE TABLE public.terrain_map (
   war_id integer,
   tile_map jsonb,
   generated_at timestamp with time zone DEFAULT now(),
+  map_width integer,
+  map_height integer,
+  map_seed integer,
+  map_version integer DEFAULT 1,
+  generated_by uuid,
+  map_name text,
+  last_updated timestamp with time zone DEFAULT now(),
   CONSTRAINT terrain_map_pkey PRIMARY KEY (terrain_id),
   CONSTRAINT terrain_map_war_id_fkey FOREIGN KEY (war_id) REFERENCES public.wars_tactical(war_id)
 );


### PR DESCRIPTION
## Summary
- expand `terrain_map` schema with width/height and metadata
- expose map dimensions through battle API
- track map dimensions in the battle engine state
- use map dimensions in live battle UI
- document new table in schema docs

## Testing
- `python -m py_compile backend/battle_engine/engine.py backend/models.py backend/routers/battle.py`
- `node -c Javascript/battle_live.js`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684626a8251883309d2670be8bd375a0