### PR TITLE
Add VIP leaderboard and secure routes

### DIFF
--- a/CSS/donate_vip.css
+++ b/CSS/donate_vip.css
@@ -6,12 +6,10 @@ Author: Deathsgift66
 */
 @import url("./root_theme.css");
 
-
-
 body {
   margin: 0;
-  font-family: 'IM Fell English', serif;
-  background: url('../Assets/donate.png') no-repeat center center fixed;
+  font-family: "IM Fell English", serif;
+  background: url("../Assets/donate.png") no-repeat center center fixed;
   background-size: cover;
   color: var(--parchment);
   display: flex;
@@ -44,7 +42,7 @@ body {
 }
 
 .alliance-customization-area h2 {
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   color: var(--gold);
   text-shadow: 1px 1px 3px black;
   margin-bottom: 1rem;
@@ -76,7 +74,7 @@ body {
 }
 
 .alliance-members-container h2 {
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   color: var(--gold);
   text-shadow: 1px 1px 3px black;
   margin-bottom: 1rem;
@@ -104,7 +102,7 @@ body {
 }
 
 .vip-tier h3 {
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   color: var(--gold);
   text-shadow: 1px 1px 3px black;
   margin-bottom: 0.5rem;
@@ -122,9 +120,11 @@ body {
   border-radius: 6px;
   border: 1px solid var(--gold);
   cursor: pointer;
-  font-family: 'Cinzel', serif;
+  font-family: "Cinzel", serif;
   font-weight: bold;
-  transition: background 0.3s ease, color 0.3s ease;
+  transition:
+    background 0.3s ease,
+    color 0.3s ease;
 }
 
 .donate-btn:hover {
@@ -150,7 +150,9 @@ body {
   border-radius: var(--btn-radius);
   padding: var(--btn-padding);
   cursor: pointer;
-  transition: background var(--transition-medium), color var(--transition-medium);
+  transition:
+    background var(--transition-medium),
+    color var(--transition-medium);
 }
 .vip-button:hover {
   background: var(--btn-hover-bg);
@@ -193,6 +195,34 @@ body {
 .vip-perks-table th {
   background: var(--table-header-bg);
   color: var(--ink);
+}
+
+/* Leaderboard */
+.vip-leaderboard {
+  margin-top: 2rem;
+  width: 100%;
+  text-align: center;
+}
+
+.leaderboard-container {
+  overflow-x: auto;
+  background: rgba(251, 240, 217, 0.95);
+  border: 3px solid var(--gold);
+  border-radius: 12px;
+  box-shadow: 0 8px 16px var(--shadow);
+  padding: 1rem;
+  color: var(--ink);
+}
+
+.leaderboard-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.leaderboard-table th,
+.leaderboard-table td {
+  border: 1px solid var(--gold);
+  padding: 0.5rem;
 }
 
 /* Footer - handled globally */

--- a/Javascript/donate_vip.js
+++ b/Javascript/donate_vip.js
@@ -6,26 +6,43 @@ Author: Deathsgift66
 */
 // VIP Donation Logic
 
-import { supabase } from './supabaseClient.js';
+import { supabase } from "./supabaseClient.js";
 
 let vipStatus = null;
 let vipTiers = [];
+let vipChannel = null;
+let currentSession = null;
 
 async function init() {
-  const { data: { session } } = await supabase.auth.getSession();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
   if (!session) {
-    window.location.href = 'login.html';
+    window.location.href = "login.html";
     return;
   }
+  currentSession = session;
 
   await loadVIPStatus();
   await loadVIPTiers();
+  await loadLeaderboard();
 
-  const form = document.getElementById('donation-form');
+  vipChannel = supabase
+    .channel("public:vip_donations")
+    .on(
+      "postgres_changes",
+      { event: "*", schema: "public", table: "vip_donations" },
+      () => {
+        loadLeaderboard();
+      },
+    )
+    .subscribe();
+
+  const form = document.getElementById("donation-form");
   if (form) {
-    form.addEventListener('submit', async (e) => {
+    form.addEventListener("submit", async (e) => {
       e.preventDefault();
-      const tierId = document.getElementById('selected-tier-id').value;
+      const tierId = document.getElementById("selected-tier-id").value;
       if (tierId) {
         await submitVIPDonation(parseInt(tierId));
       }
@@ -33,12 +50,16 @@ async function init() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', init);
+document.addEventListener("DOMContentLoaded", init);
 
 export async function loadVIPStatus() {
   try {
-    const res = await fetch('/api/vip/status');
-    if (!res.ok) throw new Error('failed');
+    const headers = {
+      Authorization: `Bearer ${currentSession.access_token}`,
+      "X-User-ID": currentSession.user.id,
+    };
+    const res = await fetch("/api/vip/status", { headers });
+    if (!res.ok) throw new Error("failed");
     vipStatus = await res.json();
     renderStatus(vipStatus);
   } catch {
@@ -48,8 +69,12 @@ export async function loadVIPStatus() {
 
 export async function loadVIPTiers() {
   try {
-    const res = await fetch('/api/vip/tiers');
-    if (!res.ok) throw new Error('failed');
+    const headers = {
+      Authorization: `Bearer ${currentSession.access_token}`,
+      "X-User-ID": currentSession.user.id,
+    };
+    const res = await fetch("/api/vip/tiers", { headers });
+    if (!res.ok) throw new Error("failed");
     const data = await res.json();
     vipTiers = data.tiers || [];
     renderTiers(vipTiers);
@@ -60,40 +85,44 @@ export async function loadVIPTiers() {
 
 export async function submitVIPDonation(tier_id) {
   try {
-    const res = await fetch('/api/vip/donate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tier_id })
+    const res = await fetch("/api/vip/donate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${currentSession.access_token}`,
+        "X-User-ID": currentSession.user.id,
+      },
+      body: JSON.stringify({ tier_id }),
     });
     if (!res.ok) {
       const err = await res.json();
-      alert(err.detail || 'Failed');
+      alert(err.detail || "Failed");
       return;
     }
     await loadVIPStatus();
-    document.getElementById('donation-form').hidden = true;
-    alert('VIP updated!');
+    document.getElementById("donation-form").hidden = true;
+    alert("VIP updated!");
   } catch (err) {
     console.error(err);
   }
 }
 
 function renderTiers(tiers) {
-  const container = document.getElementById('vip-tier-cards');
+  const container = document.getElementById("vip-tier-cards");
   if (!container) return;
-  container.innerHTML = '';
-  tiers.forEach(t => {
-    const card = document.createElement('div');
-    card.className = 'vip-tier-card';
+  container.innerHTML = "";
+  tiers.forEach((t) => {
+    const card = document.createElement("div");
+    card.className = "vip-tier-card";
     card.innerHTML = `
       <h3>${t.tier_name}</h3>
       <div class="vip-price">${t.price_gold} gold</div>
       <button class="vip-button" data-tier="${t.tier_id}">Donate</button>
     `;
-    const btn = card.querySelector('button');
-    btn.addEventListener('click', () => {
-      document.getElementById('selected-tier-id').value = t.tier_id;
-      document.getElementById('donation-form').hidden = false;
+    const btn = card.querySelector("button");
+    btn.addEventListener("click", () => {
+      document.getElementById("selected-tier-id").value = t.tier_id;
+      document.getElementById("donation-form").hidden = false;
       renderPerks(t);
     });
     container.appendChild(card);
@@ -101,35 +130,35 @@ function renderTiers(tiers) {
 }
 
 function renderStatus(status) {
-  const banner = document.getElementById('current-status-banner');
-  const founder = document.getElementById('founder-preview');
+  const banner = document.getElementById("current-status-banner");
+  const founder = document.getElementById("founder-preview");
   if (!banner) return;
 
   if (status.founder) {
     founder.hidden = false;
-    founder.textContent = 'Founder Perk Active';
-    banner.textContent = 'Founder VIP - Permanent';
+    founder.textContent = "Founder Perk Active";
+    banner.textContent = "Founder VIP - Permanent";
   } else if (status.vip_level) {
     banner.innerHTML = `VIP ${status.vip_level} - expires in <span id="vip-timer"></span>`;
     renderTimer(status.expires_at);
   } else {
-    banner.textContent = 'No active VIP status';
+    banner.textContent = "No active VIP status";
   }
 }
 
 export function renderPerks(tier) {
-  const container = document.getElementById('founder-preview');
+  const container = document.getElementById("founder-preview");
   if (!container) return;
-  container.innerHTML = tier.perks || '';
+  container.innerHTML = tier.perks || "";
 }
 
 export function renderTimer(expiry) {
-  const timerEl = document.getElementById('vip-timer');
+  const timerEl = document.getElementById("vip-timer");
   if (!timerEl || !expiry) return;
   function update() {
     const diff = new Date(expiry) - new Date();
     if (diff <= 0) {
-      timerEl.textContent = 'expired';
+      timerEl.textContent = "expired";
       clearInterval(interval);
       return;
     }
@@ -142,3 +171,55 @@ export function renderTimer(expiry) {
   update();
   const interval = setInterval(update, 1000);
 }
+
+export async function loadLeaderboard() {
+  const container = document.getElementById("leaderboard-body");
+  if (!container) return;
+  container.innerHTML = '<tr><td colspan="3">Loading...</td></tr>';
+  try {
+    const headers = {
+      Authorization: `Bearer ${currentSession.access_token}`,
+      "X-User-ID": currentSession.user.id,
+    };
+    const res = await fetch("/api/vip/leaders", { headers });
+    const data = await res.json();
+    renderLeaderboard(data.leaders || []);
+  } catch (err) {
+    console.error(err);
+    container.innerHTML =
+      '<tr><td colspan="3">Error loading leaderboard</td></tr>';
+  }
+}
+
+function renderLeaderboard(leaders) {
+  const container = document.getElementById("leaderboard-body");
+  if (!container) return;
+  container.innerHTML = "";
+  if (!leaders.length) {
+    container.innerHTML = '<tr><td colspan="3">No donations yet.</td></tr>';
+    return;
+  }
+  leaders.forEach((l, idx) => {
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td>${idx + 1}</td>
+      <td>${escapeHTML(l.username)}</td>
+      <td>${l.total_donated}</td>
+    `;
+    container.appendChild(row);
+  });
+}
+
+function escapeHTML(str) {
+  if (!str) return "";
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+window.addEventListener("beforeunload", () => {
+  if (vipChannel) supabase.removeChannel(vipChannel);
+});

--- a/donate_vip.html
+++ b/donate_vip.html
@@ -4,90 +4,138 @@ File Name: donate_vip.html
 Date: June 2, 2025
 Author: Deathsgift66
 -->
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Donate & VIP | Kingmaker's Rise</title>
+    <meta
+      name="description"
+      content="Support Kingmaker's Rise and unlock exclusive VIP rewards and cosmetic bonuses."
+    />
+    <meta
+      name="keywords"
+      content="Kingmaker's Rise, donate, VIP, rewards, cosmetics, support the game"
+    />
+    <meta name="robots" content="index, follow" />
+    <link
+      rel="canonical"
+      href="https://www.kingmakersrise.com/donate_vip.html"
+    />
 
-  <title>Donate & VIP | Kingmaker's Rise</title>
-  <meta name="description" content="Support Kingmaker's Rise and unlock exclusive VIP rewards and cosmetic bonuses." />
-  <meta name="keywords" content="Kingmaker's Rise, donate, VIP, rewards, cosmetics, support the game" />
-  <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.kingmakersrise.com/donate_vip.html" />
+    <!-- Open Graph -->
+    <meta property="og:title" content="Donate & VIP | Kingmaker's Rise" />
+    <meta
+      property="og:description"
+      content="Support Kingmaker's Rise and unlock exclusive VIP rewards and cosmetic bonuses."
+    />
+    <meta
+      property="og:image"
+      content="https://www.kingmakersrise.com/images/og-preview.jpg"
+    />
+    <meta
+      property="og:url"
+      content="https://www.kingmakersrise.com/donate_vip.html"
+    />
+    <meta property="og:type" content="website" />
 
-  <!-- Open Graph -->
-  <meta property="og:title" content="Donate & VIP | Kingmaker's Rise" />
-  <meta property="og:description" content="Support Kingmaker's Rise and unlock exclusive VIP rewards and cosmetic bonuses." />
-  <meta property="og:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
-  <meta property="og:url" content="https://www.kingmakersrise.com/donate_vip.html" />
-  <meta property="og:type" content="website" />
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Donate & VIP | Kingmaker's Rise" />
+    <meta
+      name="twitter:description"
+      content="Support the game and unlock exclusive cosmetic VIP rewards in Kingmaker's Rise."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.kingmakersrise.com/images/og-preview.jpg"
+    />
 
-  <!-- Twitter -->
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Donate & VIP | Kingmaker's Rise" />
-  <meta name="twitter:description" content="Support the game and unlock exclusive cosmetic VIP rewards in Kingmaker's Rise." />
-  <meta name="twitter:image" content="https://www.kingmakersrise.com/images/og-preview.jpg" />
+    <!-- Page-Specific Assets -->
+    <link rel="stylesheet" href="CSS/donate_vip.css" />
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"
+    ></script>
+    <script defer type="module" src="Javascript/donate_vip.js"></script>
 
-  <!-- Page-Specific Assets -->
-  <link rel="stylesheet" href="CSS/donate_vip.css" />
-  <script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-  <script defer type="module" src="Javascript/donate_vip.js"></script>
+    <!-- Global Assets -->
+    <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
+    <link rel="stylesheet" href="CSS/root_theme.css" />
+    <link rel="stylesheet" href="CSS/kr_navbar.css" />
+    <script type="module" src="Javascript/navDropdown.js"></script>
+    <script type="module" src="Javascript/components/authGuard.js"></script>
+  </head>
 
-  <!-- Global Assets -->
-  <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
-  <link rel="stylesheet" href="CSS/root_theme.css" />
-  <link rel="stylesheet" href="CSS/kr_navbar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
-  <script type="module" src="Javascript/components/authGuard.js"></script>
-</head>
+  <body>
+    <!-- Navbar -->
+    <div id="navbar-container"></div>
+    <script>
+      fetch("navbar.html")
+        .then((res) => res.text())
+        .then((html) => {
+          document.getElementById("navbar-container").innerHTML = html;
+        });
+    </script>
 
-<body>
+    <!-- Page Banner -->
+    <header class="kr-top-banner" aria-label="Donate & VIP Banner">
+      Kingmaker's Rise — Donate & VIP
+    </header>
 
-<!-- Navbar -->
-<div id="navbar-container"></div>
-<script>
-  fetch('navbar.html')
-    .then(res => res.text())
-    .then(html => {
-      document.getElementById('navbar-container').innerHTML = html;
-    });
-</script>
+    <!-- Main Centered Layout -->
+    <main class="donate-vip-container" aria-label="Donate & VIP Interface">
+      <!-- Core VIP Panel -->
+      <section class="alliance-members-container">
+        <h2>Donate & VIP</h2>
+        <p>
+          Support the game and unlock exclusive cosmetic VIP rewards. VIP status
+          offers NO gameplay advantage and is purely cosmetic or
+          convenience-based.
+        </p>
 
-<!-- Page Banner -->
-<header class="kr-top-banner" aria-label="Donate & VIP Banner">
-  Kingmaker's Rise — Donate & VIP
-</header>
+        <div id="current-status-banner" class="vip-expiry-banner"></div>
+        <div id="founder-preview" class="founder-badge" hidden></div>
+        <div id="vip-tier-cards" class="vip-tier-cards"></div>
 
-<!-- Main Centered Layout -->
-<main class="donate-vip-container" aria-label="Donate & VIP Interface">
-  <!-- Core VIP Panel -->
-  <section class="alliance-members-container">
-    <h2>Donate & VIP</h2>
-    <p>Support the game and unlock exclusive cosmetic VIP rewards. VIP status offers NO gameplay advantage and is purely cosmetic or convenience-based.</p>
+        <form id="donation-form" class="vip-donation-form" hidden>
+          <input type="hidden" id="selected-tier-id" />
+          <button type="submit" class="vip-button">Donate</button>
+        </form>
 
-    <div id="current-status-banner" class="vip-expiry-banner"></div>
-    <div id="founder-preview" class="founder-badge" hidden></div>
-    <div id="vip-tier-cards" class="vip-tier-cards"></div>
+        <section class="vip-leaderboard">
+          <h3>Top Donors</h3>
+          <div class="leaderboard-container">
+            <table class="leaderboard-table">
+              <thead>
+                <tr>
+                  <th>Rank</th>
+                  <th>Player</th>
+                  <th>Gold Donated</th>
+                </tr>
+              </thead>
+              <tbody id="leaderboard-body">
+                <tr>
+                  <td colspan="3">Loading...</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </section>
+    </main>
 
-    <form id="donation-form" class="vip-donation-form" hidden>
-      <input type="hidden" id="selected-tier-id" />
-      <button type="submit" class="vip-button">Donate</button>
-    </form>
-  </section>
-</main>
-
-<!-- Footer -->
-<footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
-  <div>
-    <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
-    <a href="Assets/legal/EULA.pdf">EULA</a>
-    <a href="legal.html">and more</a>
-  </div>
-</footer>
-
-</body>
+    <!-- Footer -->
+    <footer class="site-footer">
+      <div>© 2025 Kingmaker’s Rise</div>
+      <div>
+        <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
+        <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
+        <a href="Assets/legal/EULA.pdf">EULA</a>
+        <a href="legal.html">and more</a>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/tests/test_vip_leaderboard_router.py
+++ b/tests/test_vip_leaderboard_router.py
@@ -1,0 +1,40 @@
+from backend.routers import donate_vip
+
+
+class DummyTable:
+    def __init__(self, data=None):
+        self._data = data or []
+        self._ordered = self._data
+
+    def select(self, *_args):
+        return self
+
+    def order(self, column, desc=True):
+        self._ordered = sorted(self._data, key=lambda x: x[column], reverse=desc)
+        return self
+
+    def limit(self, n):
+        self._ordered = self._ordered[:n]
+        return self
+
+    def execute(self):
+        return {"data": self._ordered}
+
+
+class DummyClient:
+    def __init__(self, tables):
+        self.tables = tables
+
+    def table(self, name):
+        return DummyTable(self.tables.get(name, []))
+
+
+def test_vip_leaderboard_sorted():
+    data = [
+        {"user_id": "u1", "username": "A", "total_donated": 100},
+        {"user_id": "u2", "username": "B", "total_donated": 200},
+    ]
+    donate_vip.get_supabase_client = lambda: DummyClient({"vip_donations": data})
+    result = donate_vip.vip_leaderboard(user_id="u1")
+    assert result["leaders"][0]["total_donated"] == 200
+    assert len(result["leaders"]) == 2


### PR DESCRIPTION
## Summary
- overhaul donate_vip backend to use JWT auth and support leaderboard
- add realtime leaderboard support in donate_vip.js
- enhance donate_vip.html layout with a new Top Donors table
- style the leaderboard in donate_vip.css
- test leaderboard route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68486713fb38833081e74711b33774b6