### PR TITLE
Integrate live battle view

### DIFF
--- a/CSS/battle_live.css
+++ b/CSS/battle_live.css
@@ -61,6 +61,36 @@ body {
   border-radius: 2px;
 }
 
+.unit-icon {
+  font-size: 12px;
+  color: #fff;
+  text-align: center;
+}
+
+.hud {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  background: var(--dark-panel);
+  padding: var(--padding-sm);
+  border: var(--border);
+}
+
+.order-panel {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--panel-bg);
+  padding: var(--padding-md);
+  border: var(--border);
+  z-index: 100;
+}
+
+.hidden {
+  display: none;
+}
+
 /* Sidebar */
 .sidebar {
   display: flex;

--- a/battle_live.html
+++ b/battle_live.html
@@ -65,6 +65,13 @@ Author: Deathsgift66
 
   <!-- Battle Area -->
   <section class="battle-area" aria-label="Battlefield">
+    <div class="hud" aria-label="Battle Status">
+      <div>Weather: <span id="weather"></span></div>
+      <div>Phase: <span id="phase"></span></div>
+      <div>Castle HP: <span id="castle-hp"></span></div>
+      <div>Score A: <span id="score-a"></span> vs B: <span id="score-b"></span></div>
+      <div>Next Tick in: <span id="tick-timer"></span></div>
+    </div>
     <div class="battle-container">
       <div id="battle-map" class="battle-map" aria-label="Battle Map">
         <!-- Tiles + units rendered by JS -->
@@ -79,6 +86,14 @@ Author: Deathsgift66
           <button class="btn-fantasy" onclick="refreshBattle()">Refresh Battle Data</button>
         </div>
       </aside>
+    </div>
+    <div id="order-panel" class="order-panel hidden" aria-label="Issue Orders">
+      <h3>Unit Orders</h3>
+      <div>Unit: <span id="order-unit"></span></div>
+      <label>Move to X:<input type="number" id="order-x" min="0" max="59"></label>
+      <label>Y:<input type="number" id="order-y" min="0" max="19"></label>
+      <button class="btn-fantasy" onclick="submitOrders()">Submit</button>
+      <button class="btn-fantasy" onclick="closeOrderPanel()">Close</button>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- add battle status HUD and order panel to `battle_live.html`
- style HUD, units, and order panel
- poll battle status and submit orders via `battle_live.js`
- expose battle status and order APIs in FastAPI router
- support filtered combat log queries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68484d1f12bc8330a2640f9c97832433