### PR TITLE
Add alliance war battle integration

### DIFF
--- a/CSS/alliance_wars.css
+++ b/CSS/alliance_wars.css
@@ -152,4 +152,84 @@ body {
   border-radius: 4px;
 }
 
+/* Tabs */
+.tabs {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tab-button {
+  background: var(--accent);
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  border: 1px solid var(--gold);
+  font-family: 'Cinzel', serif;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.tab-button:hover,
+.tab-button.active {
+  background: var(--gold);
+  color: #1a1a1a;
+}
+
+.tab-section {
+  display: none;
+  margin-top: 1rem;
+}
+
+.tab-section.active {
+  display: block;
+}
+
+/* Battle Map */
+.battle-container {
+  display: flex;
+  gap: var(--gap-default);
+  width: 100%;
+}
+
+.battle-map {
+  display: grid;
+  grid-template-columns: repeat(60, 20px);
+  grid-template-rows: repeat(20, 20px);
+  gap: 1px;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 5px;
+  border: 1px solid var(--gold);
+}
+
+.battle-map .tile {
+  width: 20px;
+  height: 20px;
+  background: var(--stone-panel);
+}
+
+.unit-icon {
+  width: 20px;
+  height: 20px;
+  background: var(--accent);
+  border-radius: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: white;
+}
+
+.combat-log {
+  flex: 1;
+  background: var(--stone-panel);
+  border: var(--border);
+  padding: var(--padding-sm);
+  overflow-y: auto;
+  max-height: 400px;
+  list-style: none;
+}
+
 /* Footer - handled globally */

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -77,10 +77,59 @@ Author: Deathsgift66
 
   <!-- Core War Panel -->
   <section class="alliance-members-container">
-    <h2>Ongoing Alliance Wars</h2>
-    <p>Monitor active wars, view progress, and manage your alliance's battle efforts.</p>
-    <div id="wars-container" aria-live="polite">
-      <!-- War cards injected by JavaScript -->
+    <div class="tabs">
+      <button class="tab-button active" data-tab="tab-active">⚔️ Active Wars</button>
+      <button class="tab-button" data-tab="tab-history">📜 War History</button>
+      <button class="tab-button" data-tab="tab-overview">🧭 War Overview</button>
+      <button class="tab-button" data-tab="tab-preplan">🧠 Pre‑Planning</button>
+      <button class="tab-button" data-tab="tab-live">🔴 Live Battle</button>
+      <button class="tab-button" data-tab="tab-resolution">📊 Results</button>
+    </div>
+
+    <!-- Active Wars -->
+    <div id="tab-active" class="tab-section active" aria-label="Active Wars">
+      <h2>Ongoing Alliance Wars</h2>
+      <p>Monitor active wars, view progress, and manage your alliance's battle efforts.</p>
+      <div id="wars-container" aria-live="polite">
+        <!-- War cards injected by JavaScript -->
+      </div>
+    </div>
+
+    <!-- War History -->
+    <div id="tab-history" class="tab-section" aria-label="Past Wars">
+      <h2>Past Wars</h2>
+      <div id="history-container">
+        <!-- Past wars injected by JavaScript -->
+      </div>
+    </div>
+
+    <!-- War Overview -->
+    <div id="tab-overview" class="tab-section" aria-label="War Overview">
+      <h2>War Overview</h2>
+      <div id="war-overview"></div>
+    </div>
+
+    <!-- Pre‑Planning -->
+    <div id="tab-preplan" class="tab-section" aria-label="Preplanning">
+      <h2>Pre‑Planning Phase</h2>
+      <div id="preplan-area"></div>
+    </div>
+
+    <!-- Live Battle -->
+    <div id="tab-live" class="tab-section" aria-label="Live Battle Phase">
+      <h2>Live Battle</h2>
+      <div class="battle-container">
+        <div id="battle-map" class="battle-map"></div>
+        <aside class="sidebar">
+          <div id="combat-log" class="combat-log" aria-live="polite"><strong>Combat Log:</strong><hr></div>
+        </aside>
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div id="tab-resolution" class="tab-section" aria-label="Battle Results">
+      <h2>Battle Results</h2>
+      <div id="results-area"></div>
     </div>
   </section>
 

--- a/tests/test_alliance_wars_router.py
+++ b/tests/test_alliance_wars_router.py
@@ -1,0 +1,53 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.database import Base
+from backend.models import User, AllianceWar, AllianceWarPreplan
+from backend.routers.alliance_wars import list_wars, submit_preplan
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def seed_user(db):
+    user = User(
+        user_id="00000000-0000-0000-0000-000000000001",
+        username="tester",
+        display_name="Tester",
+        email="t@example.com",
+        kingdom_id=1,
+        alliance_id=1,
+    )
+    db.add(user)
+    db.commit()
+    return user.user_id
+
+
+def test_list_wars_groups_by_status():
+    Session = setup_db()
+    db = Session()
+    uid = seed_user(db)
+    db.add(AllianceWar(alliance_war_id=1, attacker_alliance_id=1, defender_alliance_id=2, war_status="active", phase="battle"))
+    db.add(AllianceWar(alliance_war_id=2, attacker_alliance_id=1, defender_alliance_id=3, war_status="completed", phase="resolution"))
+    db.commit()
+
+    res = list_wars(user_id=uid, db=db)
+    assert len(res["active_wars"]) == 1
+    assert len(res["completed_wars"]) == 1
+
+
+def test_submit_preplan_upserts():
+    Session = setup_db()
+    db = Session()
+    uid = seed_user(db)
+    db.add(AllianceWar(alliance_war_id=5, attacker_alliance_id=1, defender_alliance_id=2, war_status="preplan", phase="preplan"))
+    db.commit()
+
+    submit_preplan(5, {"units": []}, user_id=uid, db=db)
+    row = db.query(AllianceWarPreplan).filter_by(alliance_war_id=5, kingdom_id=1).first()
+    assert row is not None
+    assert row.preplan_jsonb == {"units": []}


### PR DESCRIPTION
## Summary
- expand alliance wars page with tabs for history, overview, preplan, live battle and results
- render battle map and combat log from backend
- add tab styles and battle map styling
- fetch war data from new API routes and implement client side tab logic
- implement alliance war router endpoints
- add regression tests for router logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for backend and sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68484759c5188330a91ef7fb5a351b79