### PR TITLE
Update trade_logs schema

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -548,7 +548,11 @@ CREATE TABLE trade_logs (
     buyer_alliance_id  INTEGER,
     seller_alliance_id INTEGER,
     buyer_name         TEXT,
-    seller_name        TEXT
+    seller_name        TEXT,
+    trade_type         TEXT,
+    trade_status       TEXT DEFAULT 'completed',
+    initiated_by_system BOOLEAN DEFAULT FALSE,
+    last_updated       TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
 CREATE TABLE black_market_listings (

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -598,6 +598,10 @@ CREATE TABLE public.trade_logs (
   seller_alliance_id integer,
   buyer_name text,
   seller_name text,
+  trade_type text,
+  trade_status text DEFAULT 'completed',
+  initiated_by_system boolean DEFAULT false,
+  last_updated timestamp with time zone DEFAULT now(),
   CONSTRAINT trade_logs_pkey PRIMARY KEY (trade_id),
   CONSTRAINT trade_logs_buyer_id_fkey FOREIGN KEY (buyer_id) REFERENCES public.users(user_id),
   CONSTRAINT trade_logs_seller_id_fkey FOREIGN KEY (seller_id) REFERENCES public.users(user_id)


### PR DESCRIPTION
## Summary
- add audit columns to `trade_logs` table in schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68476d19b28483309e7a08786502810b