### PR TITLE
Implement admin dashboard endpoints

### DIFF
--- a/Javascript/admin_dashboard.js
+++ b/Javascript/admin_dashboard.js
@@ -76,12 +76,9 @@ async function loadAuditLogs() {
   container.innerHTML = '<p>Loading logs...</p>';
 
   try {
-    const { data: logs, error } = await supabase
-      .from('audit_log')
-      .select('*')
-      .order('created_at', { ascending: false });
-
-    if (error) throw new Error('Failed to fetch audit logs: ' + error.message);
+    const res = await fetch('/api/admin/audit/logs');
+    if (!res.ok) throw new Error('Failed to fetch audit logs');
+    const logs = await res.json();
 
     container.innerHTML = '';
     if (logs.length === 0) {
@@ -191,6 +188,37 @@ async function postAdminAction(endpoint, payload) {
   }
 }
 
+// Toggle a system flag using the admin API
+async function toggleFlag() {
+  const key = document.getElementById('flag-key').value;
+  const val = document.getElementById('flag-value').value === 'true';
+  try {
+    await postAdminAction('/api/admin/flags/toggle', { flag_key: key, value: val });
+    alert('Flag updated');
+  } catch (err) {
+    console.error('Flag update failed:', err);
+    alert('Failed to update flag');
+  }
+}
+
+// Update a kingdom field via the admin API
+async function updateKingdom() {
+  const kid = document.getElementById('kingdom-id').value;
+  const field = document.getElementById('kingdom-field').value;
+  const value = document.getElementById('kingdom-value').value;
+  try {
+    await postAdminAction('/api/admin/kingdoms/update', {
+      kingdom_id: Number(kid),
+      field,
+      value
+    });
+    alert('Kingdom updated');
+  } catch (err) {
+    console.error('Kingdom update failed:', err);
+    alert('Failed to update kingdom');
+  }
+}
+
 // 🧩 DOM Ready Hooks
 document.addEventListener('DOMContentLoaded', () => {
   loadDashboardStats();
@@ -200,4 +228,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('search-btn').addEventListener('click', loadPlayerList);
   document.getElementById('status-filter').addEventListener('change', loadPlayerList);
   document.getElementById('load-logs-btn').addEventListener('click', loadAuditLogs);
+  document.getElementById('toggle-flag-btn').addEventListener('click', toggleFlag);
+  document.getElementById('update-kingdom-btn').addEventListener('click', updateKingdom);
 });

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -103,6 +103,26 @@ Author: Deathsgift66
         <button class="action-btn" id="create-event">Create New Event</button>
       </section>
 
+      <!-- System Flags -->
+      <section class="flag-management" aria-label="System Flags">
+        <h3>System Flags</h3>
+        <input id="flag-key" type="text" placeholder="Flag key" aria-label="Flag key" />
+        <select id="flag-value" aria-label="Flag value">
+          <option value="true">True</option>
+          <option value="false">False</option>
+        </select>
+        <button id="toggle-flag-btn">Toggle</button>
+      </section>
+
+      <!-- Kingdom Tools -->
+      <section class="kingdom-management" aria-label="Kingdom Tools">
+        <h3>Kingdom Update</h3>
+        <input id="kingdom-id" type="number" placeholder="Kingdom ID" aria-label="Kingdom ID" />
+        <input id="kingdom-field" type="text" placeholder="Field" aria-label="Field" />
+        <input id="kingdom-value" type="text" placeholder="Value" aria-label="Value" />
+        <button id="update-kingdom-btn">Update</button>
+      </section>
+
       <!-- Audit Logs -->
       <section class="audit-logs" aria-label="Audit Logs Section">
         <h3>Audit Logs</h3>

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,7 @@ from .routers import (
     titles_router,
     treaties_router,
     alliance_treaties_router,
+    admin_dashboard,
     account_settings,
     spies_router,
     trade_logs,
@@ -52,6 +53,7 @@ load_game_settings()
 
 app.include_router(alliance_members.router)
 app.include_router(admin.router)
+app.include_router(admin_dashboard.router)
 app.include_router(alliance_projects.router)
 app.include_router(kingdom.router)
 app.include_router(conflicts.router)

--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -1,0 +1,126 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+from typing import Any, Optional
+
+from ..database import get_db
+from .progression_router import get_user_id
+from services.audit_service import log_action
+
+router = APIRouter(prefix="/api/admin", tags=["admin_dashboard"])
+
+
+def verify_admin(user_id: str, db: Session) -> None:
+    """Raise HTTP 403 if the user is not an admin."""
+    res = db.execute(
+        text("SELECT is_admin FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not res or not res[0]:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+
+@router.get("/dashboard")
+def dashboard_summary(
+    admin_user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return basic dashboard stats and latest logs."""
+    verify_admin(admin_user_id, db)
+    total_users = db.execute(text("SELECT COUNT(*) FROM users")).fetchone()[0]
+    flagged = db.execute(text("SELECT COUNT(*) FROM account_alerts")).fetchone()[0]
+    open_wars = db.execute(
+        text("SELECT COUNT(*) FROM alliance_wars WHERE status = 'active'")
+    ).fetchone()[0]
+    logs = db.execute(
+        text(
+            "SELECT log_id, user_id, action, details, created_at "
+            "FROM audit_log ORDER BY created_at DESC LIMIT 10"
+        )
+    ).fetchall()
+    return {
+        "total_users": total_users,
+        "flagged_users": flagged,
+        "open_wars": open_wars,
+        "recent_logs": [dict(r._mapping) for r in logs],
+    }
+
+
+@router.get("/audit/logs")
+def get_audit_logs(
+    page: int = 1,
+    per_page: int = 50,
+    search: str = "",
+    sort_by: str = "created_at",
+    sort_dir: str = "desc",
+    user_id: Optional[str] = Query(None),
+    admin_user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """Return paginated audit logs with optional search and sorting."""
+    verify_admin(admin_user_id, db)
+    base = "SELECT * FROM audit_log"
+    clauses = []
+    params: dict[str, Any] = {}
+    if search:
+        clauses.append("action ILIKE :search")
+        params["search"] = f"%{search}%"
+    if user_id:
+        clauses.append("user_id = :uid")
+        params["uid"] = user_id
+    if clauses:
+        base += " WHERE " + " AND ".join(clauses)
+    if sort_by not in {"created_at", "action", "user_id"}:
+        sort_by = "created_at"
+    direction = "DESC" if sort_dir.lower() == "desc" else "ASC"
+    base += f" ORDER BY {sort_by} {direction}"
+    base += " LIMIT :limit OFFSET :offset"
+    params["limit"] = per_page
+    params["offset"] = (page - 1) * per_page
+    rows = db.execute(text(base), params).fetchall()
+    return [dict(r._mapping) for r in rows]
+
+
+@router.post("/flags/toggle")
+def toggle_flag(
+    flag_key: str,
+    value: bool,
+    admin_user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """Toggle a system flag on or off."""
+    verify_admin(admin_user_id, db)
+    db.execute(
+        text("UPDATE system_flags SET is_active = :val WHERE flag_key = :key"),
+        {"val": value, "key": flag_key},
+    )
+    db.commit()
+    log_action(
+        db,
+        admin_user_id,
+        "Toggle System Flag",
+        f"Set {flag_key} to {value}",
+    )
+    return {"status": "updated"}
+
+
+@router.post("/kingdoms/update")
+def update_kingdom_field(
+    kingdom_id: int,
+    field: str,
+    value: Any,
+    admin_user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """Update an arbitrary kingdom field."""
+    verify_admin(admin_user_id, db)
+    query = text(f"UPDATE kingdoms SET {field} = :val WHERE kingdom_id = :kid")
+    db.execute(query, {"val": value, "kid": kingdom_id})
+    db.commit()
+    log_action(
+        db,
+        admin_user_id,
+        "Update Kingdom",
+        f"{field} -> {value} for {kingdom_id}",
+    )
+    return {"status": "updated"}

--- a/tests/test_admin_dashboard_router.py
+++ b/tests/test_admin_dashboard_router.py
@@ -1,0 +1,54 @@
+from backend.routers import admin_dashboard
+
+
+class DummyResult:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+
+    def fetchall(self):
+        return self._rows
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+
+class DummyDB:
+    def __init__(self):
+        self.queries = []
+        self.rows = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        self.queries.append((q, params))
+        lower = q.strip().lower()
+        if lower.startswith("select is_admin"):
+            return DummyResult([(True,)])
+        if "from audit_log" in lower:
+            return DummyResult(self.rows)
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_get_audit_logs_returns_rows():
+    db = DummyDB()
+    db.rows = [(1, "u1", "login", "ok", "2025-01-01")]
+    logs = admin_dashboard.get_audit_logs(db=db, admin_user_id="a1")
+    assert len(logs) == 1
+    assert logs[0]["action"] == "login"
+
+
+def test_toggle_flag_updates_and_logs():
+    db = DummyDB()
+    admin_dashboard.toggle_flag("war_enabled", True, admin_user_id="a1", db=db)
+    executed = " ".join(db.queries[1][0].split())
+    assert "update system_flags" in executed.lower()
+    assert any("insert into audit_log" in q[0].lower() for q in db.queries)
+
+
+def test_update_kingdom_field_runs_update():
+    db = DummyDB()
+    admin_dashboard.update_kingdom_field(1, "gold", 5, admin_user_id="a1", db=db)
+    assert any("update kingdoms" in q[0].lower() for q in db.queries)
+    assert any("insert into audit_log" in q[0].lower() for q in db.queries)


### PR DESCRIPTION
## Summary
- build admin dashboard backend router for logs, flags, and kingdom updates
- expose router via main FastAPI app
- update admin dashboard UI with system flag and kingdom update forms
- add JS helpers for new admin endpoints
- test admin dashboard router functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848439701e48330aed2a06f2615db03