### PR TITLE
Implement full kingdom history page

### DIFF
--- a/CSS/kingdom_history.css
+++ b/CSS/kingdom_history.css
@@ -28,23 +28,62 @@ body {
   align-items: center;
 }
 
-.history-list {
+.history-section {
+  width: 100%;
+  margin-bottom: 1.5rem;
+}
+
+.timeline {
   list-style: none;
   padding: 0;
+  margin: 0;
+  border-left: 2px solid var(--gold);
+}
+
+.timeline li {
+  position: relative;
+  padding: 0 0 1rem 1rem;
+}
+
+.timeline li::before {
+  content: '\2022';
+  position: absolute;
+  left: -0.6rem;
+  color: var(--gold);
+}
+
+.achievement-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.achievement-badge {
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid var(--gold);
+  padding: 0.5rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+.collapsible {
   width: 100%;
 }
 
-.history-item {
-  background: rgba(0, 0, 0, 0.55);
+.collapsible h3 {
+  margin: 0;
+  background: rgba(0, 0, 0, 0.35);
+  padding: 0.5rem;
   border: 1px solid var(--gold);
-  border-radius: 8px;
-  padding: 0.75rem;
-  margin-bottom: 1rem;
-  box-shadow: 0 2px 8px var(--shadow);
+  cursor: pointer;
 }
 
-.history-item .date {
-  font-family: 'Cinzel', serif;
-  color: var(--gold);
-  margin-bottom: 0.25rem;
+.collapsible ul {
+  list-style: none;
+  padding: 0.5rem;
+  display: none;
+}
+
+.collapsible.open ul {
+  display: block;
 }

--- a/Javascript/kingdom_history.js
+++ b/Javascript/kingdom_history.js
@@ -7,47 +7,81 @@ Author: Deathsgift66
 
 import { supabase } from './supabaseClient.js';
 
-document.addEventListener('DOMContentLoaded', async () => {
-  await loadHistory();
-});
+document.addEventListener('DOMContentLoaded', init);
 
-async function loadHistory() {
-  const listEl = document.getElementById('history-list');
-  listEl.innerHTML = '<li>Loading history...</li>';
+async function init() {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
 
-  try {
-    const { data: { user } } = await supabase.auth.getUser();
-    const { data: userData, error: userError } = await supabase
-      .from('users')
-      .select('kingdom_id')
-      .eq('user_id', user.id)
-      .single();
+  const { data: userData } = await supabase
+    .from('users')
+    .select('kingdom_id')
+    .eq('user_id', user.id)
+    .single();
 
-    if (userError) throw userError;
+  if (!userData) return;
 
-    const res = await fetch(`/api/kingdom-history?kingdom_id=${userData.kingdom_id}&limit=50`);
-    const result = await res.json();
+  await loadFullHistory(user.id, userData.kingdom_id);
+  bindCollapsibles();
+}
 
-    listEl.innerHTML = '';
+async function loadFullHistory(userId, kingdomId) {
+  const res = await fetch(`/api/kingdom-history/${kingdomId}/full`, {
+    headers: { 'X-User-ID': userId }
+  });
+  const data = await res.json();
 
-    if (!result.history || result.history.length === 0) {
-      listEl.innerHTML = '<li>No history found.</li>';
-      return;
-    }
+  renderTimeline(data.timeline || []);
+  renderAchievements(data.achievements || []);
+  renderLog('war-log', data.wars_fought || [], e => `War ID ${e.war_id}`);
+  renderLog('project-log', data.projects_log || [], e => e.name);
+  renderLog('quest-log', data.quests_log || [], e => e.quest_code + ' - ' + e.status);
+  renderLog('training-log', data.training_log || [], e => `${e.quantity} ${e.unit_name}`);
+}
 
-    result.history.forEach(entry => {
-      const item = document.createElement('li');
-      item.classList.add('history-item');
-      item.innerHTML = `
-        <div class="date">[${new Date(entry.event_date).toLocaleString()}]</div>
-        <div class="detail">${escapeHTML(entry.event_details)}</div>
-      `;
-      listEl.appendChild(item);
-    });
-  } catch (err) {
-    console.error('Error loading history:', err);
-    listEl.innerHTML = '<li>Failed to load history.</li>';
+function renderTimeline(events) {
+  const el = document.getElementById('timeline');
+  el.innerHTML = '';
+  if (!events.length) {
+    el.innerHTML = '<li>No events</li>';
+    return;
   }
+  events.forEach(ev => {
+    const li = document.createElement('li');
+    li.textContent = `[${new Date(ev.event_date).toLocaleDateString()}] ${ev.event_details}`;
+    el.appendChild(li);
+  });
+}
+
+function renderAchievements(list) {
+  const grid = document.getElementById('achievement-grid');
+  grid.innerHTML = '';
+  list.forEach(a => {
+    const div = document.createElement('div');
+    div.classList.add('achievement-badge');
+    div.textContent = a.name;
+    grid.appendChild(div);
+  });
+}
+
+function renderLog(id, list, formatter) {
+  const container = document.getElementById(id);
+  container.innerHTML = '';
+  list.forEach(entry => {
+    const li = document.createElement('li');
+    li.textContent = formatter(entry);
+    container.appendChild(li);
+  });
+}
+
+function bindCollapsibles() {
+  document.querySelectorAll('.collapsible').forEach(sec => {
+    const header = sec.querySelector('h3');
+    if (!header) return;
+    header.addEventListener('click', () => {
+      sec.classList.toggle('open');
+    });
+  });
 }
 
 function escapeHTML(str) {

--- a/backend/routers/kingdom_history.py
+++ b/backend/routers/kingdom_history.py
@@ -1,8 +1,15 @@
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, HTTPException
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from ..database import get_db
-from services.kingdom_history_service import log_event, fetch_history
+from services.kingdom_history_service import (
+    log_event,
+    fetch_history,
+    fetch_full_history,
+)
+from .progression_router import get_user_id, get_kingdom_id
+from .admin_dashboard import verify_admin
 from pydantic import BaseModel
 
 router = APIRouter(prefix="/api/kingdom-history", tags=["kingdom_history"])
@@ -21,7 +28,6 @@ def kingdom_history(
     limit: int = 50,
     db: Session = Depends(get_db),
 ):
-codex/integrate-player-kingdom-history-log
     """Return recent history for a kingdom."""
     records = fetch_history(db, kingdom_id, limit)
     return {"history": records}
@@ -34,3 +40,26 @@ def create_history(payload: HistoryPayload, db: Session = Depends(get_db)):
 
     log_event(db, payload.kingdom_id, payload.event_type, payload.event_details)
     return {"message": "logged"}
+
+
+@router.get("/{kingdom_id}/full")
+def full_history(
+    kingdom_id: int,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """Return all historical data for the requested kingdom."""
+
+    try:
+        player_kid = get_kingdom_id(db, user_id)
+    except HTTPException:
+        player_kid = None
+
+    if player_kid != kingdom_id:
+        try:
+            verify_admin(user_id, db)
+        except HTTPException:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+    data = fetch_full_history(db, kingdom_id)
+    return data

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -59,13 +59,37 @@ Author: Deathsgift66
 <!-- Main Centered Layout -->
 <main class="main-centered-container" aria-label="Kingdom History Interface">
 
-  <!-- History Panel -->
-  <section class="alliance-members-container">
-    <h2>Kingdom History</h2>
-    <p>A chronological record of your kingdom's major events.</p>
-    <ul id="history-list" class="history-list">
-      <!-- JS populates -->
-    </ul>
+  <!-- Timeline Panel -->
+  <section class="history-section">
+    <h2>Kingdom Timeline</h2>
+    <ul id="timeline" class="timeline"></ul>
+  </section>
+
+  <!-- Achievement Grid -->
+  <section class="history-section">
+    <h2>Achievements</h2>
+    <div id="achievement-grid" class="achievement-grid"></div>
+  </section>
+
+  <!-- Collapsible Logs -->
+  <section id="war-log-panel" class="collapsible">
+    <h3>Past Wars</h3>
+    <ul id="war-log"></ul>
+  </section>
+
+  <section id="project-log-panel" class="collapsible">
+    <h3>Project Activity</h3>
+    <ul id="project-log"></ul>
+  </section>
+
+  <section id="quest-log-panel" class="collapsible">
+    <h3>Quest Attempts</h3>
+    <ul id="quest-log"></ul>
+  </section>
+
+  <section id="training-log-panel" class="collapsible">
+    <h3>Training History</h3>
+    <ul id="training-log"></ul>
   </section>
 
 </main>

--- a/services/kingdom_history_service.py
+++ b/services/kingdom_history_service.py
@@ -40,3 +40,68 @@ def fetch_history(db: Session, kingdom_id: int, limit: int = 50) -> list[dict]:
         }
         for r in rows
     ]
+
+
+def fetch_full_history(db: Session, kingdom_id: int) -> dict:
+    """Return aggregated historical data for a kingdom."""
+
+    def single(query: str) -> dict:
+        row = (
+            db.execute(text(query), {"kid": kingdom_id}).mappings().fetchone()
+        )
+        return dict(row) if row else {}
+
+    def many(query: str) -> list[dict]:
+        rows = (
+            db.execute(text(query), {"kid": kingdom_id}).mappings().fetchall()
+        )
+        return [dict(r) for r in rows]
+
+    return {
+        "core": single(
+            "SELECT kingdom_name, ruler_name, created_at, motto, region "
+            "FROM kingdoms WHERE kingdom_id = :kid"
+        ),
+        "timeline": many(
+            "SELECT event_type, event_details, event_date "
+            "FROM kingdom_history_log WHERE kingdom_id = :kid "
+            "ORDER BY event_date DESC"
+        ),
+        "wars_fought": many(
+            "SELECT war_id, attacker_id, defender_id, war_reason, outcome, "
+            "start_date, end_date FROM wars "
+            "WHERE attacker_kingdom_id = :kid OR defender_kingdom_id = :kid "
+            "ORDER BY start_date DESC"
+        ),
+        "achievements": many(
+            "SELECT k.achievement_code, c.name, c.description, k.awarded_at "
+            "FROM kingdom_achievements k "
+            "JOIN kingdom_achievement_catalogue c "
+            "ON k.achievement_code = c.achievement_code "
+            "WHERE k.kingdom_id = :kid"
+        ),
+        "titles": many(
+            "SELECT title, awarded_at FROM kingdom_titles "
+            "WHERE kingdom_id = :kid ORDER BY awarded_at DESC"
+        ),
+        "research_log": many(
+            "SELECT tech_code, status, progress, ends_at "
+            "FROM kingdom_research_tracking WHERE kingdom_id = :kid"
+        ),
+        "quests_log": many(
+            "SELECT quest_code, status, started_at, ends_at "
+            "FROM quest_kingdom_tracking WHERE kingdom_id = :kid "
+            "ORDER BY started_at DESC"
+        ),
+        "training_log": many(
+            "SELECT unit_name, quantity, completed_at "
+            "FROM training_history WHERE kingdom_id = :kid "
+            "ORDER BY completed_at DESC"
+        ),
+        "projects_log": many(
+            "SELECT p.project_code, c.name, p.starts_at, p.ends_at "
+            "FROM projects_player p "
+            "JOIN project_player_catalogue c ON p.project_code = c.project_code "
+            "WHERE p.kingdom_id = :kid ORDER BY p.starts_at DESC"
+        ),
+    }

--- a/tests/test_kingdom_history_service.py
+++ b/tests/test_kingdom_history_service.py
@@ -1,25 +1,50 @@
-from services.kingdom_history_service import log_event, fetch_history
+from services.kingdom_history_service import log_event, fetch_history, fetch_full_history
 
 class DummyResult:
-    def __init__(self, rows=None):
+    def __init__(self, row=None, rows=None):
+        self._row = row
         self._rows = rows or []
+
+    def fetchone(self):
+        return self._row
 
     def fetchall(self):
         return self._rows
+
+    def mappings(self):
+        return self
 
 class DummyDB:
     def __init__(self):
         self.inserts = []
         self.select_rows = []
+        self.calls = []
 
     def execute(self, query, params=None):
         q = str(query)
         params = params or {}
+        self.calls.append(q)
         if q.strip().startswith("INSERT INTO kingdom_history_log"):
             self.inserts.append(params)
             return DummyResult()
         if "FROM kingdom_history_log" in q:
-            return DummyResult(self.select_rows)
+            return DummyResult(rows=self.select_rows)
+        if "FROM kingdoms" in q:
+            return DummyResult(row={"kingdom_name": "Demo"})
+        if "FROM wars" in q:
+            return DummyResult(rows=[{"war_id": 1}])
+        if "FROM kingdom_achievements" in q:
+            return DummyResult(rows=[{"achievement_code": "A"}])
+        if "FROM kingdom_titles" in q:
+            return DummyResult(rows=[{"title": "Hero"}])
+        if "FROM kingdom_research_tracking" in q:
+            return DummyResult(rows=[{"tech_code": "t1"}])
+        if "FROM quest_kingdom_tracking" in q:
+            return DummyResult(rows=[{"quest_code": "q1"}])
+        if "FROM training_history" in q:
+            return DummyResult(rows=[{"unit_name": "Archer"}])
+        if "FROM projects_player" in q:
+            return DummyResult(rows=[{"project_code": "p1"}])
         return DummyResult()
 
     def commit(self):
@@ -39,3 +64,10 @@ def test_fetch_history_returns_rows():
     logs = fetch_history(db, 1, 10)
     assert len(logs) == 1
     assert logs[0]["event_type"] == "war_victory"
+
+
+def test_fetch_full_history_structure():
+    db = DummyDB()
+    result = fetch_full_history(db, 1)
+    assert result["core"]["kingdom_name"] == "Demo"
+    assert result["wars_fought"][0]["war_id"] == 1


### PR DESCRIPTION
## Summary
- enhance kingdom history service with new `fetch_full_history`
- secure new `/api/kingdom-history/{kingdom_id}/full` endpoint
- expand history UI with timeline, badges, and collapsible logs
- style new history layout
- adjust JS to load the new endpoint
- cover new service with tests

## Testing
- `PYTHONPATH=. pytest tests/test_kingdom_history_service.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68485a83ba3083308757872a49981a9a