### PR TITLE
Implement account settings page with profile API

### DIFF
--- a/CSS/account_settings.css
+++ b/CSS/account_settings.css
@@ -51,6 +51,13 @@ body {
   position: relative;
   overflow: hidden;
 }
+.banner-img {
+  width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+  border-bottom: 3px solid var(--leather);
+  margin-bottom: 1rem;
+}
 .account-settings-container::before {
   content: '';
   position: absolute;

--- a/account_settings.html
+++ b/account_settings.html
@@ -56,17 +56,22 @@ Author: Deathsgift66
   <main class="main-container">
     <section class="main-content">
       <div class="account-settings-container">
+        <img id="banner-preview" src="/assets/profile_banners/default.jpg" alt="Profile banner" class="banner-img" />
         <h2>Update Your Account</h2>
         <form id="account-form" aria-label="Account Settings Form">
 
           <!-- Profile Info -->
           <fieldset>
             <legend>Profile</legend>
+            <img id="avatar-preview" src="/avatars/default_avatar.png" alt="Avatar preview" width="80" height="80" />
+            <label for="avatar_url">Avatar URL</label>
+            <input type="text" id="avatar_url" name="avatar_url" />
+
             <label for="display_name">Display Name</label>
             <input type="text" id="display_name" name="display_name" required />
 
-            <label for="kingdom_name">Kingdom Name</label>
-            <input type="text" id="kingdom_name" name="kingdom_name" required />
+            <label for="motto">Motto</label>
+            <input type="text" id="motto" name="motto" />
 
             <label for="profile_bio">Bio</label>
             <textarea id="profile_bio" name="profile_bio" rows="3"></textarea>
@@ -85,14 +90,15 @@ Author: Deathsgift66
           <!-- Appearance -->
           <fieldset>
             <legend>Customization</legend>
-            <label for="kingdom_banner">Banner URL</label>
-            <input type="text" id="kingdom_banner" name="kingdom_banner" />
+            <label for="profile_banner">Profile Banner URL</label>
+            <input type="text" id="profile_banner" name="profile_banner" />
 
-            <label for="avatar_icon">Avatar Icon URL</label>
-            <input type="text" id="avatar_icon" name="avatar_icon" />
-
-            <label for="nameplate_color">Nameplate Color</label>
-            <input type="color" id="nameplate_color" name="nameplate_color" />
+            <label for="theme_preference">Theme</label>
+            <select id="theme_preference" name="theme_preference">
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+              <option value="parchment">Parchment</option>
+            </select>
           </fieldset>
 
           <!-- Preferences -->
@@ -110,11 +116,22 @@ Author: Deathsgift66
 
           <!-- VIP Status -->
           <fieldset>
-            <legend>VIP Status</legend>
-            <p id="vip-status">Checking status...</p>
-          </fieldset>
+          <legend>VIP Status</legend>
+          <p id="vip-status">Checking status...</p>
+        </fieldset>
 
-          <!-- Submit -->
+        <!-- Sessions -->
+        <fieldset>
+          <legend>Active Sessions</legend>
+          <table id="sessions-table">
+            <thead>
+              <tr><th>Device</th><th>Last Seen</th><th>Action</th></tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </fieldset>
+
+        <!-- Submit -->
           <button type="submit" class="btn">Save Changes</button>
         </form>
       </div>

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,7 @@ from .routers import (
     titles_router,
     treaties_router,
     alliance_treaties_router,
+    account_settings,
     spies_router,
     trade_logs,
     training_history,
@@ -72,12 +73,13 @@ app.include_router(diplomacy.router)
 app.include_router(leaderboard.router)
 app.include_router(buildings.router)
 app.include_router(progression_router.router)
-app.include_router(villages_router.router)
-app.include_router(vip_status_router.router)
-app.include_router(titles_router.router)
-app.include_router(treaties_router.router)
-app.include_router(alliance_treaties_router.router)
-app.include_router(spies_router.router)
+    app.include_router(villages_router.router)
+    app.include_router(vip_status_router.router)
+    app.include_router(titles_router.router)
+    app.include_router(treaties_router.router)
+    app.include_router(alliance_treaties_router.router)
+    app.include_router(account_settings.router)
+    app.include_router(spies_router.router)
 app.include_router(trade_logs.router)
 app.include_router(training_history.router)
 app.include_router(village_modifiers.router)

--- a/backend/routers/account_settings.py
+++ b/backend/routers/account_settings.py
@@ -1,0 +1,175 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from .progression_router import get_user_id
+from services.audit_service import log_action
+
+router = APIRouter(prefix="/api/account", tags=["account"])
+
+
+class UpdatePayload(BaseModel):
+    display_name: str | None = None
+    motto: str | None = None
+    bio: str | None = None
+    profile_picture_url: str | None = None
+    theme_preference: str | None = None
+    profile_banner: str | None = None
+
+
+class SessionPayload(BaseModel):
+    session_id: str
+
+
+@router.get("/profile")
+def load_profile(
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    row = db.execute(
+        text(
+            """
+            SELECT u.username, u.display_name, u.profile_picture_url, u.email, u.region,
+                   k.kingdom_name,
+                   a.name AS alliance_name,
+                   c.motto, c.bio, c.theme_preference, c.profile_banner,
+                   v.vip_level, v.founder, v.expires_at
+            FROM users u
+            LEFT JOIN kingdoms k ON k.user_id = u.user_id
+            LEFT JOIN alliances a ON a.alliance_id = u.alliance_id
+            LEFT JOIN user_customization c ON c.user_id = u.user_id
+            LEFT JOIN kingdom_vip_status v ON v.user_id = u.user_id
+            WHERE u.user_id = :uid
+            """
+        ),
+        {"uid": user_id},
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="User not found")
+    keys = [
+        "username",
+        "display_name",
+        "profile_picture_url",
+        "email",
+        "region",
+        "kingdom_name",
+        "alliance_name",
+        "motto",
+        "bio",
+        "theme_preference",
+        "profile_banner",
+        "vip_level",
+        "founder",
+        "expires_at",
+    ]
+    profile = {k: row[i] for i, k in enumerate(keys)}
+    session_rows = db.execute(
+        text(
+            "SELECT session_id, device, last_seen FROM user_active_sessions WHERE user_id = :uid AND session_status = 'active'"
+        ),
+        {"uid": user_id},
+    ).fetchall()
+    sessions = [
+        {"session_id": r[0], "device": r[1], "last_seen": r[2]} for r in session_rows
+    ]
+    profile["sessions"] = sessions
+    return profile
+
+
+@router.post("/update")
+def update_profile(
+    payload: UpdatePayload,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    # fetch current values
+    current = db.execute(
+        text(
+            "SELECT display_name, profile_picture_url FROM users WHERE user_id = :uid"
+        ),
+        {"uid": user_id},
+    ).fetchone()
+    customization = db.execute(
+        text(
+            "SELECT motto, bio, theme_preference, profile_banner FROM user_customization WHERE user_id = :uid"
+        ),
+        {"uid": user_id},
+    ).fetchone()
+
+    db.execute(
+        text(
+            "UPDATE users SET display_name = :dn, profile_picture_url = :pic WHERE user_id = :uid"
+        ),
+        {
+            "dn": payload.display_name,
+            "pic": payload.profile_picture_url,
+            "uid": user_id,
+        },
+    )
+    db.execute(
+        text(
+            """
+            INSERT INTO user_customization (user_id, motto, bio, theme_preference, profile_banner)
+            VALUES (:uid, :motto, :bio, :theme, :banner)
+            ON CONFLICT (user_id)
+            DO UPDATE SET motto = EXCLUDED.motto,
+                          bio = EXCLUDED.bio,
+                          theme_preference = EXCLUDED.theme_preference,
+                          profile_banner = EXCLUDED.profile_banner
+            """
+        ),
+        {
+            "uid": user_id,
+            "motto": payload.motto,
+            "bio": payload.bio,
+            "theme": payload.theme_preference,
+            "banner": payload.profile_banner,
+        },
+    )
+    db.commit()
+
+    diffs = {}
+    if current:
+        if payload.display_name != current[0]:
+            diffs["display_name"] = payload.display_name
+        if payload.profile_picture_url != current[1]:
+            diffs["profile_picture_url"] = payload.profile_picture_url
+    if customization:
+        if payload.motto != customization[0]:
+            diffs["motto"] = payload.motto
+        if payload.bio != customization[1]:
+            diffs["bio"] = payload.bio
+        if payload.theme_preference != customization[2]:
+            diffs["theme_preference"] = payload.theme_preference
+        if payload.profile_banner != customization[3]:
+            diffs["profile_banner"] = payload.profile_banner
+
+    log_action(db, user_id, "update_profile", str(diffs))
+    return {"message": "updated"}
+
+
+@router.post("/logout-session")
+def logout_session(
+    payload: SessionPayload,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    row = db.execute(
+        text(
+            "SELECT session_id FROM user_active_sessions WHERE session_id = :sid AND user_id = :uid"
+        ),
+        {"sid": payload.session_id, "uid": user_id},
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Session not found")
+    db.execute(
+        text(
+            "UPDATE user_active_sessions SET session_status = 'revoked' WHERE session_id = :sid"
+        ),
+        {"sid": payload.session_id},
+    )
+    db.commit()
+    log_action(db, user_id, "logout_session", payload.session_id)
+    return {"message": "session revoked"}


### PR DESCRIPTION
## Summary
- add backend account settings router for profile, update and session revoke
- include router in FastAPI main app
- overhaul account_settings.html for avatar/banner/theme and sessions
- update account_settings.js to load/save profile via API
- tweak CSS for banner preview

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68483f4297588330ad007a9ceda6c066