### PR TITLE
Add admin alerts feed with backend endpoint

### DIFF
--- a/CSS/admin_alerts.css
+++ b/CSS/admin_alerts.css
@@ -6,6 +6,13 @@ Author: Deathsgift66
 */
 @import url("./root_theme.css");
 
+:root {
+  --alert-red: var(--danger);
+  --alert-yellow: var(--warning);
+  --alert-blue: var(--info);
+  --alert-green: var(--success);
+}
+
 
 
 
@@ -117,3 +124,27 @@ tr:nth-child(even) {
   opacity: 0.9;
   box-shadow: 0 2px 6px var(--shadow);
 }
+
+/* Alert Feed */
+.alert-category {
+  margin-bottom: 1.5rem;
+}
+
+.alert-category h3 {
+  margin-bottom: 0.5rem;
+  color: var(--gold);
+  font-family: var(--font-header);
+}
+
+.alert-item {
+  background: var(--parchment-dark);
+  border: 1px solid var(--gold);
+  border-left: 6px solid var(--info);
+  padding: 0.5rem 1rem;
+  margin-bottom: 0.5rem;
+  box-shadow: 0 2px 6px var(--shadow-base);
+}
+
+.alert-item.severity-low { border-left-color: var(--alert-yellow); }
+.alert-item.severity-medium { border-left-color: var(--alert-blue); }
+.alert-item.severity-high { border-left-color: var(--alert-red); }

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -66,27 +66,32 @@ Author: Deathsgift66
 
       <!-- Filter Controls -->
       <section class="search-sort-controls" aria-label="Admin Alert Filters">
-        <input type="text" id="filter-username" placeholder="Search by player name..." aria-label="Filter by player name" />
-        <select id="filter-type" aria-label="Select alert type">
+        <input type="datetime-local" id="filter-start" class="filter-input" aria-label="Start time" />
+        <input type="datetime-local" id="filter-end" class="filter-input" aria-label="End time" />
+        <select id="filter-alert-type" class="filter-input" aria-label="Select alert type">
           <option value="">All Types</option>
-          <option value="multi_accounting">Multi-Accounting</option>
-          <option value="unusual_transaction">Unusual Transactions</option>
-          <option value="rapid_login_attempts">Rapid Login</option>
-          <option value="excessive_generation">Excessive Item Generation</option>
-          <option value="under_average_sale">Under-Average Sale</option>
-          <option value="unusual_login_location">Unusual Login Location</option>
-          <option value="unusual_chat_pattern">Unusual Chat Pattern</option>
-          <option value="rapid_progression">Rapid Progression</option>
-          <option value="high_player_reports">High Player Reports</option>
+          <option value="moderation">Moderation</option>
+          <option value="war">War</option>
+          <option value="economy">Economy</option>
+          <option value="diplomacy">Diplomacy</option>
+          <option value="quests">Quests</option>
+          <option value="abuse">Resource Abuse</option>
         </select>
-        <input type="date" id="filter-date" aria-label="Select date" />
+        <select id="filter-severity" class="filter-input" aria-label="Select severity">
+          <option value="">Any Severity</option>
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+        </select>
+        <input type="text" id="filter-kingdom" class="filter-input" placeholder="Kingdom ID" aria-label="Filter by Kingdom" />
+        <input type="text" id="filter-alliance" class="filter-input" placeholder="Alliance ID" aria-label="Filter by Alliance" />
         <button id="refresh-alerts">Refresh</button>
         <button id="clear-filters">Clear</button>
       </section>
 
       <!-- Alert Results -->
       <section class="kr-alerts-panel" aria-label="Alert Results Panel">
-        <div id="alerts-container" aria-live="polite">
+        <div id="alerts-feed" aria-live="polite">
           <!-- JS Populates alerts here -->
         </div>
       </section>


### PR DESCRIPTION
## Summary
- expand Admin Alerts page with new filter controls and alert feed section
- implement severity color styling for alert items
- add periodic JS fetch of `/api/admin/alerts` and utilities
- expose `/api/admin/alerts` aggregator endpoint on backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68483fd8d9b483309937fa465a8ac6f8