### PR TITLE
Add alliance members view API and integrate roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ the records created during onboarding.
 ✅ Alliance project catalogue documented in [docs/project_alliance_catalogue.md](docs/project_alliance_catalogue.md)
 ✅ Alliance projects runtime table documented in [docs/projects_alliance.md](docs/projects_alliance.md)
 ✅ Alliance quest contributions documented in [docs/quest_alliance_contributions.md](docs/quest_alliance_contributions.md)
+✅ Alliance member roster uses Supabase RPC `get_alliance_members_detailed`
 
 
 ✅ VIP status system documented in [docs/vip_status.md](docs/vip_status.md)

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -52,10 +52,14 @@ Author: Deathsgift66
       <section class="search-sort-controls" aria-label="Alliance Member Controls">
         <input type="text" id="member-search" placeholder="Search by name..." aria-label="Search Members" />
         <select id="sort-by" aria-label="Sort By">
-          <option value="name">Name</option>
+          <option value="username">Name</option>
           <option value="rank">Rank</option>
           <option value="contribution">Contribution</option>
           <option value="status">Status</option>
+          <option value="military_score">Military</option>
+          <option value="economy_score">Economy</option>
+          <option value="diplomacy_score">Diplomacy</option>
+          <option value="total_output">Resource Output</option>
         </select>
         <select id="sort-direction" aria-label="Sort Direction">
           <option value="asc">Ascending</option>
@@ -71,14 +75,19 @@ Author: Deathsgift66
             <tr>
               <th>Name</th>
               <th>Rank</th>
+              <th>Role</th>
               <th>Status</th>
               <th>Contribution</th>
+              <th>Economy</th>
+              <th>Military</th>
+              <th>Diplomacy</th>
+              <th>Output</th>
               <th>Actions</th>
             </tr>
           </thead>
           <tbody id="members-list">
             <tr>
-              <td colspan="5">Loading members...</td>
+              <td colspan="10">Loading members...</td>
             </tr>
           </tbody>
         </table>

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from .routers import (
     admin,
     alliance_members,
+    alliance_members_view,
     alliance_projects,
     kingdom,
     conflicts,
@@ -51,6 +52,7 @@ Base.metadata.create_all(bind=engine)
 load_game_settings()
 
 app.include_router(alliance_members.router)
+app.include_router(alliance_members_view.router)
 app.include_router(admin.router)
 app.include_router(alliance_projects.router)
 app.include_router(kingdom.router)

--- a/backend/routers/alliance_members_view.py
+++ b/backend/routers/alliance_members_view.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException, Header
+
+router = APIRouter()
+
+
+def get_current_user_id(x_user_id: str | None = Header(None)) -> str:
+    if not x_user_id:
+        raise HTTPException(status_code=401, detail="User ID header missing")
+    return x_user_id
+
+
+def get_supabase_client():
+    try:
+        from supabase import create_client
+    except ImportError as e:
+        raise RuntimeError("supabase client library not installed") from e
+    import os
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+    if not url or not key:
+        raise RuntimeError("Supabase credentials not configured")
+    return create_client(url, key)
+
+
+@router.get("/api/alliance-members/view")
+def view_alliance_members(user_id: str = Depends(get_current_user_id)):
+    supabase = get_supabase_client()
+
+    user_res = (
+        supabase.table("users")
+        .select("alliance_id")
+        .eq("user_id", user_id)
+        .single()
+        .execute()
+    )
+    user = getattr(user_res, "data", user_res)
+    if not user:
+        raise HTTPException(401, "Not authorized")
+
+    members_res = (
+        supabase.rpc("get_alliance_members_detailed", {"viewer_user_id": user_id})
+        .execute()
+    )
+    members = getattr(members_res, "data", members_res)
+
+    return {"alliance_members": members}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]
 sqlalchemy
 psycopg2-binary
 python-dotenv
+supabase


### PR DESCRIPTION
## Summary
- create `/api/alliance-members/view` route using Supabase
- expose new router from `backend.main`
- extend alliance roster page to show full member details
- fetch members using the new API route
- document Supabase RPC usage in `README`
- require `supabase` package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684843be373c83309995fa0fa96e3ebe