### PR TITLE
Add dynamic legal docs page

### DIFF
--- a/CSS/legal.css
+++ b/CSS/legal.css
@@ -96,6 +96,23 @@ body {
   gap: 1.5rem;
 }
 
+#search-container {
+  width: 100%;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+#doc-search {
+  width: 100%;
+  max-width: 400px;
+  padding: var(--input-padding);
+  border: var(--input-border);
+  border-radius: var(--input-radius);
+  background: var(--input-bg);
+  color: var(--input-text);
+  font-family: var(--font-body);
+}
+
 .legal-card {
   background: var(--stone-panel);
   padding: 1.5rem;

--- a/Javascript/legal.js
+++ b/Javascript/legal.js
@@ -6,15 +6,75 @@ Author: Deathsgift66
 */
 // legal.js - Handles loading and dynamic interactions for legal page
 
-document.addEventListener("DOMContentLoaded", () => {
-  // Optionally preview PDF inline or toggle sections if needed
-  const toggleLinks = document.querySelectorAll(".legal-toggle");
-  toggleLinks.forEach(link => {
-    link.addEventListener("click", () => {
-      const target = document.getElementById(link.dataset.target);
-      if (target) {
-        target.classList.toggle("hidden");
-      }
-    });
-  });
+import { supabase } from './supabaseClient.js';
+
+let docs = [];
+let realtimeSub;
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadDocuments();
+  setupRealtime();
+
+  const search = document.getElementById('doc-search');
+  if (search) search.addEventListener('input', filterDocuments);
 });
+
+async function loadDocuments() {
+  const container = document.getElementById('legal-docs');
+  container.innerHTML = '<p>Loading documents...</p>';
+  try {
+    const res = await fetch('/api/legal/documents');
+    const data = await res.json();
+    docs = data.documents || [];
+    renderDocuments(docs);
+  } catch (err) {
+    console.error('Error loading legal documents:', err);
+    container.innerHTML = '<p>Failed to load documents.</p>';
+  }
+}
+
+function setupRealtime() {
+  realtimeSub = supabase
+    .channel('legal_documents')
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'legal_documents' }, loadDocuments)
+    .subscribe();
+}
+
+window.addEventListener('beforeunload', () => {
+  realtimeSub?.unsubscribe();
+});
+
+function filterDocuments() {
+  const q = document.getElementById('doc-search').value.toLowerCase();
+  const filtered = docs.filter(d => d.title.toLowerCase().includes(q));
+  renderDocuments(filtered);
+}
+
+function renderDocuments(list) {
+  const container = document.getElementById('legal-docs');
+  container.innerHTML = '';
+  if (!list.length) {
+    container.innerHTML = '<p>No documents found.</p>';
+    return;
+  }
+  list.forEach(doc => {
+    const card = document.createElement('div');
+    card.className = 'legal-card';
+    card.innerHTML = `
+      <h3>${escapeHTML(doc.title)}</h3>
+      <p>${escapeHTML(doc.summary)}</p>
+      <a href="${escapeHTML(doc.url)}" target="_blank">View Document</a>
+    `;
+    container.appendChild(card);
+  });
+}
+
+function escapeHTML(str) {
+  if (!str) return '';
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -39,6 +39,7 @@ from .routers import (
     admin_dashboard,
     account_settings,
     spies_router,
+    legal,
     trade_logs,
     training_history,
     village_modifiers,
@@ -110,4 +111,5 @@ app.include_router(projects_router.router)
 app.include_router(kingdom_history.router)
 app.include_router(forgot_password.router)
 app.include_router(kingdom_achievements.router)
+app.include_router(legal.router)
 

--- a/backend/routers/legal.py
+++ b/backend/routers/legal.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, HTTPException
+
+
+def get_supabase_client():
+    """Return a configured Supabase client or raise if unavailable."""
+    try:
+        from supabase import create_client
+    except ImportError as e:  # pragma: no cover - optional
+        raise RuntimeError("supabase client library not installed") from e
+    import os
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+    if not url or not key:
+        raise RuntimeError("Supabase credentials not configured")
+    return create_client(url, key)
+
+
+router = APIRouter(prefix="/api/legal", tags=["legal"])
+
+
+@router.get("/documents")
+async def list_documents():
+    """Return available legal documents sorted by display order."""
+    supabase = get_supabase_client()
+    try:
+        res = (
+            supabase.table("legal_documents")
+            .select("id,title,summary,url,display_order")
+            .order("display_order")
+            .execute()
+        )
+    except Exception as e:  # pragma: no cover - network/db errors
+        raise HTTPException(status_code=500, detail="Failed to fetch documents") from e
+
+    rows = getattr(res, "data", res) or []
+    docs = [
+        {
+            "id": r.get("id"),
+            "title": r.get("title"),
+            "summary": r.get("summary"),
+            "url": r.get("url"),
+        }
+        for r in rows
+    ]
+    return {"documents": docs}

--- a/legal.html
+++ b/legal.html
@@ -66,63 +66,10 @@ Author: Deathsgift66
     <h2>Legal Documents</h2>
     <p>View the complete legal documents for Kingmaker’s Rise. All players must comply with these terms to participate in the game.</p>
 
-    <div class="legal-card-grid">
-
-      <div class="legal-card">
-        <h3>Privacy Policy</h3>
-        <p>How we collect, use, and protect your data.</p>
-        <a href="Assets/legal/PrivacyPolicy.pdf" target="_blank">View Document</a>
-      </div>
-
-      <div class="legal-card">
-        <h3>Terms of Service</h3>
-        <p>The rules governing the use of Kingmaker’s Rise.</p>
-        <a href="Assets/legal/TermsOfService.pdf" target="_blank">View Document</a>
-      </div>
-
-      <div class="legal-card">
-        <h3>End User License Agreement (EULA)</h3>
-        <p>The licensing terms for using Kingmaker’s Rise.</p>
-        <a href="Assets/legal/EULA.pdf" target="_blank">View Document</a>
-      </div>
-
-      <div class="legal-card">
-        <h3>Data Processing Addendum (DPA)</h3>
-        <p>Additional privacy terms for data processing and compliance.</p>
-        <a href="Assets/legal/KingmakersRise_DPA.pdf" target="_blank">View Document</a>
-      </div>
-
-      <div class="legal-card">
-        <h3>Cookie Policy</h3>
-        <p>How we use cookies and tracking technologies.</p>
-        <a href="Assets/legal/CookiePolicy.pdf" target="_blank">View Document</a>
-      </div>
-
-      <div class="legal-card">
-        <h3>Game Rules</h3>
-        <p>Core game rules for fair and balanced play.</p>
-        <a href="Assets/legal/GameRules.pdf" target="_blank">View Document</a>
-      </div>
-
-      <div class="legal-card">
-        <h3>Refund Policy</h3>
-        <p>Our policy regarding refund requests and eligibility.</p>
-        <a href="Assets/legal/RefundPolicy.pdf" target="_blank">View Document</a>
-      </div>
-
-      <div class="legal-card">
-        <h3>Terms of Sale</h3>
-        <p>Terms covering all in-game purchases and sales.</p>
-        <a href="Assets/legal/TermsOfSale.pdf" target="_blank">View Document</a>
-      </div>
-
-      <div class="legal-card">
-        <h3>Accessibility Statement</h3>
-        <p>Our commitment to accessibility for all players.</p>
-        <a href="Assets/legal/AccessibilityStatement.pdf" target="_blank">View Document</a>
-      </div>
-
+    <div id="search-container">
+      <input id="doc-search" type="text" placeholder="Search documents..." />
     </div>
+    <div id="legal-docs" class="legal-card-grid"></div>
 
   </section>
 
@@ -138,6 +85,8 @@ Author: Deathsgift66
     <a href="legal.html">and more</a>
   </div>
 </footer>
+
+<script type="module" src="Javascript/legal.js"></script>
 
 </body>
 </html>

--- a/tests/test_legal_router.py
+++ b/tests/test_legal_router.py
@@ -1,0 +1,36 @@
+from backend.routers import legal
+
+
+class DummyTable:
+    def __init__(self, data=None):
+        self._data = data or []
+        self._ordered = self._data
+
+    def select(self, *_args):
+        return self
+
+    def order(self, *_args, **_kwargs):
+        self._ordered = sorted(self._data, key=lambda x: x.get("display_order", 0))
+        return self
+
+    def execute(self):
+        return {"data": self._ordered}
+
+
+class DummyClient:
+    def __init__(self, tables):
+        self.tables = tables
+
+    def table(self, name):
+        return DummyTable(self.tables.get(name, []))
+
+
+def test_returns_sorted_docs():
+    docs = [
+        {"id": 2, "title": "B", "summary": "s", "url": "u", "display_order": 2},
+        {"id": 1, "title": "A", "summary": "s", "url": "u", "display_order": 1},
+    ]
+    legal.get_supabase_client = lambda: DummyClient({"legal_documents": docs})
+    result = legal.list_documents()
+    assert result["documents"][0]["id"] == 1
+    assert len(result["documents"]) == 2


### PR DESCRIPTION
## Summary
- create FastAPI router for legal documents
- connect router in backend
- add legal document search field and dynamic JS
- load docs from API and update realtime
- style search input
- test legal router

## Testing
- `pytest tests/test_legal_router.py -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6848696459c88330a322a6c3f4bdd1d4