### PR TITLE
Add account projects page and backend router

### DIFF
--- a/CSS/account_projects.css
+++ b/CSS/account_projects.css
@@ -1,0 +1,91 @@
+@import url("./root_theme.css");
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  background: url('../Assets/projects_kingdom_background.png') no-repeat center center fixed;
+  background-size: cover;
+  color: var(--parchment);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.main-centered-container {
+  width: auto;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+  flex: 1;
+}
+
+.account-projects-container {
+  background: rgba(0,0,0,0.55);
+  backdrop-filter: blur(5px);
+  border-radius: var(--border-radius);
+  border: 1px solid var(--gold);
+  box-shadow: 0 6px 14px var(--shadow);
+  padding: 2rem;
+}
+
+.tab-buttons {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.tab-btn {
+  background: var(--accent);
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: var(--border-radius-small);
+  border: 1px solid var(--gold);
+  font-family: var(--font-primary);
+  cursor: pointer;
+}
+
+.tab-btn.active,
+.tab-btn:hover {
+  background: var(--gold);
+  color: #1a1a1a;
+}
+
+.tab-content { display: none; }
+.tab-content.active { display: block; }
+
+.project-panel {
+  background: var(--stone-panel);
+  padding: 1rem;
+  border-radius: var(--border-radius);
+  box-shadow: 0 2px 6px var(--shadow);
+  margin-bottom: 1.5rem;
+}
+
+.project-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.project-card {
+  background: var(--stone-panel);
+  padding: 1rem;
+  border-radius: var(--border-radius);
+  box-shadow: 0 2px 6px var(--shadow);
+  border: 1px solid var(--gold);
+}
+
+@media (max-width: 600px) {
+  .main-centered-container { padding: 1rem; }
+  .project-list { grid-template-columns: 1fr; }
+}
+
+.site-footer {
+  text-align: center;
+  font-size: 0.9rem;
+  color: #888;
+  padding: 1rem;
+}
+
+.site-footer a { color: var(--accent); text-decoration: none; }
+.site-footer a:hover { color: var(--gold); }

--- a/FILE_LIST.md
+++ b/FILE_LIST.md
@@ -4,6 +4,7 @@
 - .ENV
 
 ## HTML Files
+- account_projects.html
 - account_settings.html
 - admin_alerts.html
 - admin_dashboard.html
@@ -68,6 +69,7 @@
 - world_map.html
 
 ## CSS Files
+- CSS/account_projects.css
 - CSS/account_settings.css
 - CSS/admin_alerts.css
 - CSS/admin_dashboard.css
@@ -130,6 +132,7 @@
 - CSS/world_map.css
 
 ## JavaScript Files
+- Javascript/account_projects.js
 - Javascript/account_settings.js
 - Javascript/admin_alerts.js
 - Javascript/admin_dashboard.js
@@ -218,6 +221,7 @@
 - backend/models.py
 - backend/progression_service.py
 - backend/routers/__init__.py
+- backend/routers/account_projects.py
 - backend/routers/admin.py
 - backend/routers/alliance_changelog.py
 - backend/routers/alliance_members.py

--- a/Javascript/account_projects.js
+++ b/Javascript/account_projects.js
@@ -1,0 +1,108 @@
+import { supabase } from './supabaseClient.js';
+
+async function loadProjects() {
+  const availableList = document.getElementById('available-projects-list');
+  const activeList = document.getElementById('active-projects-list');
+  const powerScoreEl = document.getElementById('power-score');
+
+  availableList.innerHTML = '<p>Loading...</p>';
+  activeList.innerHTML = '<p>Loading...</p>';
+  powerScoreEl.textContent = 'Loading...';
+
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('Not authenticated');
+
+    const { data: userRow } = await supabase
+      .from('users')
+      .select('kingdom_id')
+      .eq('user_id', user.id)
+      .single();
+    const kingdomId = userRow.kingdom_id;
+
+    const { data: resources } = await supabase
+      .from('kingdom_resources')
+      .select('*')
+      .eq('kingdom_id', kingdomId)
+      .single();
+
+    const { data: catalogue } = await supabase
+      .from('project_player_catalogue')
+      .select('*')
+      .eq('is_active', true);
+
+    const { data: activeProjects } = await supabase
+      .from('projects_player')
+      .select('*')
+      .eq('kingdom_id', kingdomId);
+
+    const powerScore = activeProjects.reduce((s,p)=>s+(p.power_score||0),0);
+    powerScoreEl.textContent = powerScore;
+
+    const activeCodes = activeProjects.map(p=>p.project_code);
+
+    availableList.innerHTML = '';
+    (catalogue||[]).forEach(proj=>{
+      if (proj.expires_at && new Date(proj.expires_at) < new Date()) return;
+      const card = document.createElement('div');
+      const canAfford = Object.entries(proj.cost||{}).every(([res,val]) => (resources[res]||0) >= val);
+      const active = activeCodes.includes(proj.project_code);
+      card.className = 'project-card';
+      card.innerHTML = `
+        <h3>${proj.name}</h3>
+        <p>${proj.description}</p>
+        <p>Cost: ${formatCost(proj.cost)}</p>
+        <button class="action-btn start" data-code="${proj.project_code}" ${active||!canAfford?'disabled':''}>${active?'Active':canAfford?'Start':'Insufficient Resources'}</button>
+      `;
+      availableList.appendChild(card);
+    });
+
+    document.querySelectorAll('.start').forEach(btn=>{
+      btn.addEventListener('click', async ()=>{
+        const code = btn.dataset.code;
+        const res = await fetch('/api/account-projects/start', {
+          method:'POST',
+          headers:{'Content-Type':'application/json','X-User-Id':user.id},
+          body: JSON.stringify({project_code: code})
+        });
+        const out = await res.json();
+        if(!res.ok) return alert(out.detail||'Failed');
+        alert(out.message);
+      });
+    });
+
+    activeList.innerHTML = '';
+    activeProjects.forEach(proj=>{
+      const card = document.createElement('div');
+      card.className = 'project-card';
+      card.innerHTML = `<h3>${proj.project_code}</h3><p>Power: ${proj.power_score}</p>`;
+      activeList.appendChild(card);
+    });
+  } catch(err) {
+    console.error(err);
+    availableList.innerHTML = '<p>Error loading projects.</p>';
+    activeList.innerHTML = '<p>Error loading projects.</p>';
+    powerScoreEl.textContent = 'Error';
+  }
+}
+
+function formatCost(cost){
+  if(!cost) return 'None';
+  return Object.entries(cost).map(([k,v])=>`${v} ${k}`).join(', ');
+}
+
+document.addEventListener('DOMContentLoaded', ()=>{
+  loadProjects();
+  supabase.channel('projects_player')
+    .on('postgres_changes',{event:'*',schema:'public',table:'projects_player'}, ()=> loadProjects())
+    .subscribe();
+
+  document.querySelectorAll('.tab-btn').forEach(btn=>{
+    btn.addEventListener('click', ()=>{
+      document.querySelectorAll('.tab-btn').forEach(b=>b.classList.remove('active'));
+      document.querySelectorAll('.tab-content').forEach(t=>t.classList.remove('active'));
+      btn.classList.add('active');
+      document.getElementById(btn.dataset.tab).classList.add('active');
+    });
+  });
+});

--- a/account_projects.html
+++ b/account_projects.html
@@ -1,0 +1,55 @@
+<!--
+Project Name: Kingmakers Rise Frontend
+File Name: account_projects.html
+--> 
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Account Projects | Kingmaker's Rise</title>
+  <meta name="description" content="Manage your personal kingdom projects." />
+  <link rel="stylesheet" href="CSS/account_projects.css" />
+  <script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script defer type="module" src="Javascript/account_projects.js"></script>
+  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+  <link rel="stylesheet" href="CSS/root_theme.css" />
+  <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/progressionBanner.css" />
+  <script type="module" src="Javascript/navDropdown.js"></script>
+  <script type="module" src="Javascript/components/authGuard.js"></script>
+  <script type="module" src="Javascript/progressionBanner.js"></script>
+</head>
+<body>
+  <div id="navbar-container"></div>
+  <script>
+    fetch('navbar.html').then(r=>r.text()).then(html=>{document.getElementById('navbar-container').innerHTML=html});
+  </script>
+  <header class="kr-top-banner" aria-label="Account Projects Banner">
+    Account Projects
+  </header>
+  <main class="main-centered-container" aria-label="Account Projects Interface">
+    <section class="account-projects-container">
+      <h2>Your Projects</h2>
+      <div class="tab-buttons">
+        <button class="tab-btn active" data-tab="available-projects">Available</button>
+        <button class="tab-btn" data-tab="active-projects">Active</button>
+      </div>
+      <div class="project-panel" id="power-score-panel">
+        <h3 class="panel-title">Kingdom Power Score</h3>
+        <div id="power-score"></div>
+      </div>
+      <div id="available-projects" class="tab-content active">
+        <div class="project-list" id="available-projects-list"></div>
+      </div>
+      <div id="active-projects" class="tab-content">
+        <div class="project-list" id="active-projects-list"></div>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <div>&copy; 2025 Kingmaker’s Rise</div>
+    <div><a href="legal.html">View Legal Documents</a></div>
+  </footer>
+</body>
+</html>

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,6 +37,7 @@ from .routers import (
     admin_dashboard,
     account_settings,
     spies_router,
+    account_projects,
     trade_logs,
     training_history,
     village_modifiers,
@@ -102,6 +103,7 @@ app.include_router(alliance_home.router)
 app.include_router(wars.router)
 app.include_router(quests_router.router)
 app.include_router(projects_router.router)
+app.include_router(account_projects.router)
 app.include_router(kingdom_history.router)
 app.include_router(forgot_password.router)
 

--- a/backend/routers/account_projects.py
+++ b/backend/routers/account_projects.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+from pydantic import BaseModel
+
+from ..database import get_db
+from .progression_router import get_user_id, get_kingdom_id
+
+router = APIRouter(prefix="/api/account-projects", tags=["account_projects"])
+
+class StartPayload(BaseModel):
+    project_code: str
+
+@router.post("/start")
+def start_project(payload: StartPayload, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    kid = get_kingdom_id(db, user_id)
+    try:
+        db.execute(
+            text("""
+                INSERT INTO projects_player (kingdom_id, project_code, power_score, ends_at)
+                VALUES (:kid, :code, 0, NOW())
+            """),
+            {"kid": kid, "code": payload.project_code},
+        )
+        db.commit()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"message": "Project started", "project_code": payload.project_code}


### PR DESCRIPTION
## Summary
- add `account_projects.html` with immersive banner and project panels
- style the page with new `CSS/account_projects.css`
- implement real-time loading in `Javascript/account_projects.js`
- secure new FastAPI route in `backend/routers/account_projects.py`
- register router in `backend/main.py`
- document new files in `FILE_LIST.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6848602878148330b43bc368ca51c4ac