### PR TITLE
Enhance compose workflow

### DIFF
--- a/CSS/compose.css
+++ b/CSS/compose.css
@@ -11,6 +11,15 @@ body {
   min-height: 100vh;
 }
 
+@media (max-width: 600px) {
+  .tabs {
+    flex-direction: column;
+  }
+  .tab {
+    border-bottom: 1px solid var(--gold);
+  }
+}
+
 .main-container {
   width: auto;
   max-width: 1200px;
@@ -77,4 +86,9 @@ body {
   padding: 1rem;
   background: var(--stone-panel);
   border: 1px dashed var(--gold);
+}
+
+datalist option {
+  background: var(--parchment-dark);
+  color: var(--ink);
 }

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from .routers import (
     donate_vip,
     forgot_password,
     messages,
+    compose,
     player_management,
     market,
     diplomacy,
@@ -80,6 +81,7 @@ app.include_router(audit_log.router)
 app.include_router(admin_audit_log.router)
 app.include_router(donate_vip.router)
 app.include_router(messages.router)
+app.include_router(compose.router)
 app.include_router(player_management.router)
 app.include_router(market.router)
 app.include_router(diplomacy.router)

--- a/backend/routers/compose.py
+++ b/backend/routers/compose.py
@@ -1,0 +1,140 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+
+from ..database import get_db
+from ..models import PlayerMessage, Notification, War
+from ..security import verify_jwt_token
+from services.audit_service import log_action
+
+router = APIRouter(prefix="/api/compose", tags=["compose"])
+
+
+class MessagePayload(BaseModel):
+    recipient_id: str
+    message: str
+
+
+class NoticePayload(BaseModel):
+    title: str
+    message: str
+    category: str | None = None
+    link_action: str | None = None
+
+
+class TreatyPayload(BaseModel):
+    partner_alliance_id: int
+    treaty_type: str
+
+
+class WarPayload(BaseModel):
+    defender_id: str
+    war_reason: str
+
+
+@router.post("/send-message")
+def send_message(
+    payload: MessagePayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    row = db.execute(
+        text("SELECT user_id FROM users WHERE user_id = :rid"),
+        {"rid": payload.recipient_id},
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Recipient not found")
+
+    msg = PlayerMessage(
+        recipient_id=payload.recipient_id,
+        user_id=user_id,
+        message=payload.message,
+    )
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    log_action(db, user_id, "send_message", payload.recipient_id)
+    return {"status": "sent", "message_id": msg.message_id}
+
+
+@router.post("/send-notification")
+def send_notification(
+    payload: NoticePayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    users = db.execute(text("SELECT user_id FROM users")).fetchall()
+    for (uid,) in users:
+        db.add(
+            Notification(
+                user_id=uid,
+                title=payload.title,
+                message=payload.message,
+                category=payload.category,
+                link_action=payload.link_action,
+                source_system="compose",
+            )
+        )
+    db.commit()
+    log_action(db, user_id, "broadcast_notice", payload.title)
+    return {"status": "sent", "count": len(users)}
+
+
+@router.post("/propose-treaty")
+def propose_treaty(
+    payload: TreatyPayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    row = db.execute(
+        text("SELECT alliance_id FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not row or row[0] is None:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+    aid = row[0]
+
+    db.execute(
+        text(
+            "INSERT INTO alliance_treaties (alliance_id, treaty_type, partner_alliance_id, status) "
+            "VALUES (:aid, :type, :pid, 'proposed')"
+        ),
+        {"aid": aid, "type": payload.treaty_type, "pid": payload.partner_alliance_id},
+    )
+    db.commit()
+    log_action(db, user_id, "propose_treaty", payload.treaty_type)
+    return {"status": "proposed"}
+
+
+@router.post("/declare-war")
+def declare_war(
+    payload: WarPayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    attacker = db.execute(
+        text("SELECT username FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    defender = db.execute(
+        text("SELECT username FROM users WHERE user_id = :did"),
+        {"did": payload.defender_id},
+    ).fetchone()
+    if not defender:
+        raise HTTPException(status_code=404, detail="Defender not found")
+
+    war = War(
+        attacker_id=user_id,
+        defender_id=payload.defender_id,
+        attacker_name=attacker[0] if attacker else None,
+        defender_name=defender[0],
+        war_reason=payload.war_reason,
+        status="pending",
+        submitted_by=user_id,
+    )
+    db.add(war)
+    db.commit()
+    db.refresh(war)
+    log_action(db, user_id, "declare_war", payload.defender_id)
+    return {"status": "pending", "war_id": war.war_id}

--- a/compose.html
+++ b/compose.html
@@ -10,6 +10,9 @@ Updated: Compose interface with tabs
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Compose | Kingmaker's Rise</title>
   <meta name="description" content="Send messages, notices, treaties or war declarations." />
+  <meta property="og:title" content="Compose | Kingmaker's Rise" />
+  <meta property="og:description" content="Send messages, notices, treaties or war declarations." />
+  <meta name="twitter:card" content="summary" />
   <link rel="stylesheet" href="CSS/compose.css" />
   <script defer type="module" src="Javascript/compose.js"></script>
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
@@ -34,8 +37,9 @@ Updated: Compose interface with tabs
   <section id="tab-message" class="tab-content active">
     <form id="message-form">
       <div class="form-group">
-        <label for="msg-recipient">Recipient ID</label>
-        <input id="msg-recipient" required />
+        <label for="msg-recipient">Recipient</label>
+        <input id="msg-recipient" list="recipient-list" autocomplete="off" required />
+        <datalist id="recipient-list"></datalist>
       </div>
       <div class="form-group">
         <label for="msg-content">Message</label>


### PR DESCRIPTION
## Summary
- improve Compose page design with new meta tags and datalist for recipient lookup
- add responsive styles in `compose.css`
- support recipient suggestions and preview enhancements in `compose.js`
- create new `compose` FastAPI router with endpoints
- register Compose router in backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684866f19834833090eb9a8e0080199a