### PR TITLE
Integrate training_history table

### DIFF
--- a/Javascript/kingdom_military.js
+++ b/Javascript/kingdom_military.js
@@ -164,7 +164,7 @@ async function loadTrainingHistory() {
   container.innerHTML = "<p>Loading training history...</p>";
 
   try {
-    const res = await fetch("/api/kingdom_military/history");
+    const res = await fetch("/api/training-history?kingdom_id=1&limit=50");
     const data = await res.json();
 
     container.innerHTML = "";
@@ -178,7 +178,7 @@ async function loadTrainingHistory() {
 
     data.history.forEach(entry => {
       const li = document.createElement("li");
-      li.textContent = `${escapeHTML(entry.unit_name)} x${entry.quantity} — Completed: ${formatTimestamp(entry.completed_at)}`;
+      li.textContent = `[${formatTimestamp(entry.completed_at)}] Trained ${entry.quantity} ${escapeHTML(entry.unit_name)} (source: ${entry.source})`;
       list.appendChild(li);
     });
 

--- a/Javascript/train_troops.js
+++ b/Javascript/train_troops.js
@@ -158,7 +158,8 @@ function renderTrainingHistory(history) {
 
     card.innerHTML = `
       <h4>${escapeHTML(entry.unit_name)} x ${entry.quantity}</h4>
-      <p>Completed: ${new Date(entry.completed_at).toLocaleString()}</p>
+      <p>[${new Date(entry.completed_at).toLocaleString()}] (source: ${escapeHTML(entry.source)})</p>
+      ${entry.xp_awarded ? `<p>XP Awarded: ${entry.xp_awarded}</p>` : ""}
     `;
 
     historyEl.appendChild(card);

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,6 +30,7 @@ from .routers import (
     alliance_treaties_router,
     spies_router,
     trade_logs,
+    training_history,
     settings_router,
     wars,
     quests_router,
@@ -76,6 +77,7 @@ app.include_router(treaties_router.router)
 app.include_router(alliance_treaties_router.router)
 app.include_router(spies_router.router)
 app.include_router(trade_logs.router)
+app.include_router(training_history.router)
 app.include_router(settings_router.router)
 app.include_router(wars.router)
 app.include_router(quests_router.router)

--- a/backend/routers/training_history.py
+++ b/backend/routers/training_history.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from services.training_history_service import record_training, fetch_history
+
+router = APIRouter(prefix="/api/training-history", tags=["training_history"])
+
+
+class TrainingPayload(BaseModel):
+    kingdom_id: int
+    unit_id: int
+    unit_name: str
+    quantity: int
+    source: str
+    initiated_at: str
+    trained_by: str | None = None
+    xp_awarded: int = 0
+    modifiers_applied: dict | None = None
+
+
+@router.get("")
+def get_history(
+    kingdom_id: int = Query(...),
+    limit: int = 50,
+    db: Session = Depends(get_db),
+):
+    records = fetch_history(db, kingdom_id, limit)
+    return {"history": records}
+
+
+@router.post("")
+def create_history(payload: TrainingPayload, db: Session = Depends(get_db)):
+    hid = record_training(
+        db,
+        kingdom_id=payload.kingdom_id,
+        unit_id=payload.unit_id,
+        unit_name=payload.unit_name,
+        quantity=payload.quantity,
+        source=payload.source,
+        initiated_at=payload.initiated_at,
+        trained_by=payload.trained_by,
+        xp_awarded=payload.xp_awarded,
+        modifiers_applied=payload.modifiers_applied or {},
+    )
+    return {"history_id": hid}

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -153,7 +153,12 @@ CREATE TABLE training_history (
     unit_id      INTEGER REFERENCES training_catalog(unit_id),
     unit_name    TEXT,
     quantity     INTEGER NOT NULL,
-    completed_at TIMESTAMP WITH TIME ZONE
+    completed_at TIMESTAMP WITH TIME ZONE,
+    source TEXT,
+    initiated_at TIMESTAMP WITH TIME ZONE,
+    trained_by UUID REFERENCES users(user_id),
+    xp_awarded INTEGER DEFAULT 0,
+    modifiers_applied JSONB DEFAULT '{}'::jsonb
 );
 
 -- MILITARY SLOTS ------------------------------------------------------------

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -643,6 +643,11 @@ CREATE TABLE public.training_history (
   unit_name text,
   quantity integer NOT NULL,
   completed_at timestamp with time zone,
+  source text,
+  initiated_at timestamp with time zone,
+  trained_by uuid,
+  xp_awarded integer DEFAULT 0,
+  modifiers_applied jsonb DEFAULT '{}'::jsonb,
   CONSTRAINT training_history_pkey PRIMARY KEY (history_id),
   CONSTRAINT training_history_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id),
   CONSTRAINT training_history_unit_id_fkey FOREIGN KEY (unit_id) REFERENCES public.training_catalog(unit_id)

--- a/migrations/2025_06_22_add_training_history.sql
+++ b/migrations/2025_06_22_add_training_history.sql
@@ -1,0 +1,24 @@
+-- Migration: add training_history table
+
+CREATE TABLE public.training_history (
+  history_id SERIAL PRIMARY KEY,
+  kingdom_id INTEGER REFERENCES public.kingdoms(kingdom_id),
+  unit_id INTEGER REFERENCES public.training_catalog(unit_id),
+  unit_name TEXT,
+  quantity INTEGER NOT NULL,
+  completed_at TIMESTAMP WITH TIME ZONE,
+  source TEXT,
+  initiated_at TIMESTAMP WITH TIME ZONE,
+  trained_by UUID REFERENCES public.users(user_id),
+  xp_awarded INTEGER DEFAULT 0,
+  modifiers_applied JSONB DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE public.training_history ENABLE ROW LEVEL SECURITY;
+CREATE POLICY access_own_training_history ON public.training_history
+  FOR SELECT USING (
+    auth.uid() = (
+      SELECT user_id FROM public.kingdoms k
+      WHERE k.kingdom_id = training_history.kingdom_id
+    )
+  );

--- a/services/training_history_service.py
+++ b/services/training_history_service.py
@@ -1,0 +1,75 @@
+try:
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+except Exception:  # pragma: no cover
+    text = lambda q: q  # type: ignore
+    Session = object  # type: ignore
+
+
+def record_training(
+    db: Session,
+    kingdom_id: int,
+    unit_id: int,
+    unit_name: str,
+    quantity: int,
+    source: str,
+    initiated_at: str,
+    trained_by: str | None,
+    xp_awarded: int,
+    modifiers_applied: dict | None,
+) -> int:
+    """Insert a new training history row and return its id."""
+    result = db.execute(
+        text(
+            """
+            INSERT INTO training_history (
+                kingdom_id, unit_id, unit_name, quantity, completed_at,
+                source, initiated_at, trained_by, xp_awarded, modifiers_applied
+            ) VALUES (
+                :kid, :uid, :uname, :qty, now(),
+                :src, :init, :tby, :xp, :mods
+            ) RETURNING history_id
+            """
+        ),
+        {
+            "kid": kingdom_id,
+            "uid": unit_id,
+            "uname": unit_name,
+            "qty": quantity,
+            "src": source,
+            "init": initiated_at,
+            "tby": trained_by,
+            "xp": xp_awarded,
+            "mods": modifiers_applied or {},
+        },
+    )
+    row = result.fetchone()
+    db.commit()
+    return row[0] if row else 0
+
+
+def fetch_history(db: Session, kingdom_id: int, limit: int = 50) -> list[dict]:
+    """Return recent training history for a kingdom."""
+    rows = db.execute(
+        text(
+            """
+            SELECT unit_name, quantity, completed_at, source, xp_awarded
+            FROM training_history
+            WHERE kingdom_id = :kid
+            ORDER BY completed_at DESC
+            LIMIT :lim
+            """
+        ),
+        {"kid": kingdom_id, "lim": limit},
+    ).fetchall()
+
+    return [
+        {
+            "unit_name": r[0],
+            "quantity": r[1],
+            "completed_at": r[2],
+            "source": r[3],
+            "xp_awarded": r[4],
+        }
+        for r in rows
+    ]

--- a/tests/test_training_history_service.py
+++ b/tests/test_training_history_service.py
@@ -1,0 +1,58 @@
+from services.training_history_service import record_training, fetch_history
+
+
+class DummyResult:
+    def __init__(self, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self):
+        self.executed = []
+        self.rows = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        self.executed.append((q, params))
+        if q.strip().startswith("INSERT INTO training_history"):
+            return DummyResult((1,))
+        if "FROM training_history" in q:
+            return DummyResult(rows=self.rows)
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_record_training_inserts():
+    db = DummyDB()
+    hid = record_training(
+        db,
+        kingdom_id=1,
+        unit_id=5,
+        unit_name="Knight",
+        quantity=10,
+        source="manual",
+        initiated_at="2025-06-09 10:00",
+        trained_by="u1",
+        xp_awarded=50,
+        modifiers_applied={"bonus": 10},
+    )
+    assert hid == 1
+    assert len(db.executed) == 1
+    assert "INSERT INTO training_history" in db.executed[0][0]
+
+
+def test_fetch_history_returns_rows():
+    db = DummyDB()
+    db.rows = [("Knight", 10, "2025-06-10", "manual", 50)]
+    rows = fetch_history(db, 1, 20)
+    assert len(rows) == 1
+    assert rows[0]["unit_name"] == "Knight"


### PR DESCRIPTION
## Summary
- integrate training_history table creation via migration
- expose training history via FastAPI
- add service layer for recording/fetching
- hook router into API
- update JS to display source and XP
- add unit tests for service
- update SQL schema files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6846375979888330b4a5821dd7a98490