### PR TITLE
Add training_catalog documentation

### DIFF
--- a/FINAL_SCHEMA_DOCUMENTATION.md
+++ b/FINAL_SCHEMA_DOCUMENTATION.md
@@ -256,3 +256,40 @@ Columns:
 - `constructed_by` — user who initiated the construction
 - `active_modifiers` — JSON of buffs or debuffs applied
 - `construction_status` — `idle`, `queued`, `under_construction`, `paused`, `complete`
+
+## Table: `public.training_catalog`
+Defines base training times and costs for every troop type.
+
+Columns:
+- `unit_id` — serial primary key
+- `unit_name` — name of the unit
+- `tier` — tech tier or level
+- `training_time` — time in seconds to train one unit
+- `cost_wood` — wood required
+- `cost_stone` — stone required
+- `cost_iron_ore` — iron ore required
+- `cost_gold` — gold required
+- `cost_gems` — gems required
+- `cost_food` — food required
+- `cost_coal` — coal required
+- `cost_livestock` — livestock required
+- `cost_clay` — clay required
+- `cost_flax` — flax required
+- `cost_tools` — tools required
+- `cost_wood_planks` — wood planks required
+- `cost_refined_stone` — refined stone required
+- `cost_iron_ingots` — iron ingots required
+- `cost_charcoal` — charcoal required
+- `cost_leather` — leather required
+- `cost_arrows` — arrows required
+- `cost_swords` — swords required
+- `cost_axes` — axes required
+- `cost_shields` — shields required
+- `cost_armour` — armour required
+- `cost_wagon` — wagons required
+- `cost_siege_weapons` — siege weapons required
+- `cost_jewelry` — jewelry required
+- `cost_spear` — spears required
+- `cost_horses` — horses required
+- `cost_pitchforks` — pitchforks required
+

--- a/docs/training_catalog.md
+++ b/docs/training_catalog.md
@@ -1,0 +1,41 @@
+# Training Catalog
+
+The `training_catalog` table defines the base cost and time to train every unit. Records here are referenced by `training_queue` and `training_history` when tracking troop production.
+
+## Table Structure
+
+| Column | Description |
+| --- | --- |
+| `unit_id` | Primary key for the unit entry |
+| `unit_name` | Display name of the unit |
+| `tier` | Tech progression tier |
+| `training_time` | Base training time in seconds |
+| `cost_wood` | Wood required to train one unit |
+| `cost_stone` | Stone required |
+| `cost_iron_ore` | Iron ore required |
+| `cost_gold` | Gold required |
+| `cost_gems` | Gems required |
+| `cost_food` | Food required |
+| `cost_coal` | Coal required |
+| `cost_livestock` | Livestock required |
+| `cost_clay` | Clay required |
+| `cost_flax` | Flax required |
+| `cost_tools` | Tools required |
+| `cost_wood_planks` | Wood planks required |
+| `cost_refined_stone` | Refined stone required |
+| `cost_iron_ingots` | Iron ingots required |
+| `cost_charcoal` | Charcoal required |
+| `cost_leather` | Leather required |
+| `cost_arrows` | Arrows required |
+| `cost_swords` | Swords required |
+| `cost_axes` | Axes required |
+| `cost_shields` | Shields required |
+| `cost_armour` | Armour pieces required |
+| `cost_wagon` | Wagons required |
+| `cost_siege_weapons` | Siege weapons required |
+| `cost_jewelry` | Jewelry required |
+| `cost_spear` | Spears required |
+| `cost_horses` | Horses required |
+| `cost_pitchforks` | Pitchforks required |
+
+All cost columns default to `0` if not specified.


### PR DESCRIPTION
## Summary
- document `training_catalog` table
- add new documentation file explaining each column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68476d20364c8330896c78463e95ff1a