### PR TITLE
Add village production table

### DIFF
--- a/FINAL_SCHEMA_DOCUMENTATION.md
+++ b/FINAL_SCHEMA_DOCUMENTATION.md
@@ -276,6 +276,21 @@ Columns:
 - `created_at` — timestamp applied
 - `last_updated` — timestamp last changed
 =======
+## Table: `public.village_production`
+Tracks accumulated resources and production rates for each village.
+
+Columns:
+- `village_id` — FK to `kingdom_villages.village_id`
+- `resource_type` — resource being produced
+- `amount_produced` — uncollected amount
+- `production_rate` — units produced per hour
+- `active_modifiers` — jsonb of bonuses in effect
+- `last_collected_at` — when the player last claimed resources
+- `collection_method` — `automatic`, `manual`, or `caravan`
+- `created_at` — row initialization time
+- `last_updated` — last sync time
+- `updated_by` — user or system that modified the row
+=======
 ## Table: `public.training_catalog`
 Defines base training times and costs for every troop type.
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -464,6 +464,23 @@ class VillageModifier(Base):
     last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
 
+class VillageProduction(Base):
+    """Real-time resource production tracking for each village."""
+
+    __tablename__ = 'village_production'
+
+    village_id = Column(Integer, ForeignKey('kingdom_villages.village_id'), primary_key=True)
+    resource_type = Column(String, primary_key=True)
+    amount_produced = Column(Numeric, default=0)
+    production_rate = Column(Numeric, default=0)
+    active_modifiers = Column(JSONB, default={})
+    last_collected_at = Column(DateTime(timezone=True))
+    collection_method = Column(String)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    updated_by = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+
+
 class SpyMission(Base):
     """Active and completed spy missions."""
 

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -1026,3 +1026,18 @@ CREATE POLICY access_own_kingdom_history ON kingdom_history_log
       WHERE k.kingdom_id = kingdom_history_log.kingdom_id
     )
   );
+
+-- Village Production Tracking ----------------------------------------------
+CREATE TABLE village_production (
+    village_id INTEGER REFERENCES kingdom_villages(village_id),
+    resource_type TEXT,
+    amount_produced NUMERIC DEFAULT 0,
+    production_rate NUMERIC DEFAULT 0,
+    active_modifiers JSONB DEFAULT '{}'::jsonb,
+    last_collected_at TIMESTAMP WITH TIME ZONE,
+    collection_method TEXT CHECK (collection_method IN ('automatic','manual','caravan')),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_by UUID REFERENCES users(user_id),
+    PRIMARY KEY (village_id, resource_type)
+);

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -887,3 +887,17 @@ CREATE TABLE public.village_modifiers (
   last_updated timestamp with time zone DEFAULT now()
 );
 
+CREATE TABLE public.village_production (
+  village_id integer NOT NULL REFERENCES public.kingdom_villages(village_id),
+  resource_type text NOT NULL,
+  amount_produced numeric DEFAULT 0,
+  production_rate numeric DEFAULT 0,
+  active_modifiers jsonb DEFAULT '{}',
+  last_collected_at timestamp with time zone,
+  collection_method text CHECK (collection_method IN ('automatic','manual','caravan')),
+  created_at timestamp with time zone DEFAULT now(),
+  last_updated timestamp with time zone DEFAULT now(),
+  updated_by uuid REFERENCES public.users(user_id),
+  CONSTRAINT village_production_pkey PRIMARY KEY (village_id, resource_type)
+);
+


### PR DESCRIPTION
## Summary
- track per-village resource production in backend models
- define `village_production` table in SQL schemas
- document `village_production` table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847703246088330a20ed2fc6a12a04a