### PR TITLE
Implement buildings_page_forge

### DIFF
--- a/CSS/buildings.css
+++ b/CSS/buildings.css
@@ -104,6 +104,31 @@ body {
   color: var(--parchment);
 }
 
+.building-icon {
+  width: 48px;
+  height: 48px;
+}
+
+.progress-bar {
+  background: var(--parchment-dark);
+  border: 1px solid var(--gold);
+  border-radius: 6px;
+  overflow: hidden;
+  height: 1rem;
+}
+
+.progress-bar-fill {
+  background: var(--accent);
+  height: 100%;
+  width: 0;
+}
+
+.timer {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.9rem;
+}
+
 .buildings-table th {
   background: var(--gold);
   color: #1a1a1a;

--- a/backend/routers/buildings.py
+++ b/backend/routers/buildings.py
@@ -1,24 +1,204 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from ..database import get_db
+from services.audit_service import log_action
+from .progression_router import get_user_id, get_kingdom_id
 
 router = APIRouter(prefix="/api/buildings", tags=["buildings"])
 
 
-class UpgradePayload(BaseModel):
-    building: str
-
-
-@router.post("/upgrade")
-async def upgrade(payload: UpgradePayload):
-    return {"message": "upgrading", "building": payload.building}
+class BuildingActionPayload(BaseModel):
+    village_id: int
+    building_id: int
 
 
 @router.get("/catalogue")
 def get_catalogue(db: Session = Depends(get_db)):
-    rows = db.execute(text("SELECT * FROM building_catalogue ORDER BY building_id")).mappings().fetchall()
+    rows = (
+        db.execute(text("SELECT * FROM building_catalogue ORDER BY building_id"))
+        .mappings()
+        .fetchall()
+    )
     return {"buildings": [dict(r) for r in rows]}
+
+
+@router.get("/village/{village_id}")
+def get_village_buildings(
+    village_id: int,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    kid = get_kingdom_id(db, user_id)
+    owner = db.execute(
+        text("SELECT kingdom_id FROM kingdom_villages WHERE village_id = :vid"),
+        {"vid": village_id},
+    ).fetchone()
+    if not owner or owner[0] != kid:
+        raise HTTPException(status_code=403, detail="Village does not belong to your kingdom")
+
+    rows = (
+        db.execute(
+            text(
+                """
+                SELECT bc.building_id, bc.building_name, bc.category, bc.description,
+                       bc.production_type, bc.build_cost, bc.modifiers,
+                       bc.build_time_seconds,
+                       COALESCE(vb.level, 0) AS level,
+                       vb.is_under_construction, vb.construction_started_at,
+                       vb.construction_ends_at
+                FROM building_catalogue bc
+                LEFT JOIN village_buildings vb
+                  ON vb.building_id = bc.building_id
+                 AND vb.village_id = :vid
+                ORDER BY bc.building_id
+                """
+            ),
+            {"vid": village_id},
+        )
+        .mappings()
+        .fetchall()
+    )
+    return {"buildings": [dict(r) for r in rows]}
+
+
+@router.post("/construct")
+def construct_build(
+    payload: BuildingActionPayload,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    kid = get_kingdom_id(db, user_id)
+    owner = db.execute(
+        text("SELECT kingdom_id FROM kingdom_villages WHERE village_id = :vid"),
+        {"vid": payload.village_id},
+    ).fetchone()
+    if not owner or owner[0] != kid:
+        raise HTTPException(status_code=403, detail="Village does not belong to your kingdom")
+
+    build_time = db.execute(
+        text("SELECT build_time_seconds FROM building_catalogue WHERE building_id = :bid"),
+        {"bid": payload.building_id},
+    ).fetchone()
+    if not build_time:
+        raise HTTPException(status_code=404, detail="Building not found")
+
+    db.execute(
+        text(
+            """
+            INSERT INTO village_buildings (
+                village_id, building_id, level,
+                construction_started_at, construction_ends_at,
+                is_under_construction, constructed_by, construction_status
+            ) VALUES (
+                :vid, :bid, 1, now(), now() + make_interval(secs := :secs),
+                true, :uid, 'under_construction'
+            )
+            ON CONFLICT (village_id, building_id) DO UPDATE
+              SET construction_started_at = EXCLUDED.construction_started_at,
+                  construction_ends_at = EXCLUDED.construction_ends_at,
+                  is_under_construction = true,
+                  constructed_by = EXCLUDED.constructed_by,
+                  construction_status = 'under_construction'
+            """
+        ),
+        {
+            "vid": payload.village_id,
+            "bid": payload.building_id,
+            "secs": build_time[0],
+            "uid": user_id,
+        },
+    )
+    log_action(db, user_id, "start_build", f"{payload.village_id}:{payload.building_id}")
+    db.commit()
+    return {"message": "Construction started"}
+
+
+@router.post("/upgrade")
+def upgrade_build(
+    payload: BuildingActionPayload,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    kid = get_kingdom_id(db, user_id)
+    owner = db.execute(
+        text("SELECT kingdom_id FROM kingdom_villages WHERE village_id = :vid"),
+        {"vid": payload.village_id},
+    ).fetchone()
+    if not owner or owner[0] != kid:
+        raise HTTPException(status_code=403, detail="Village does not belong to your kingdom")
+
+    existing = db.execute(
+        text(
+            "SELECT level, is_under_construction FROM village_buildings WHERE village_id = :vid AND building_id = :bid"
+        ),
+        {"vid": payload.village_id, "bid": payload.building_id},
+    ).fetchone()
+
+    if not existing:
+        raise HTTPException(status_code=404, detail="Building not constructed yet")
+    if existing[1]:
+        raise HTTPException(status_code=400, detail="Upgrade already in progress")
+
+    build_time = db.execute(
+        text("SELECT build_time_seconds FROM building_catalogue WHERE building_id = :bid"),
+        {"bid": payload.building_id},
+    ).fetchone()[0]
+
+    db.execute(
+        text(
+            """
+            UPDATE village_buildings
+            SET construction_started_at = now(),
+                construction_ends_at = now() + make_interval(secs := :secs),
+                is_under_construction = true,
+                construction_status = 'under_construction',
+                constructed_by = :uid
+            WHERE village_id = :vid AND building_id = :bid
+            """
+        ),
+        {
+            "vid": payload.village_id,
+            "bid": payload.building_id,
+            "secs": build_time,
+            "uid": user_id,
+        },
+    )
+    log_action(db, user_id, "upgrade_build", f"{payload.village_id}:{payload.building_id}")
+    db.commit()
+    return {"message": "Upgrade started", "level": existing[0] + 1}
+
+
+@router.post("/cancel")
+def cancel_build(
+    payload: BuildingActionPayload,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    kid = get_kingdom_id(db, user_id)
+    owner = db.execute(
+        text("SELECT kingdom_id FROM kingdom_villages WHERE village_id = :vid"),
+        {"vid": payload.village_id},
+    ).fetchone()
+    if not owner or owner[0] != kid:
+        raise HTTPException(status_code=403, detail="Village does not belong to your kingdom")
+
+    db.execute(
+        text(
+            """
+            UPDATE village_buildings
+            SET is_under_construction = false,
+                construction_status = 'idle',
+                construction_started_at = NULL,
+                construction_ends_at = NULL
+            WHERE village_id = :vid AND building_id = :bid
+            """
+        ),
+        {"vid": payload.village_id, "bid": payload.building_id},
+    )
+    log_action(db, user_id, "cancel_build", f"{payload.village_id}:{payload.building_id}")
+    db.commit()
+    return {"message": "Construction cancelled"}
 

--- a/buildings.html
+++ b/buildings.html
@@ -71,15 +71,18 @@ Author: Deathsgift66
     <p>View, upgrade, and manage your kingdom's buildings and infrastructure.</p>
 
     <!-- Buildings Table -->
+    <label for="villageSelect">Village:</label>
+    <select id="villageSelect"></select>
+
     <section class="buildings-table" aria-label="Buildings List">
       <table id="buildingsTable">
         <thead>
           <tr>
+            <th>Icon</th>
             <th>Building</th>
             <th>Level</th>
-            <th>Production</th>
-            <th>Upkeep</th>
-            <th>Upgrade</th>
+            <th>Status</th>
+            <th>Action</th>
           </tr>
         </thead>
         <tbody id="buildingsTableBody">


### PR DESCRIPTION
## Summary
- add real-time buildings management logic with village selector and timers
- update backend buildings router for village endpoints and audit logging
- style building page icons and progress bars
- extend buildings HTML with village picker and updated table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848546a2cfc8330aac05bddcfb64f5e