### PR TITLE
Align frontend fetch paths with backend routes

### DIFF
--- a/Javascript/alliance_quests.js
+++ b/Javascript/alliance_quests.js
@@ -61,7 +61,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     acceptBtn.addEventListener("click", async () => {
       const questId = acceptBtn.dataset.questId;
       if (!questId) return;
-      const res = await fetch("/api/alliance-quests/accept", {
+      const res = await fetch("/api/alliance-quests/start", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ quest_id: questId })
@@ -83,7 +83,15 @@ async function loadQuests(status) {
   heroes.innerHTML = "<li>Loading heroes...</li>";
 
   try {
-    const res = await fetch(`/api/alliance-quests?status=${status}`);
+    let endpoint;
+    if (status === "active") {
+      endpoint = "/api/alliance-quests/active";
+    } else if (status === "completed") {
+      endpoint = "/api/alliance-quests/completed";
+    } else {
+      endpoint = "/api/alliance-quests/available";
+    }
+    const res = await fetch(endpoint);
     const data = await res.json();
 
     // Clear board
@@ -212,14 +220,3 @@ function openQuestModal(q) {
   modal.classList.add("open");
 }
 
-// ✅ Contribute to quest (called from modal if needed)
-async function contributeToQuest(questId) {
-  const res = await fetch("/api/alliance-quests/contribute", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ quest_id: questId })
-  });
-  const result = await res.json();
-  alert(result.message || "Contribution sent!");
-  await loadQuests("active");
-}

--- a/Javascript/alliance_wars.js
+++ b/Javascript/alliance_wars.js
@@ -29,7 +29,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 // ✅ Load Alliance Custom Board (image + text)
 async function loadCustomBoard() {
   try {
-    const res = await fetch("/api/alliance-wars/custom-board");
+    const res = await fetch("/api/alliance-vault/custom-board");
     const data = await res.json();
 
     const imgSlot = document.getElementById("custom-image-slot");

--- a/Javascript/leaderboard.js
+++ b/Javascript/leaderboard.js
@@ -160,7 +160,7 @@ function openApplyModal(allianceId, allianceName) {
     }
 
     try {
-      const res = await fetch("/api/alliances/apply", {
+      const res = await fetch("/api/alliance_members/apply", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
- correct alliance application endpoint in `leaderboard.js`
- update `alliance_quests.js` to use existing quest routes and drop unused contribution code
- fix custom board fetch path in `alliance_wars.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68485befd2d88330914faaaa24cfb790