### PR TITLE
Document tactical war preplans

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ the records created during onboarding.
 ✅ Progression stages documented in [docs/kingdom_progression_stages.md](docs/kingdom_progression_stages.md)
 ✅ Progression gating documented in [docs/page_access_gating.md](docs/page_access_gating.md)
 ✅ Alliance war pre-plan storage documented in [docs/alliance_war_preplans.md](docs/alliance_war_preplans.md)
+✅ Tactical war pre-plan storage documented in [docs/war_preplans.md](docs/war_preplans.md)
 ✅ Alliance war participant list documented in [docs/alliance_war_participants.md](docs/alliance_war_participants.md)
 ✅ Alliance war master record documented in [docs/alliance_wars.md](docs/alliance_wars.md)
 ✅ Kingdom resources usage documented in [docs/kingdom_resources.md](docs/kingdom_resources.md)

--- a/backend/models.py
+++ b/backend/models.py
@@ -316,6 +316,23 @@ class AllianceWarPreplan(Base):
     last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
 
+class WarPreplan(Base):
+    """Pre‑battle plans for tactical wars."""
+
+    __tablename__ = 'war_preplans'
+
+    preplan_id = Column(Integer, primary_key=True)
+    war_id = Column(Integer, ForeignKey('wars_tactical.war_id'))
+    kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'))
+    preplan_jsonb = Column(JSONB)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    submitted_by = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+    is_finalized = Column(Boolean, default=False)
+    version = Column(Integer, default=1)
+    status = Column(String, default='draft')
+
+
 class AllianceWarScore(Base):
     __tablename__ = 'alliance_war_scores'
     alliance_war_id = Column(

--- a/docs/war_preplans.md
+++ b/docs/war_preplans.md
@@ -1,0 +1,77 @@
+# public.war_preplans — Codex Integration Guide
+
+This table stores each kingdom's strategic plan for a tactical war. Records are created when a kingdom joins a war and are finalized before combat begins. The battle engine loads only the finalized plans.
+
+## Integration Overview
+
+| Phase | How it's used |
+| --- | --- |
+| Pre‑War | Insert an empty row for every participating kingdom |
+| Planning | Players update `preplan_jsonb` many times as a draft |
+| Lock‑In | When finalized set `is_finalized = true` and update `status` |
+| Battle Start | Engine selects rows where `is_finalized = true` |
+| Replay | Preplans are displayed as the starting state |
+
+## How Codex should use this table
+
+1. **Insert an Initial Preplan**
+   ```sql
+   INSERT INTO public.war_preplans (war_id, kingdom_id, submitted_by, preplan_jsonb)
+   VALUES (?, ?, ?, '{}');
+   ```
+2. **Save Draft**
+   ```sql
+   UPDATE public.war_preplans
+   SET preplan_jsonb = ?, last_updated = now(), version = version + 1
+   WHERE war_id = ? AND kingdom_id = ?;
+   ```
+3. **Finalize Submission**
+   ```sql
+   UPDATE public.war_preplans
+   SET is_finalized = true, status = 'submitted', last_updated = now()
+   WHERE war_id = ? AND kingdom_id = ?;
+   ```
+4. **Load for Battle Engine**
+   ```sql
+   SELECT * FROM public.war_preplans
+   WHERE war_id = ? AND is_finalized = true;
+   ```
+
+## Column-by-Column Explanation
+
+| Column | Description |
+| --- | --- |
+| `preplan_id` | Primary key, unique per preplan |
+| `war_id` | FK to `wars_tactical` — identifies the war |
+| `kingdom_id` | FK to `kingdoms` — who submitted the plan |
+| `preplan_jsonb` | JSON payload of unit orders, formations and fallback points |
+| `created_at` | When the plan was first created |
+| `last_updated` | Last time this plan was modified |
+| `submitted_by` | FK to `users.user_id` — who submitted the plan |
+| `is_finalized` | Marks plan as locked and ready for execution |
+| `version` | Integer version to track changes |
+| `status` | `'draft'`, `'submitted'`, `'approved'` |
+
+## Recommended JSON Format for `preplan_jsonb`
+```json
+{
+  "formation": "phalanx",
+  "fallback_point": { "x": 5, "y": 12 },
+  "orders": [
+    { "unit": "infantry", "stance": "aggressive", "target": "tile:10x12" },
+    { "unit": "archers", "stance": "defensive", "target": "bridge" }
+  ],
+  "bridge_targets": [12, 15],
+  "priority_zones": [
+    { "zone": [[10,11],[10,12]], "importance": "high" }
+  ]
+}
+```
+
+## Best Practices
+
+- Enforce one row per kingdom per war
+- Use `is_finalized` to lock plans before battle
+- Increment `version` on each save for audit history
+- Always record `submitted_by` and timestamps for accountability
+- Index `war_id` and `kingdom_id` for performance


### PR DESCRIPTION
## Summary
- document `public.war_preplans` integration and usage
- register `WarPreplan` ORM model
- reference the new documentation in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684772bc15808330bd17351421875c6a