### PR TITLE
Enhance Alliance Treaties page with realtime modal UI

### DIFF
--- a/CSS/alliance_treaties.css
+++ b/CSS/alliance_treaties.css
@@ -128,4 +128,79 @@ body {
   color: #1e1e1e;
 }
 
+/* Treaty Card Layout */
+#treaties-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+  width: 100%;
+}
+
+.treaty-card {
+  background: var(--panel-bg);
+  border: var(--card-border);
+  border-radius: var(--border-radius);
+  padding: var(--padding-md);
+  box-shadow: var(--box-shadow);
+}
+
+.treaty-card h3 {
+  margin-top: 0;
+  font-family: var(--font-header);
+}
+
+.treaty-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+@media (max-width: 600px) {
+  #treaties-container {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-index-modal);
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: var(--panel-bg);
+  border: 3px solid var(--gold);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow);
+  padding: var(--padding-lg);
+  max-width: 480px;
+  width: 90%;
+  position: relative;
+  color: var(--ink);
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  color: var(--ink);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
 /* Footer - handled by global theme */

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -78,6 +78,14 @@ Author: Deathsgift66
 
 </main>
 
+<!-- Treaty Details Modal -->
+<div id="treaty-modal" class="modal hidden" aria-hidden="true">
+  <div class="modal-content">
+    <button class="modal-close" aria-label="Close">&times;</button>
+    <div id="treaty-details"></div>
+  </div>
+</div>
+
 <!-- Footer -->
 <footer class="site-footer">
   <div>© 2025 Kingmaker’s Rise</div>


### PR DESCRIPTION
## Summary
- add modal markup for treaty details
- style treaty cards and modal in `alliance_treaties.css`
- subscribe to realtime treaty updates in `alliance_treaties.js`
- show treaty details in modal via new API call
- implement `/view/{treaty_id}` route in FastAPI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6848602e447883309f06655cf7f67238