### PR TITLE
Add village modifiers support

### DIFF
--- a/CSS/village.css
+++ b/CSS/village.css
@@ -115,7 +115,8 @@ body {
 .building-list,
 .military-stats,
 .queue-list,
-.event-log {
+.event-log,
+.modifier-list {
   display: grid;
   gap: 1rem;
 }

--- a/FINAL_SCHEMA_DOCUMENTATION.md
+++ b/FINAL_SCHEMA_DOCUMENTATION.md
@@ -256,3 +256,21 @@ Columns:
 - `constructed_by` — user who initiated the construction
 - `active_modifiers` — JSON of buffs or debuffs applied
 - `construction_status` — `idle`, `queued`, `under_construction`, `paused`, `complete`
+
+## Table: `public.village_modifiers`
+Tracks temporary or permanent bonuses applied to individual villages.
+
+Columns:
+- `modifier_id` — primary key
+- `village_id` — FK to `kingdom_villages.village_id`
+- `resource_bonus` — jsonb resource boosts
+- `troop_bonus` — jsonb combat bonuses
+- `construction_speed_bonus` — build speed percentage
+- `defense_bonus` — defensive bonus value
+- `trade_bonus` — trade efficiency boost
+- `source` — origin of the modifier
+- `stacking_rules` — jsonb stacking rules
+- `expires_at` — when the effect ends (null for permanent)
+- `applied_by` — user that triggered the bonus
+- `created_at` — timestamp applied
+- `last_updated` — timestamp last changed

--- a/Javascript/village.js
+++ b/Javascript/village.js
@@ -42,6 +42,9 @@ async function loadVillagePage() {
     // ✅ Load buildings
     await loadVillageBuildings(villageId);
 
+    // ✅ Load modifiers
+    await loadVillageModifiers(villageId);
+
     // ✅ Load military
     await loadVillageMilitary(villageId);
 
@@ -123,6 +126,42 @@ async function loadVillageBuildings(villageId) {
       <p>Level: ${building.level}</p>
     `;
     listEl.appendChild(card);
+  });
+}
+
+// ✅ Load Modifiers
+async function loadVillageModifiers(villageId) {
+  const modEl = document.getElementById('modifier-list');
+  if (!modEl) return;
+  modEl.innerHTML = "<p>Loading modifiers...</p>";
+
+  const { data: mods, error } = await supabase
+    .from('village_modifiers')
+    .select('*')
+    .eq('village_id', villageId);
+
+  if (error) {
+    console.error('❌ Error loading modifiers:', error);
+    modEl.innerHTML = '<p>Failed to load modifiers.</p>';
+    return;
+  }
+
+  modEl.innerHTML = '';
+  const now = Date.now();
+  if (!mods || mods.length === 0) {
+    modEl.innerHTML = '<p>No active modifiers.</p>';
+    return;
+  }
+
+  mods.forEach(mod => {
+    if (mod.expires_at && new Date(mod.expires_at).getTime() < now) return;
+    const card = document.createElement('div');
+    card.classList.add('modifier-card');
+    card.innerHTML = `
+      <h4>${mod.source}</h4>
+      <p>Expires: ${mod.expires_at ? new Date(mod.expires_at).toLocaleDateString() : 'Never'}</p>
+    `;
+    modEl.appendChild(card);
   });
 }
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ the records created during onboarding.
 ✅ Training queue documented in [docs/training_queue.md](docs/training_queue.md)
 ✅ Unit stats table documented in [docs/unit_stats.md](docs/unit_stats.md)
 ✅ Village buildings table documented in [docs/village_buildings.md](docs/village_buildings.md)
+✅ Village modifiers table documented in [docs/village_modifiers.md](docs/village_modifiers.md)
 ✅ Kingdoms master table documented in [docs/kingdoms.md](docs/kingdoms.md)
 ✅ Terrain map integration documented in [docs/terrain_map.md](docs/terrain_map.md)
 ✅ Final schema summary in [FINAL_SCHEMA_DOCUMENTATION.md](FINAL_SCHEMA_DOCUMENTATION.md)

--- a/backend/main.py
+++ b/backend/main.py
@@ -31,6 +31,7 @@ from .routers import (
     spies_router,
     trade_logs,
     training_history,
+    village_modifiers,
     settings_router,
     wars,
     quests_router,
@@ -78,6 +79,7 @@ app.include_router(alliance_treaties_router.router)
 app.include_router(spies_router.router)
 app.include_router(trade_logs.router)
 app.include_router(training_history.router)
+app.include_router(village_modifiers.router)
 app.include_router(settings_router.router)
 app.include_router(wars.router)
 app.include_router(quests_router.router)

--- a/backend/models.py
+++ b/backend/models.py
@@ -444,6 +444,26 @@ class KingdomSpies(Base):
     last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
 
+class VillageModifier(Base):
+    """Temporary or permanent bonuses applied to a village."""
+
+    __tablename__ = 'village_modifiers'
+
+    modifier_id = Column(Integer, primary_key=True)
+    village_id = Column(Integer, index=True)
+    resource_bonus = Column(JSONB, default={})
+    troop_bonus = Column(JSONB, default={})
+    construction_speed_bonus = Column(Integer, default=0)
+    defense_bonus = Column(Integer, default=0)
+    trade_bonus = Column(Integer, default=0)
+    source = Column(String)
+    stacking_rules = Column(JSONB, default={})
+    expires_at = Column(DateTime(timezone=True))
+    applied_by = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
 class SpyMission(Base):
     """Active and completed spy missions."""
 

--- a/backend/routers/village_modifiers.py
+++ b/backend/routers/village_modifiers.py
@@ -1,0 +1,109 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import func
+
+from ..database import get_db
+from ..models import VillageModifier
+
+router = APIRouter(prefix="/api/village_modifiers", tags=["village_modifiers"])
+
+
+class ModifierPayload(BaseModel):
+    village_id: int
+    resource_bonus: dict | None = None
+    troop_bonus: dict | None = None
+    construction_speed_bonus: int | None = None
+    defense_bonus: int | None = None
+    trade_bonus: int | None = None
+    source: str
+    stacking_rules: dict | None = None
+    expires_at: datetime | None = None
+    applied_by: str | None = None
+
+
+@router.get("/{village_id}")
+def list_modifiers(village_id: int, db: Session = Depends(get_db)):
+    rows = (
+        db.query(VillageModifier)
+        .filter(VillageModifier.village_id == village_id)
+        .filter(
+            (VillageModifier.expires_at.is_(None))
+            | (VillageModifier.expires_at > func.now())
+        )
+        .all()
+    )
+    return {
+        "modifiers": [
+            {
+                "modifier_id": r.modifier_id,
+                "village_id": r.village_id,
+                "resource_bonus": r.resource_bonus,
+                "troop_bonus": r.troop_bonus,
+                "construction_speed_bonus": r.construction_speed_bonus,
+                "defense_bonus": r.defense_bonus,
+                "trade_bonus": r.trade_bonus,
+                "source": r.source,
+                "stacking_rules": r.stacking_rules,
+                "expires_at": r.expires_at,
+                "applied_by": r.applied_by,
+                "created_at": r.created_at,
+                "last_updated": r.last_updated,
+            }
+            for r in rows
+        ]
+    }
+
+
+@router.post("/apply")
+def apply_modifier(payload: ModifierPayload, db: Session = Depends(get_db)):
+    existing = (
+        db.query(VillageModifier)
+        .filter(
+            VillageModifier.village_id == payload.village_id,
+            VillageModifier.source == payload.source,
+        )
+        .first()
+    )
+    if existing:
+        existing.resource_bonus = payload.resource_bonus or {}
+        existing.troop_bonus = payload.troop_bonus or {}
+        existing.construction_speed_bonus = payload.construction_speed_bonus or 0
+        existing.defense_bonus = payload.defense_bonus or 0
+        existing.trade_bonus = payload.trade_bonus or 0
+        existing.stacking_rules = payload.stacking_rules or {}
+        existing.expires_at = payload.expires_at
+        existing.applied_by = payload.applied_by
+        existing.last_updated = func.now()
+    else:
+        mod = VillageModifier(
+            village_id=payload.village_id,
+            resource_bonus=payload.resource_bonus or {},
+            troop_bonus=payload.troop_bonus or {},
+            construction_speed_bonus=payload.construction_speed_bonus or 0,
+            defense_bonus=payload.defense_bonus or 0,
+            trade_bonus=payload.trade_bonus or 0,
+            source=payload.source,
+            stacking_rules=payload.stacking_rules or {},
+            expires_at=payload.expires_at,
+            applied_by=payload.applied_by,
+        )
+        db.add(mod)
+    db.commit()
+    return {"message": "modifier applied"}
+
+
+@router.post("/cleanup_expired")
+def cleanup_expired(db: Session = Depends(get_db)):
+    deleted = (
+        db.query(VillageModifier)
+        .filter(
+            VillageModifier.expires_at.is_not(None),
+            VillageModifier.expires_at < func.now(),
+        )
+        .delete()
+    )
+    db.commit()
+    return {"deleted": deleted}

--- a/docs/village_modifiers.md
+++ b/docs/village_modifiers.md
@@ -1,0 +1,51 @@
+# public.village_modifiers — Codex Integration Guide
+
+The `village_modifiers` table stores temporary or permanent bonuses applied to a village. These modifiers adjust resource production, troop effectiveness, construction speed and more. Each row records the origin of the effect and when it expires.
+
+## Table Structure
+
+| Column | Description |
+| --- | --- |
+| `modifier_id` | Primary key |
+| `village_id` | FK to `kingdom_villages.village_id` |
+| `resource_bonus` | JSON of resource boosts |
+| `troop_bonus` | JSON of combat bonuses |
+| `construction_speed_bonus` | Flat percent boost to build speed |
+| `defense_bonus` | Defensive bonus when attacked |
+| `trade_bonus` | Trade related bonuses |
+| `source` | Origin of the modifier (system, event, building, etc.) |
+| `stacking_rules` | JSON defining stacking behaviour |
+| `expires_at` | When the effect ends (`null` = permanent) |
+| `applied_by` | UUID of the user who triggered it |
+| `created_at` | Timestamp when applied |
+| `last_updated` | Last time the record changed |
+
+## Usage
+
+### Listing active modifiers
+```sql
+SELECT *
+FROM public.village_modifiers
+WHERE village_id = ?
+  AND (expires_at IS NULL OR expires_at > NOW());
+```
+
+### Applying a modifier
+```sql
+INSERT INTO public.village_modifiers (
+  village_id, resource_bonus, troop_bonus,
+  source, applied_by, expires_at
+) VALUES (...)
+ON CONFLICT (village_id, source) DO UPDATE
+SET resource_bonus = EXCLUDED.resource_bonus,
+    troop_bonus = EXCLUDED.troop_bonus,
+    last_updated = NOW();
+```
+
+### Cleaning up expired rows
+```sql
+DELETE FROM public.village_modifiers
+WHERE expires_at < NOW();
+```
+
+Always check `expires_at` when loading modifiers and respect `stacking_rules` for combined effects.

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -871,3 +871,19 @@ CREATE TABLE public.kingdom_vip_status (
   founder boolean DEFAULT false
 );
 
+CREATE TABLE public.village_modifiers (
+  modifier_id serial PRIMARY KEY,
+  village_id integer REFERENCES public.kingdom_villages(village_id),
+  resource_bonus jsonb DEFAULT '{}',
+  troop_bonus jsonb DEFAULT '{}',
+  construction_speed_bonus integer DEFAULT 0,
+  defense_bonus integer DEFAULT 0,
+  trade_bonus integer DEFAULT 0,
+  source text,
+  stacking_rules jsonb DEFAULT '{}',
+  expires_at timestamp with time zone,
+  applied_by uuid REFERENCES public.users(user_id),
+  created_at timestamp with time zone DEFAULT now(),
+  last_updated timestamp with time zone DEFAULT now()
+);
+

--- a/tests/test_village_modifiers_router.py
+++ b/tests/test_village_modifiers_router.py
@@ -1,0 +1,56 @@
+import uuid
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.database import Base
+from backend.models import User, VillageModifier
+from backend.routers.village_modifiers import (
+    ModifierPayload,
+    list_modifiers,
+    apply_modifier,
+    cleanup_expired,
+)
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def create_user(db):
+    uid = uuid.uuid4()
+    user = User(user_id=uid, username="test", email="t@example.com")
+    db.add(user)
+    db.commit()
+    return str(uid)
+
+
+def test_modifier_flow():
+    Session = setup_db()
+    db = Session()
+    uid = create_user(db)
+
+    payload = ModifierPayload(
+        village_id=1,
+        resource_bonus={"wood": 10},
+        troop_bonus={"defense": 5},
+        source="quest",
+        applied_by=uid,
+        expires_at=datetime.utcnow() + timedelta(days=1),
+    )
+    apply_modifier(payload, db)
+
+    res = list_modifiers(1, db)
+    assert len(res["modifiers"]) == 1
+    assert res["modifiers"][0]["resource_bonus"]["wood"] == 10
+
+    # expire and cleanup
+    db.query(VillageModifier).update({VillageModifier.expires_at: datetime.utcnow() - timedelta(days=1)})
+    db.commit()
+    cleanup_expired(db)
+    res2 = list_modifiers(1, db)
+    assert len(res2["modifiers"]) == 0

--- a/village.html
+++ b/village.html
@@ -100,6 +100,14 @@ Author: Deathsgift66
           </div>
         </div>
 
+        <!-- Active Modifiers -->
+        <div class="ledger-section">
+          <h3>Active Modifiers</h3>
+          <div class="modifier-list" id="modifier-list">
+            <!-- JS will populate -->
+          </div>
+        </div>
+
         <!-- Military -->
         <div class="ledger-section">
           <h3>Military</h3>


### PR DESCRIPTION
## Summary
- document village modifiers table
- implement `VillageModifier` SQLAlchemy model
- expose `/api/village_modifiers` endpoints
- integrate modifiers into the village page
- update schema and docs
- include tests for new router

## Testing
- `python -m py_compile backend/routers/village_modifiers.py backend/models.py tests/test_village_modifiers_router.py`
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68476dd916ac8330aec0b2c8fb48241a