### PR TITLE
Fix mismatched DB references

### DIFF
--- a/Javascript/world_map.js
+++ b/Javascript/world_map.js
@@ -79,16 +79,17 @@ async function renderVisibleTiles() {
   const startX = Math.floor(-offsetX / TILE_SIZE) - Math.floor(cols / 2);
   const startY = Math.floor(-offsetY / TILE_SIZE) - Math.floor(rows / 2);
 
-  const { data: tiles, error } = await supabase
-    .from('world_tiles')
-    .select('*')
-    .gte('x', startX)
-    .lte('x', startX + cols)
-    .gte('y', startY)
-    .lte('y', startY + rows);
+  const { data: mapRow, error } = await supabase
+    .from('terrain_map')
+    .select('tile_map')
+    .limit(1)
+    .single();
 
   if (error) return console.error('Tile fetch failed', error);
 
+  const tiles = (mapRow?.tile_map?.tiles || [])
+    .filter(t => t.x >= startX && t.x <= startX + cols &&
+                t.y >= startY && t.y <= startY + rows);
   tiles.forEach(tile => drawTile(tile));
 }
 


### PR DESCRIPTION
## Summary
- fetch world map tiles from `terrain_map` instead of removed `world_tiles`
- remove obsolete progression requirements checks
- read temple modifiers via `village_buildings`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for backend/sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68485dcddac48330a9ed5cfaf3a2dc87