### PR TITLE
Implement basic kingdom setup onboarding

### DIFF
--- a/Javascript/components/authGuard.js
+++ b/Javascript/components/authGuard.js
@@ -27,12 +27,12 @@ const requirePermission = window.requirePermission || null; // e.g. "manage_proj
 
     const { data: userData, error: userError } = await supabase
       .from("users")
-      .select("is_admin")
+      .select("is_admin, setup_complete")
       .eq("user_id", user.id)
       .single();
 
-    if (!userData || userError) {
-      // New account without profile -> push to onboarding
+    if (!userData || userError || userData.setup_complete !== true) {
+      // New account or not finished onboarding -> push to onboarding
       return (window.location.href = "play.html");
     }
 

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -8,6 +8,7 @@ from ..data import military_state, recruitable_units
 from ..database import get_db
 from ..services.research_service import start_research as db_start_research
 from ..services.kingdom_quest_service import start_quest as db_start_quest
+from ..services.kingdom_setup_service import create_kingdom_transaction
 from .progression_router import get_user_id
 
 router = APIRouter(prefix="/api/kingdom", tags=["kingdom"])
@@ -32,6 +33,37 @@ class TemplePayload(BaseModel):
 class TrainPayload(BaseModel):
     unit_id: int
     quantity: int
+
+
+class KingdomCreatePayload(BaseModel):
+    kingdom_name: str
+    ruler_title: str | None = None
+    village_name: str
+    region: str
+    banner_image: str | None = None
+    motto: str | None = None
+
+
+@router.post("/create")
+def create_kingdom(
+    payload: KingdomCreatePayload,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    try:
+        kid = create_kingdom_transaction(
+            db,
+            user_id,
+            payload.kingdom_name,
+            payload.region,
+            payload.village_name,
+            payload.ruler_title,
+            payload.banner_image,
+            payload.motto,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"kingdom_id": kid}
 
 
 def get_state():

--- a/play.html
+++ b/play.html
@@ -61,11 +61,14 @@ Author: Deathsgift66
       <div id="setup-step" class="onboard-step">
         <h3>Kingdom Setup</h3>
         <input type="text" id="kingdom-name-input" placeholder="Kingdom Name" readonly />
+        <input type="text" id="ruler-title-input" placeholder="Ruler Title (optional)" />
         <select id="region-select">
           <option value="">Select Region</option>
         </select>
         <div id="region-info" class="region-info"></div>
-        <input type="text" id="village-name-input" placeholder="First Village Name" />
+        <input type="text" id="village-name-input" placeholder="Starting Village Name" />
+        <input type="text" id="banner-image-input" placeholder="Banner Image URL (optional)" />
+        <textarea id="motto-input" placeholder="Motto or Flavor Text"></textarea>
         <button id="create-kingdom-btn">Create Kingdom</button>
       </div>
     </section>

--- a/services/kingdom_setup_service.py
+++ b/services/kingdom_setup_service.py
@@ -1,0 +1,99 @@
+from typing import Optional
+
+try:
+    from sqlalchemy import text
+    from sqlalchemy.orm import Session
+except Exception:  # pragma: no cover
+    text = lambda q: q  # type: ignore
+    Session = object  # type: ignore
+
+START_RESOURCES = {
+    "wood": 500,
+    "stone": 500,
+    "food": 300,
+    "gold": 200,
+}
+
+START_BUILDINGS = [
+    "Town Center",
+    "Granary",
+    "Barracks",
+    "Farm",
+    "Warehouse",
+]
+
+
+def create_kingdom_transaction(
+    db: Session,
+    user_id: str,
+    kingdom_name: str,
+    region: str,
+    village_name: str,
+    ruler_title: Optional[str] = None,
+    banner_image: Optional[str] = None,
+    motto: Optional[str] = None,
+) -> int:
+    """Create a new kingdom and related records. Returns the kingdom_id."""
+    try:
+        row = db.execute(
+            text(
+                """
+                INSERT INTO kingdoms (user_id, kingdom_name, region)
+                VALUES (:uid, :name, :region)
+                RETURNING kingdom_id
+                """
+            ),
+            {"uid": user_id, "name": kingdom_name, "region": region},
+        ).fetchone()
+        if not row:
+            raise ValueError("failed")
+        kingdom_id = int(row[0])
+
+        vil_row = db.execute(
+            text(
+                """
+                INSERT INTO kingdom_villages (kingdom_id, village_name, is_capital)
+                VALUES (:kid, :vname, TRUE)
+                RETURNING village_id
+                """
+            ),
+            {"kid": kingdom_id, "vname": village_name},
+        ).fetchone()
+        village_id = int(vil_row[0]) if vil_row else None
+
+        db.execute(
+            text(
+                """
+                INSERT INTO kingdom_resources (kingdom_id, wood, stone, food, gold)
+                VALUES (:kid, :wood, :stone, :food, :gold)
+                """
+            ),
+            {"kid": kingdom_id, **START_RESOURCES},
+        )
+
+        db.execute(
+            text(
+                "INSERT INTO kingdom_troop_slots (kingdom_id, base_slots) VALUES (:kid, 20)"
+            ),
+            {"kid": kingdom_id},
+        )
+
+        db.execute(
+            text(
+                """
+                UPDATE users
+                   SET setup_complete = TRUE,
+                       kingdom_name = :name,
+                       region = :region,
+                       kingdom_id = :kid
+                 WHERE user_id = :uid
+                """
+            ),
+            {"name": kingdom_name, "region": region, "kid": kingdom_id, "uid": user_id},
+        )
+
+        db.commit()
+        return kingdom_id
+    except Exception:
+        db.rollback()
+        raise


### PR DESCRIPTION
## Summary
- add onboarding fields on play.html for new kingdom creation
- post new setup payload from play.js
- enforce onboarding completion via authGuard
- provide backend endpoint `/api/kingdom/create`
- implement service helper to create kingdom records

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_684804d57ae08330a12a9a75bc211ade