### PR TITLE
Improve message page with realtime backend

### DIFF
--- a/CSS/message.css
+++ b/CSS/message.css
@@ -28,6 +28,62 @@ body {
   align-items: center;
 }
 
+/* Message layout */
+.message-container {
+  background: var(--dark-panel);
+  border: var(--border);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow);
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 700px;
+}
+
+.message-meta {
+  font-family: var(--font-primary);
+  margin-bottom: 1rem;
+  color: var(--text-on-dark);
+  font-size: var(--font-sm);
+}
+
+.message-body {
+  font-family: var(--font-body);
+  font-size: var(--font-md);
+  margin-bottom: 1.5rem;
+  white-space: pre-wrap;
+}
+
+.message-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.action-btn {
+  background: var(--accent);
+  color: var(--btn-text);
+  padding: var(--btn-padding);
+  border: var(--btn-border);
+  border-radius: var(--btn-radius);
+  cursor: pointer;
+  font-family: var(--font-primary);
+  transition: background var(--transition-medium), color var(--transition-medium);
+}
+
+.action-btn:hover {
+  background: var(--btn-hover-bg);
+  color: var(--btn-hover-text);
+}
+
+@media (max-width: 600px) {
+  .main-centered-container {
+    padding: 1rem;
+  }
+  .message-container {
+    padding: 1rem;
+  }
+}
+
 /* Customization Section */
 .alliance-customization-area {
   background: rgba(0, 0, 0, 0.45);

--- a/Javascript/messages.js
+++ b/Javascript/messages.js
@@ -16,59 +16,61 @@ document.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
+  const { user } = session;
+  const accessToken = session.access_token;
+
   // ✅ Determine page
   if (document.getElementById("message-list")) {
-    // Inbox page
-    await loadInbox();
+    await loadInbox(user, accessToken);
+    subscribeToMessages(user.id, () => loadInbox(user, accessToken));
   } else if (document.getElementById("message-container")) {
-    // Message view page
     const urlParams = new URLSearchParams(window.location.search);
     const messageId = urlParams.get("message_id");
     if (messageId) {
-      await loadMessageView(messageId);
+      await loadMessageView(messageId, user, accessToken);
+      subscribeToMessages(user.id, (payload) => {
+        if (payload.new.message_id === parseInt(messageId)) {
+          loadMessageView(messageId, user, accessToken);
+        }
+      });
     } else {
       document.getElementById("message-container").innerHTML = "<p>Invalid message.</p>";
     }
   } else if (document.getElementById("compose-form")) {
-    // Compose page
-    setupCompose();
+    setupCompose(user, accessToken);
   }
 });
 
 // ✅ Load Inbox
-async function loadInbox() {
+async function loadInbox(user, token) {
   const container = document.getElementById("message-list");
   container.innerHTML = "<p>Loading messages...</p>";
 
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-
-    // ✅ JOIN with users table for sender name
-    const { data, error } = await supabase
-      .from("player_messages")
-      .select("message_id, subject, message, sent_at, is_read, users(username)")
-      .eq("recipient_id", user.id)
-      .eq("deleted_by_recipient", false)
-      .order("sent_at", { ascending: false })
-      .limit(100);
-
-    if (error) throw error;
+    const res = await fetch('/api/messages/list', {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'X-User-ID': user.id
+      }
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || 'Error');
 
     container.innerHTML = "";
 
-    if (!data || data.length === 0) {
+    if (!data.messages || data.messages.length === 0) {
       container.innerHTML = "<p>No messages found.</p>";
       return;
     }
 
-    data.forEach(msg => {
+    data.messages.forEach(msg => {
       const card = document.createElement("div");
       card.classList.add("message-card");
 
       card.innerHTML = `
         <a href="message.html?message_id=${msg.message_id}">
           <div class="message-meta">
-            <span>From: ${escapeHTML(msg.users?.username || "Unknown")}</span>
+            <span>From: ${escapeHTML(msg.username || "Unknown")}</span>
             <span>${formatDate(msg.sent_at)}</span>
           </div>
           <div class="message-subject">${escapeHTML((msg.subject || msg.message).substring(0, 50))}</div>
@@ -85,34 +87,23 @@ async function loadInbox() {
 }
 
 // ✅ Load Message View
-async function loadMessageView(messageId) {
+async function loadMessageView(messageId, user, token) {
   const container = document.getElementById("message-container");
   container.innerHTML = "<p>Loading message...</p>";
 
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-
-    // ✅ JOIN with users table for sender name
-    const { data, error } = await supabase
-      .from("player_messages")
-      .select("message_id, subject, message, sent_at, is_read, user_id, deleted_by_recipient, users(username)")
-      .eq("message_id", messageId)
-      .eq("recipient_id", user.id)
-      .single();
-
-    if (error || !data) {
-      throw new Error("Message not found or access denied.");
-    }
-
-    // ✅ Mark as read
-    await supabase
-      .from("player_messages")
-      .update({ is_read: true })
-      .eq("message_id", messageId);
+    const res = await fetch(`/api/messages/${messageId}`, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'X-User-ID': user.id
+      }
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || 'Error');
 
     container.innerHTML = `
       <div class="message-meta">
-        <strong>From:</strong> ${escapeHTML(data.users?.username || "Unknown")}
+        <strong>From:</strong> ${escapeHTML(data.username || "Unknown")}
         <br>
         <strong>Date:</strong> ${formatDate(data.sent_at)}
       </div>
@@ -132,13 +123,16 @@ async function loadMessageView(messageId) {
       if (!confirm("Are you sure you want to delete this message?")) return;
 
       try {
-        const { error: deleteError } = await supabase
-          .from("player_messages")
-          .update({ deleted_by_recipient: true })
-          .eq("message_id", messageId)
-          .eq("recipient_id", user.id);
-
-        if (deleteError) throw deleteError;
+        const resp = await fetch('/api/messages/delete', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`,
+            'X-User-ID': user.id
+          },
+          body: JSON.stringify({ message_id: messageId })
+        });
+        if (!resp.ok) throw new Error();
 
         alert("Message deleted.");
         window.location.href = "messages.html";
@@ -160,7 +154,7 @@ async function loadMessageView(messageId) {
 }
 
 // ✅ Setup Compose
-function setupCompose() {
+function setupCompose(user, token) {
   const composeForm = document.getElementById("compose-form");
 
   // ✅ If replying to someone
@@ -185,31 +179,16 @@ function setupCompose() {
     }
 
     try {
-      const { data: { user } } = await supabase.auth.getUser();
-
-      // ✅ Look up recipient user_id
-      const { data: recipientData, error: recipientError } = await supabase
-        .from("users")
-        .select("user_id")
-        .eq("username", recipient)
-        .single();
-
-      if (recipientError || !recipientData) {
-        throw new Error("Recipient not found.");
-      }
-
-      const { error: sendError } = await supabase
-        .from("player_messages")
-        .insert({
-          recipient_id: recipientData.user_id,
-          user_id: user.id,
-          subject: subject || null,
-          message: messageContent,
-          sent_at: new Date().toISOString(),
-          is_read: false
-        });
-
-      if (sendError) throw sendError;
+      const res = await fetch('/api/messages/send', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+          'X-User-ID': user.id
+        },
+        body: JSON.stringify({ recipient, subject, content: messageContent })
+      });
+      if (!res.ok) throw new Error();
 
       alert("Message sent!");
       window.location.href = "messages.html";
@@ -240,4 +219,16 @@ function escapeHTML(str) {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#039;");
+}
+
+// ✅ Real-time subscription
+function subscribeToMessages(userId, callback) {
+  supabase
+    .channel('messages:' + userId)
+    .on(
+      'postgres_changes',
+      { event: 'INSERT', schema: 'public', table: 'player_messages', filter: `recipient_id=eq.${userId}` },
+      payload => callback(payload)
+    )
+    .subscribe();
 }

--- a/backend/routers/messages.py
+++ b/backend/routers/messages.py
@@ -1,10 +1,21 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Header
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import func
+
 from ..database import get_db
 from ..models import User, PlayerMessage
+from ..security import verify_jwt_token
 
 router = APIRouter(prefix="/api/messages", tags=["messages"])
+
+
+def get_current_user_id(
+    authorization: str | None = Header(None),
+    x_user_id: str | None = Header(None),
+) -> str:
+    """Authenticate user via JWT headers."""
+    return verify_jwt_token(authorization, x_user_id)
 
 
 class MessagePayload(BaseModel):
@@ -15,13 +26,17 @@ class MessagePayload(BaseModel):
 
 
 @router.post("/send")
-def send_message(payload: MessagePayload, db: Session = Depends(get_db)):
+def send_message(
+    payload: MessagePayload,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+):
     recipient = db.query(User).filter(User.username == payload.recipient).first()
     if not recipient:
         raise HTTPException(status_code=404, detail="Recipient not found")
     message = PlayerMessage(
         recipient_id=recipient.user_id,
-        user_id=payload.sender_id,
+        user_id=user_id,
         subject=payload.subject,
         message=payload.content,
     )
@@ -29,4 +44,85 @@ def send_message(payload: MessagePayload, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(message)
     return {"message": "sent", "message_id": message.message_id}
+
+
+@router.get("/list")
+def list_messages(
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+):
+    rows = (
+        db.query(PlayerMessage, User.username)
+        .join(User, PlayerMessage.user_id == User.user_id)
+        .filter(PlayerMessage.recipient_id == user_id)
+        .filter(PlayerMessage.deleted_by_recipient.is_(False))
+        .order_by(PlayerMessage.sent_at.desc())
+        .all()
+    )
+    return {
+        "messages": [
+            {
+                "message_id": m.message_id,
+                "subject": m.subject,
+                "message": m.message,
+                "sent_at": m.sent_at,
+                "is_read": m.is_read,
+                "user_id": m.user_id,
+                "username": u,
+            }
+            for m, u in rows
+        ]
+    }
+
+
+class DeletePayload(BaseModel):
+    message_id: int
+
+
+@router.post("/delete")
+def delete_message(
+    payload: DeletePayload,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+):
+    msg = (
+        db.query(PlayerMessage)
+        .filter(PlayerMessage.message_id == payload.message_id,
+                PlayerMessage.recipient_id == user_id)
+        .first()
+    )
+    if not msg:
+        raise HTTPException(status_code=404, detail="Message not found")
+    msg.deleted_by_recipient = True
+    db.commit()
+    return {"status": "deleted"}
+
+
+@router.get("/{message_id}")
+def get_message(
+    message_id: int,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+):
+    row = (
+        db.query(PlayerMessage, User.username)
+        .join(User, PlayerMessage.user_id == User.user_id)
+        .filter(PlayerMessage.message_id == message_id,
+                PlayerMessage.recipient_id == user_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Message not found")
+    msg, username = row
+    msg.is_read = True
+    msg.last_updated = func.now()
+    db.commit()
+    return {
+        "message_id": msg.message_id,
+        "subject": msg.subject,
+        "message": msg.message,
+        "sent_at": msg.sent_at,
+        "user_id": msg.user_id,
+        "username": username,
+    }
 

--- a/message.html
+++ b/message.html
@@ -65,6 +65,9 @@ Author: Deathsgift66
     <div class="message-container" id="message-container">
       <!-- JS will populate message details -->
     </div>
+    <div class="message-actions">
+      <a href="messages.html" class="action-btn">Back to Inbox</a>
+    </div>
 
   </section>
 

--- a/tests/test_messages_router.py
+++ b/tests/test_messages_router.py
@@ -1,0 +1,48 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import uuid
+
+from backend.database import Base
+from backend.models import User, PlayerMessage
+from backend.routers.messages import (
+    send_message,
+    list_messages,
+    get_message,
+    delete_message,
+    MessagePayload,
+    DeletePayload,
+)
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+def create_user(db, username="u1"):
+    uid = str(uuid.uuid4())
+    user = User(user_id=uid, username=username, display_name=username, email=f"{username}@e.com")
+    db.add(user)
+    db.commit()
+    return uid
+
+def test_full_message_flow():
+    Session = setup_db()
+    db = Session()
+    sender = create_user(db, "sender")
+    recipient = create_user(db, "rec")
+
+    send_message(MessagePayload(recipient="rec", subject="Hi", content="Hello"), user_id=sender, db=db)
+    res = list_messages(user_id=recipient, db=db)
+    assert len(res["messages"]) == 1
+    mid = res["messages"][0]["message_id"]
+
+    detail = get_message(mid, user_id=recipient, db=db)
+    assert detail["subject"] == "Hi"
+
+    msg = db.query(PlayerMessage).get(mid)
+    assert msg.is_read
+
+    delete_message(DeletePayload(message_id=mid), user_id=recipient, db=db)
+    assert msg.deleted_by_recipient
+


### PR DESCRIPTION
## Summary
- style message page with immersive medieval look
- add button to return to inbox
- implement real-time subscription and API usage in messages.js
- secure new FastAPI routes for listing, viewing, sending, and deleting messages
- cover message API flow with tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6848698a155c8330be76c734e6244691