### PR TITLE
Add unit_movements table documentation and schema updates

### DIFF
--- a/FINAL_SCHEMA_DOCUMENTATION.md
+++ b/FINAL_SCHEMA_DOCUMENTATION.md
@@ -188,3 +188,29 @@ Columns:
 - `effectiveness_multiplier` — multiplier applied in combat
 - `source` — origin of the rule (`base`, `tech`, `event`)
 - `notes` — optional conditions or restrictions
+
+## Table: `public.unit_movements`
+Tracks live unit orders for each tactical battle.
+
+Columns:
+- `movement_id` — primary key
+- `war_id` — FK to `wars_tactical.war_id`
+- `kingdom_id` — owning kingdom
+- `unit_type` — troop type
+- `unit_level` — level of the unit stack
+- `quantity` — number of troops
+- `position_x` — current X tile
+- `position_y` — current Y tile
+- `stance` — movement stance
+- `movement_path` — JSON path to follow
+- `target_priority` — preferred targets
+- `patrol_zone` — patrol area JSON
+- `fallback_point_x` — fallback X coordinate
+- `fallback_point_y` — fallback Y coordinate
+- `withdraw_threshold_percent` — morale threshold to retreat
+- `morale` — current morale
+- `status` — active/retreating/etc.
+- `visible_enemies` — cached visible enemy IDs
+- `issued_by` — commander issuing the order
+- `created_at` — when the row was created
+- `last_updated` — last update time

--- a/backend/models.py
+++ b/backend/models.py
@@ -220,6 +220,7 @@ class UnitMovement(Base):
     war_id = Column(Integer, ForeignKey('wars_tactical.war_id'))
     kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'))
     unit_type = Column(String)
+    unit_level = Column(Integer)
     quantity = Column(Integer)
     position_x = Column(Integer)
     position_y = Column(Integer)
@@ -233,6 +234,9 @@ class UnitMovement(Base):
     morale = Column(Integer)
     status = Column(String)
     visible_enemies = Column(JSONB, default={})
+    issued_by = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
 
 class CombatLog(Base):

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -854,6 +854,7 @@ CREATE TABLE unit_movements (
     war_id INTEGER REFERENCES wars_tactical(war_id),
     kingdom_id INTEGER REFERENCES kingdoms(kingdom_id),
     unit_type TEXT,
+    unit_level INTEGER,
     quantity INTEGER,
     position_x INTEGER,
     position_y INTEGER,
@@ -865,7 +866,11 @@ CREATE TABLE unit_movements (
     fallback_point_y INTEGER,
     withdraw_threshold_percent INTEGER,
     morale FLOAT,
-    status TEXT
+    status TEXT,
+    visible_enemies JSONB DEFAULT '{}'::jsonb,
+    issued_by UUID REFERENCES users(user_id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
 CREATE TABLE terrain_map (

--- a/docs/unit_movements.md
+++ b/docs/unit_movements.md
@@ -1,0 +1,57 @@
+# public.unit_movements — Codex Integration Guide
+
+This table tracks every unit's movement and morale during tactical battles. Each row represents the current order for a stack of troops in an ongoing war.
+
+## Table Structure
+
+| Column | Meaning |
+| --- | --- |
+| `movement_id` | Primary key for internal updates |
+| `war_id` | Linked war from `wars_tactical` |
+| `kingdom_id` | Which kingdom the unit belongs to |
+| `unit_type` | Troop type from `unit_stats` |
+| `unit_level` | Level of the unit stack |
+| `quantity` | Number of troops in this order |
+| `position_x` | Current X tile (0–59) |
+| `position_y` | Current Y tile (0–19) |
+| `stance` | `'aggressive'`, `'defensive'`, `'fallback'`, `'patrol'` |
+| `movement_path` | JSON array of tiles to follow |
+| `target_priority` | JSON list of preferred enemy types |
+| `patrol_zone` | JSON defining patrol area |
+| `fallback_point_x` | X coordinate for fallback |
+| `fallback_point_y` | Y coordinate for fallback |
+| `withdraw_threshold_percent` | Auto‑retreat morale percent |
+| `morale` | Current morale 0‑100 |
+| `status` | `'active'`, `'retreating'`, etc. |
+| `visible_enemies` | JSON cache for fog of war |
+| `issued_by` | UUID of the commander issuing the order |
+| `created_at` | When this movement was created |
+| `last_updated` | Last time position or status changed |
+
+## Usage
+
+### Inserting orders
+When a battle starts or a pre‑plan is finalized, create rows for each unit:
+```sql
+INSERT INTO public.unit_movements (
+  war_id, kingdom_id, unit_type, unit_level, quantity,
+  position_x, position_y, stance, movement_path,
+  patrol_zone, target_priority, fallback_point_x, fallback_point_y,
+  withdraw_threshold_percent, morale, status, issued_by
+) VALUES (...);
+```
+
+### During each tick
+The battle engine updates position, morale and visible enemies:
+```sql
+UPDATE public.unit_movements
+SET position_x = :x,
+    position_y = :y,
+    morale = morale - :loss,
+    last_updated = now()
+WHERE movement_id = :id;
+```
+
+Use `visible_enemies` to maintain fog‑of‑war caching.
+
+This table powers live battle visualization and replay. Never delete rows while a war is active.

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -685,6 +685,7 @@ CREATE TABLE public.unit_movements (
   war_id integer,
   kingdom_id integer,
   unit_type text,
+  unit_level integer,
   quantity integer,
   position_x integer,
   position_y integer,
@@ -698,9 +699,13 @@ CREATE TABLE public.unit_movements (
   morale double precision,
   status text,
   visible_enemies jsonb DEFAULT '{}'::jsonb,
+  issued_by uuid,
+  created_at timestamp with time zone DEFAULT now(),
+  last_updated timestamp with time zone DEFAULT now(),
   CONSTRAINT unit_movements_pkey PRIMARY KEY (movement_id),
   CONSTRAINT unit_movements_war_id_fkey FOREIGN KEY (war_id) REFERENCES public.wars_tactical(war_id),
-  CONSTRAINT unit_movements_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id)
+  CONSTRAINT unit_movements_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id),
+  CONSTRAINT unit_movements_issued_by_fkey FOREIGN KEY (issued_by) REFERENCES public.users(user_id)
 );
 CREATE TABLE public.unit_stats (
   unit_type text NOT NULL,

--- a/migrations/2025_06_23_update_unit_movements.sql
+++ b/migrations/2025_06_23_update_unit_movements.sql
@@ -1,0 +1,8 @@
+-- Migration: expand unit_movements table
+
+ALTER TABLE public.unit_movements
+  ADD COLUMN unit_level INTEGER,
+  ADD COLUMN visible_enemies JSONB DEFAULT '{}'::jsonb,
+  ADD COLUMN issued_by UUID REFERENCES public.users(user_id),
+  ADD COLUMN created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  ADD COLUMN last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW();


### PR DESCRIPTION
## Summary
- expand `unit_movements` model to include level, issued_by and timestamps
- update schema files and add migration for new columns
- document `public.unit_movements` in docs and final schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684759e9d82483308e4d773f82508897