### PR TITLE
Improve conflicts experience

### DIFF
--- a/CSS/conflicts.css
+++ b/CSS/conflicts.css
@@ -187,4 +187,24 @@ body {
   display: none;
 }
 
+/* Live Feed */
+.live-feed {
+  background: var(--dark-panel);
+  color: var(--parchment);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 100%;
+  box-shadow: 0 2px 6px var(--shadow);
+  margin-bottom: 2rem;
+}
+
+@media (max-width: 768px) {
+  .conflict-tabs {
+    flex-direction: column;
+  }
+  .conflict-tabs .tab {
+    margin: 0.25rem 0;
+  }
+}
+
 /* Footer - handled globally */

--- a/backend/routers/conflicts.py
+++ b/backend/routers/conflicts.py
@@ -1,14 +1,108 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from .progression_router import get_kingdom_id
+from ..security import verify_jwt_token
+
+
+def get_supabase_client():
+    """Return a configured Supabase client or raise if unavailable."""
+    try:
+        from supabase import create_client
+    except ImportError as e:  # pragma: no cover - library optional in tests
+        raise RuntimeError("supabase client library not installed") from e
+    import os
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+    if not url or not key:
+        raise RuntimeError("Supabase credentials not configured")
+    return create_client(url, key)
+
 
 router = APIRouter(prefix="/api/conflicts", tags=["conflicts"])
 
 
-@router.get("/active")
-async def active_conflicts():
-    return {"conflicts": []}
+def get_alliance_id(db: Session, user_id: str) -> int:
+    row = db.execute(
+        text("SELECT alliance_id FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not row or row[0] is None:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+    return row[0]
 
 
-@router.get("/historical")
-async def historical_conflicts():
-    return {"conflicts": []}
+@router.get("/kingdom")
+def list_kingdom_wars(
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    kid = get_kingdom_id(db, user_id)
+    supabase = get_supabase_client()
+    res = (
+        supabase.table("wars")
+        .select("*")
+        .or_(f"attacker_kingdom_id.eq.{kid},defender_kingdom_id.eq.{kid}")
+        .execute()
+    )
+    return {"wars": getattr(res, "data", res) or []}
 
+
+@router.get("/alliance")
+def list_alliance_wars(
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    aid = get_alliance_id(db, user_id)
+    supabase = get_supabase_client()
+    res = (
+        supabase.table("alliance_wars")
+        .select("*")
+        .or_(f"attacker_alliance_id.eq.{aid},defender_alliance_id.eq.{aid}")
+        .execute()
+    )
+    return {"wars": getattr(res, "data", res) or []}
+
+
+@router.get("/war/{war_id}/details")
+def get_war_details(
+    war_id: int,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    supabase = get_supabase_client()
+    war_res = (
+        supabase.table("wars")
+        .select("*")
+        .eq("war_id", war_id)
+        .single()
+        .execute()
+    )
+    war = getattr(war_res, "data", war_res)
+    if not war:
+        raise HTTPException(status_code=404, detail="War not found")
+
+    kid = get_kingdom_id(db, user_id)
+    if war.get("attacker_kingdom_id") != kid and war.get("defender_kingdom_id") != kid:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    score_res = (
+        supabase.table("war_scores")
+        .select("attacker_score, defender_score, victor")
+        .eq("war_id", war_id)
+        .single()
+        .execute()
+    )
+    score = getattr(score_res, "data", score_res) or {}
+
+    return {
+        "war_id": war.get("war_id"),
+        "attacker_name": war.get("attacker_name"),
+        "defender_name": war.get("defender_name"),
+        "phase": war.get("phase"),
+        "result": score.get("victor"),
+        "attacker_score": score.get("attacker_score"),
+        "defender_score": score.get("defender_score"),
+    }

--- a/conflicts.html
+++ b/conflicts.html
@@ -60,7 +60,7 @@ Author: Deathsgift66
   Kingmaker's Rise — Conflicts
 </header>
 
-
+<main class="main-centered-container">
 
   <!-- Conflicts Hub -->
   <section class="alliance-members-container">
@@ -81,6 +81,8 @@ Author: Deathsgift66
     </div>
 
   </section>
+
+  <section id="liveFeed" class="live-feed"></section>
 
   <div id="war-detail-modal" class="modal hidden"></div>
 

--- a/tests/test_conflicts_router.py
+++ b/tests/test_conflicts_router.py
@@ -1,0 +1,93 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi import HTTPException
+
+from backend.database import Base
+from backend.models import User
+from backend.routers import conflicts
+
+
+class DummyTable:
+    def __init__(self, data=None):
+        self._data = data or []
+        self._single = False
+
+    def select(self, *_args):
+        return self
+
+    def or_(self, *_args):
+        return self
+
+    def eq(self, *_args):
+        return self
+
+    def single(self):
+        self._single = True
+        return self
+
+    def execute(self):
+        if self._single:
+            return {"data": self._data[0] if self._data else None}
+        return {"data": self._data}
+
+
+class DummyClient:
+    def __init__(self, tables):
+        self.tables = tables
+
+    def table(self, name):
+        return DummyTable(self.tables.get(name, []))
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def seed_user(db):
+    uid = "u1"
+    user = User(
+        user_id=uid,
+        username="t",
+        display_name="T",
+        email="t@example.com",
+        kingdom_id=1,
+        alliance_id=2,
+    )
+    db.add(user)
+    db.commit()
+    return uid
+
+
+def test_list_kingdom_wars_returns_rows():
+    Session = setup_db()
+    db = Session()
+    uid = seed_user(db)
+    wars = [
+        {
+            "war_id": 5,
+            "attacker_kingdom_id": 1,
+            "defender_kingdom_id": 99,
+            "attacker_name": "A",
+            "defender_name": "B",
+        }
+    ]
+    conflicts.get_supabase_client = lambda: DummyClient({"wars": wars})
+    result = conflicts.list_kingdom_wars(user_id=uid, db=db)
+    assert result["wars"][0]["war_id"] == 5
+
+
+def test_get_war_details_denies_unrelated():
+    Session = setup_db()
+    db = Session()
+    uid = seed_user(db)
+    war = {"war_id": 2, "attacker_kingdom_id": 3, "defender_kingdom_id": 4}
+    conflicts.get_supabase_client = lambda: DummyClient({"wars": [war], "war_scores": []})
+    try:
+        conflicts.get_war_details(2, user_id=uid, db=db)
+    except HTTPException as e:
+        assert e.status_code == 403
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- add main container and live feed section to conflicts page
- enhance conflicts styles for live feed and responsive tabs
- refresh conflict data periodically in new JS functions
- secure Supabase-backed FastAPI routes for conflicts
- cover new conflicts API logic with unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684866fa75708330b0f01cf99a124dd2