### PR TITLE
Improve battle_live with realtime scoring

### DIFF
--- a/CSS/battle_live.css
+++ b/CSS/battle_live.css
@@ -119,6 +119,17 @@ body {
   gap: 0.5rem;
 }
 
+.scoreboard {
+  background: var(--panel-bg);
+  border: var(--border);
+  padding: var(--padding-sm);
+  margin-top: 1rem;
+}
+
+.scoreboard div {
+  margin-bottom: 0.25rem;
+}
+
 .btn-fantasy {
   background: var(--accent);
   color: white;
@@ -134,4 +145,17 @@ body {
 .btn-fantasy:hover {
   background: var(--gold);
   color: #1a1a1a;
+}
+
+@media (max-width: 768px) {
+  .battle-container {
+    flex-direction: column;
+  }
+  .sidebar {
+    width: 100%;
+  }
+  #battle-map {
+    overflow-x: auto;
+    grid-template-columns: repeat(60, minmax(12px, 1fr));
+  }
 }

--- a/battle_live.html
+++ b/battle_live.html
@@ -81,6 +81,13 @@ Author: Deathsgift66
           <strong>Combat Log:</strong>
           <hr>
         </div>
+        <div id="scoreboard" class="scoreboard" aria-label="Scoreboard" aria-live="polite">
+          <strong>Scoreboard</strong>
+          <hr>
+          <div>Attacker: <span id="score-attacker"></span></div>
+          <div>Defender: <span id="score-defender"></span></div>
+          <div>Victor: <span id="score-victor"></span></div>
+        </div>
         <div class="button-panel">
           <button class="btn-fantasy" onclick="triggerNextTick()">Trigger Next Tick</button>
           <button class="btn-fantasy" onclick="refreshBattle()">Refresh Battle Data</button>

--- a/tests/test_battle_router.py
+++ b/tests/test_battle_router.py
@@ -1,0 +1,37 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi import HTTPException
+
+from backend.database import Base
+from backend.models import WarScore
+from backend.routers.battle import get_battle_scoreboard
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def test_get_battle_scoreboard_returns_scores():
+    Session = setup_db()
+    db = Session()
+    db.add(WarScore(war_id=1, attacker_score=10, defender_score=5, victor="attacker"))
+    db.commit()
+
+    result = get_battle_scoreboard(1, db=db, user_id="u1")
+    assert result["attacker_score"] == 10
+    assert result["defender_score"] == 5
+    assert result["victor"] == "attacker"
+
+
+def test_get_battle_scoreboard_404():
+    Session = setup_db()
+    db = Session()
+    try:
+        get_battle_scoreboard(99, db=db, user_id="u1")
+    except HTTPException as e:
+        assert e.status_code == 404
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- enrich *battle_live.html* with a scoreboard section
- style scoreboard and mobile layout in *battle_live.css*
- add Supabase-powered scoreboard updates in *battle_live.js*
- secure battle routes with JWT checks and expose new `/api/battle/scoreboard` endpoint
- test scoreboard route logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several modules)*

------
https://chatgpt.com/codex/tasks/task_e_6848625a049083309804e35f6e26eaae