### PR TITLE
Add emblem image input for kingdom setup

### DIFF
--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -62,6 +62,7 @@ function bindEvents(profileExists) {
     const regionEl = document.getElementById('region-select');
     const villageEl = document.getElementById('village-name-input');
     const bannerEl = document.getElementById('banner-image-input');
+    const emblemEl = document.getElementById('emblem-image-input');
     const mottoEl = document.getElementById('motto-input');
 
     const kingdomName = kNameEl.value.trim();
@@ -69,6 +70,7 @@ function bindEvents(profileExists) {
     const region = regionEl.value;
     const villageName = villageEl.value.trim();
     const bannerImage = bannerEl.value.trim();
+    const emblemImage = emblemEl.value.trim();
     const motto = mottoEl.value.trim();
 
     if (kingdomName.length < 3) {
@@ -99,6 +101,7 @@ function bindEvents(profileExists) {
           village_name: villageName,
           region,
           banner_image: bannerImage || null,
+          emblem_image: emblemImage || null,
           motto: motto || null
         })
       });

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -41,6 +41,7 @@ class KingdomCreatePayload(BaseModel):
     village_name: str
     region: str
     banner_image: str | None = None
+    emblem_image: str | None = None
     motto: str | None = None
 
 
@@ -59,6 +60,7 @@ def create_kingdom(
             payload.village_name,
             payload.ruler_title,
             payload.banner_image,
+            payload.emblem_image,
             payload.motto,
         )
     except Exception as e:

--- a/play.html
+++ b/play.html
@@ -68,6 +68,7 @@ Author: Deathsgift66
         <div id="region-info" class="region-info"></div>
         <input type="text" id="village-name-input" placeholder="Starting Village Name" />
         <input type="text" id="banner-image-input" placeholder="Banner Image URL (optional)" />
+        <input type="text" id="emblem-image-input" placeholder="Emblem Image URL (optional)" />
         <textarea id="motto-input" placeholder="Motto or Flavor Text"></textarea>
         <button id="create-kingdom-btn">Create Kingdom</button>
       </div>

--- a/services/kingdom_setup_service.py
+++ b/services/kingdom_setup_service.py
@@ -31,6 +31,7 @@ def create_kingdom_transaction(
     village_name: str,
     ruler_title: Optional[str] = None,
     banner_image: Optional[str] = None,
+    emblem_image: Optional[str] = None,
     motto: Optional[str] = None,
 ) -> int:
     """Create a new kingdom and related records. Returns the kingdom_id."""


### PR DESCRIPTION
## Summary
- allow players to specify an emblem image when setting up their kingdom
- send the new field from `play.js`
- accept the emblem field in the API router and service
- update the setup page UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684826616f048330a1f72c8bfcda10bc