### PR TITLE
Add wars table integration

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -316,6 +316,36 @@ class AllianceWarPreplan(Base):
     last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
 
+class War(Base):
+    """Metadata for kingdom level wars."""
+
+    __tablename__ = 'wars'
+
+    war_id = Column(Integer, primary_key=True)
+    attacker_id = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+    defender_id = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+    attacker_name = Column(String)
+    defender_name = Column(String)
+    war_reason = Column(Text)
+    status = Column(String)
+    start_date = Column(DateTime(timezone=True))
+    end_date = Column(DateTime(timezone=True))
+    attacker_score = Column(Integer, default=0)
+    defender_score = Column(Integer, default=0)
+    attacker_kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'))
+    defender_kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'))
+    war_type = Column(String)
+    is_retaliation = Column(Boolean, default=False)
+    treaty_triggered = Column(Boolean, default=False)
+    victory_condition = Column(String)
+    outcome = Column(String)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    last_updated = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+    submitted_by = Column(UUID(as_uuid=True), ForeignKey('users.user_id'))
+
+
 class WarPreplan(Base):
     """Pre‑battle plans for tactical wars."""
 

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -600,7 +600,17 @@ CREATE TABLE wars (
     start_date      TIMESTAMP WITH TIME ZONE,
     end_date        TIMESTAMP WITH TIME ZONE,
     attacker_score  INTEGER DEFAULT 0,
-    defender_score  INTEGER DEFAULT 0
+    defender_score  INTEGER DEFAULT 0,
+    attacker_kingdom_id INTEGER REFERENCES kingdoms(kingdom_id),
+    defender_kingdom_id INTEGER REFERENCES kingdoms(kingdom_id),
+    war_type        TEXT,
+    is_retaliation  BOOLEAN DEFAULT FALSE,
+    treaty_triggered BOOLEAN DEFAULT FALSE,
+    victory_condition TEXT,
+    outcome         TEXT,
+    created_at      TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_updated    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    submitted_by    UUID REFERENCES users(user_id)
 );
 
 -- NOTIFICATIONS -------------------------------------------------------------

--- a/docs/wars.md
+++ b/docs/wars.md
@@ -1,0 +1,42 @@
+# public.wars — Codex Integration Guide
+
+This table tracks every war declared between players or alliances. Records are created whenever a war is declared and remain for auditing even after the conflict ends.
+
+## Table Structure
+
+| Column | Meaning |
+| --- | --- |
+| `war_id` | Unique war ID |
+| `attacker_id` | UUID of the user who started the war |
+| `defender_id` | UUID of the user being attacked |
+| `attacker_name` | Snapshot of attacker name at declaration |
+| `defender_name` | Snapshot of defender name at declaration |
+| `war_reason` | Optional text justification |
+| `status` | `pending`, `active`, `ended`, `cancelled` |
+| `start_date` | When fighting began |
+| `end_date` | When the war ended |
+| `attacker_score` | Points earned by the attacker |
+| `defender_score` | Points earned by the defender |
+| `attacker_kingdom_id` | Kingdom initiating the war |
+| `defender_kingdom_id` | Kingdom being attacked |
+| `war_type` | `duel`, `alliance_war`, `event_war` |
+| `is_retaliation` | `true` if the war was a response |
+| `treaty_triggered` | Started automatically from a treaty |
+| `victory_condition` | `score`, `timed`, `objective`, `mutual_peace` |
+| `outcome` | `attacker_win`, `defender_win`, `draw`, `cancelled` |
+| `created_at` | Row creation timestamp |
+| `last_updated` | Auto updated timestamp |
+| `submitted_by` | User who declared the war |
+
+## Usage Patterns
+1. **Declaration** – insert a row with `status = 'pending'`.
+2. **Activation** – set `status = 'active'` and `start_date = now()` when combat begins.
+3. **Completion** – update `status` to `ended` and store scores/outcome.
+
+## Indexes
+```
+CREATE INDEX IF NOT EXISTS idx_wars_attacker ON public.wars (attacker_id);
+CREATE INDEX IF NOT EXISTS idx_wars_defender ON public.wars (defender_id);
+CREATE INDEX IF NOT EXISTS idx_wars_status ON public.wars (status);
+CREATE INDEX IF NOT EXISTS idx_wars_type ON public.wars (war_type);
+```

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -810,9 +810,22 @@ CREATE TABLE public.wars (
   end_date timestamp with time zone,
   attacker_score integer DEFAULT 0,
   defender_score integer DEFAULT 0,
+  attacker_kingdom_id integer,
+  defender_kingdom_id integer,
+  war_type text,
+  is_retaliation boolean DEFAULT false,
+  treaty_triggered boolean DEFAULT false,
+  victory_condition text,
+  outcome text,
+  created_at timestamp with time zone DEFAULT now(),
+  last_updated timestamp with time zone DEFAULT now(),
+  submitted_by uuid,
   CONSTRAINT wars_pkey PRIMARY KEY (war_id),
   CONSTRAINT wars_attacker_id_fkey FOREIGN KEY (attacker_id) REFERENCES public.users(user_id),
-  CONSTRAINT wars_defender_id_fkey FOREIGN KEY (defender_id) REFERENCES public.users(user_id)
+  CONSTRAINT wars_defender_id_fkey FOREIGN KEY (defender_id) REFERENCES public.users(user_id),
+  CONSTRAINT wars_attacker_kingdom_id_fkey FOREIGN KEY (attacker_kingdom_id) REFERENCES public.kingdoms(kingdom_id),
+  CONSTRAINT wars_defender_kingdom_id_fkey FOREIGN KEY (defender_kingdom_id) REFERENCES public.kingdoms(kingdom_id),
+  CONSTRAINT wars_submitted_by_fkey FOREIGN KEY (submitted_by) REFERENCES public.users(user_id)
 );
 CREATE TABLE public.wars_tactical (
   war_id integer NOT NULL DEFAULT nextval('wars_tactical_war_id_seq'::regclass),

--- a/migrations/2025_06_25_expand_wars_table.sql
+++ b/migrations/2025_06_25_expand_wars_table.sql
@@ -1,0 +1,17 @@
+-- Migration: expand wars table with additional metadata columns
+ALTER TABLE public.wars
+  ADD COLUMN attacker_kingdom_id INTEGER REFERENCES public.kingdoms(kingdom_id),
+  ADD COLUMN defender_kingdom_id INTEGER REFERENCES public.kingdoms(kingdom_id),
+  ADD COLUMN war_type TEXT,
+  ADD COLUMN is_retaliation BOOLEAN DEFAULT FALSE,
+  ADD COLUMN treaty_triggered BOOLEAN DEFAULT FALSE,
+  ADD COLUMN victory_condition TEXT,
+  ADD COLUMN outcome TEXT,
+  ADD COLUMN created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  ADD COLUMN last_updated TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  ADD COLUMN submitted_by UUID REFERENCES public.users(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_wars_attacker ON public.wars (attacker_id);
+CREATE INDEX IF NOT EXISTS idx_wars_defender ON public.wars (defender_id);
+CREATE INDEX IF NOT EXISTS idx_wars_status ON public.wars (status);
+CREATE INDEX IF NOT EXISTS idx_wars_type ON public.wars (war_type);

--- a/tests/test_war_model.py
+++ b/tests/test_war_model.py
@@ -1,0 +1,20 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.database import Base
+from backend.models import War
+
+
+def test_war_model_basic():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    db = Session()
+
+    war = War(attacker_name="A", defender_name="D", status="pending", war_type="duel", victory_condition="score")
+    db.add(war)
+    db.commit()
+
+    saved = db.query(War).first()
+    assert saved.war_id == 1
+    assert saved.status == "pending"


### PR DESCRIPTION
## Summary
- add docs for `public.wars`
- create SQLAlchemy `War` model
- expand wars table in db schemas
- add migration for new columns
- test basic War model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847785587d4833086606084b162c749