### PR TITLE
Enhance alliance wars page with real-time UI

### DIFF
--- a/CSS/alliance_wars.css
+++ b/CSS/alliance_wars.css
@@ -232,4 +232,38 @@ body {
   list-style: none;
 }
 
+.score-table {
+  width: 100%;
+  margin-top: 1rem;
+  border-collapse: collapse;
+}
+
+.score-table th,
+.score-table td {
+  border: 1px solid var(--gold);
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.participants {
+  display: flex;
+  gap: var(--gap-default);
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.participant-list {
+  flex: 1 1 200px;
+  background: var(--stone-panel);
+  border: var(--border);
+  padding: var(--padding-sm);
+  border-radius: var(--border-radius);
+}
+
+@media (max-width: 768px) {
+  .battle-container {
+    flex-direction: column;
+  }
+}
+
 /* Footer - handled globally */

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -107,6 +107,8 @@ Author: Deathsgift66
     <div id="tab-overview" class="tab-section" aria-label="War Overview">
       <h2>War Overview</h2>
       <div id="war-overview"></div>
+      <div id="scoreboard" class="scoreboard"></div>
+      <div id="participants" class="participants"></div>
     </div>
 
     <!-- Pre‑Planning -->


### PR DESCRIPTION
## Summary
- add scoreboard and participant panels to the war overview
- style new components and improve responsive layout
- implement real-time JS polling and Supabase data loading
- secure alliance war routes with access checks
- expose scoreboard and participant API endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68486033e09883309365fd048420b158