### PR TITLE
Enhance login page with announcements and new API

### DIFF
--- a/CSS/login.css
+++ b/CSS/login.css
@@ -193,3 +193,33 @@ body {
     padding: 1.5rem;
   }
 }
+
+/* Announcements */
+.announcements {
+  background: rgba(251, 240, 217, 0.85);
+  border: 2px solid var(--gold);
+  border-radius: 12px;
+  margin: 2rem auto;
+  max-width: 600px;
+  padding: 1rem 1.5rem;
+  color: var(--ink);
+}
+
+.announcements-title {
+  font-family: 'Cinzel', serif;
+  color: var(--gold);
+  margin-bottom: 0.5rem;
+  text-align: center;
+}
+
+.announcement-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.announcement-list li {
+  border-bottom: 1px solid var(--gold);
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -23,6 +23,7 @@ let modal;
 let closeBtn;
 let sendResetBtn;
 let forgotMessage;
+let announcementList;
 
 document.addEventListener('DOMContentLoaded', () => {
   loginForm = document.getElementById('login-form');
@@ -30,6 +31,8 @@ document.addEventListener('DOMContentLoaded', () => {
   passwordInput = document.getElementById('password');
   loginButton = document.querySelector('#login-form .royal-button');
   messageContainer = document.getElementById('message');
+
+  announcementList = document.getElementById('announcement-list');
 
   forgotLink = document.querySelector('.account-links a[href="forgot_password.html"]');
   modal = document.getElementById('forgot-password-modal');
@@ -58,6 +61,8 @@ document.addEventListener('DOMContentLoaded', () => {
   if (loginForm) {
     loginForm.addEventListener('submit', handleLogin);
   }
+
+  loadAnnouncements();
 });
 
 async function handleLogin(e) {
@@ -150,4 +155,20 @@ function showMessage(type, text) {
     messageContainer.classList.remove('show');
     messageContainer.textContent = '';
   }, 5000);
+}
+
+async function loadAnnouncements() {
+  if (!announcementList) return;
+  try {
+    const res = await fetch('/api/login/announcements');
+    if (!res.ok) return;
+    const data = await res.json();
+    data.announcements.forEach((a) => {
+      const li = document.createElement('li');
+      li.textContent = `${a.title} - ${a.content}`;
+      announcementList.appendChild(li);
+    });
+  } catch (err) {
+    console.error('Failed to load announcements', err);
+  }
 }

--- a/backend/main.py
+++ b/backend/main.py
@@ -49,6 +49,7 @@ from .routers import (
     projects_router,
     kingdom_history,
     kingdom_achievements,
+    login_routes,
 )
 from .database import engine
 from .models import Base
@@ -110,4 +111,5 @@ app.include_router(projects_router.router)
 app.include_router(kingdom_history.router)
 app.include_router(forgot_password.router)
 app.include_router(kingdom_achievements.router)
+app.include_router(login_routes.router)
 

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -1,0 +1,67 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..security import verify_jwt_token
+from services.audit_service import log_action
+
+
+def get_supabase_client():
+    """Return configured Supabase client or raise."""
+    try:
+        from supabase import create_client
+    except ImportError as e:  # pragma: no cover - optional
+        raise RuntimeError("supabase client library not installed") from e
+    import os
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+    if not url or not key:
+        raise RuntimeError("Supabase credentials not configured")
+    return create_client(url, key)
+
+
+router = APIRouter(prefix="/api/login", tags=["login"])
+
+
+@router.get("/announcements")
+async def get_announcements():
+    """Return recent login announcements."""
+    supabase = get_supabase_client()
+    try:
+        res = (
+            supabase.table("login_announcements")
+            .select("id,title,content,created_at")
+            .order("created_at", desc=True)
+            .limit(5)
+            .execute()
+        )
+    except Exception as e:  # pragma: no cover - network/db errors
+        raise HTTPException(status_code=500, detail="Failed to fetch announcements") from e
+
+    rows = getattr(res, "data", res) or []
+    data = [
+        {
+            "id": r.get("id"),
+            "title": r.get("title"),
+            "content": r.get("content"),
+            "created_at": r.get("created_at"),
+        }
+        for r in rows
+    ]
+    return {"announcements": data}
+
+
+class EventPayload(BaseModel):
+    event: str
+
+
+@router.post("/event")
+async def log_login_event(
+    payload: EventPayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Record a login related event for auditing."""
+    log_action(db, user_id, "login_event", payload.event)
+    return {"message": "event logged"}

--- a/login.html
+++ b/login.html
@@ -55,13 +55,19 @@ Author: Deathsgift66
   </form>
 
   <div class="account-links">
-    <a href="signup.html">Create Account</a> | 
+    <a href="signup.html">Create Account</a> |
     <a href="forgot_password.html">Forgot Password?</a>
   </div>
 
   <div id="message" class="message"></div>
 
 </div>
+
+<!-- Announcements -->
+<section id="announcements" class="announcements">
+  <h2 class="announcements-title">Town Crier</h2>
+  <ul id="announcement-list" class="announcement-list"></ul>
+</section>
 
 <!-- Forgot Password Modal -->
 <div id="forgot-password-modal" class="modal hidden">

--- a/tests/test_login_router.py
+++ b/tests/test_login_router.py
@@ -1,0 +1,28 @@
+import asyncio
+from backend.routers import login_routes
+
+class DummyTable:
+    def __init__(self, data=None):
+        self._data = data or []
+    def select(self, *args):
+        return self
+    def order(self, *args, **kwargs):
+        return self
+    def limit(self, *args):
+        return self
+    def execute(self):
+        return {"data": self._data}
+
+class DummyClient:
+    def __init__(self, tables):
+        self.tables = tables
+    def table(self, name):
+        return DummyTable(self.tables.get(name, []))
+
+def test_announcements_returned():
+    rows = [
+        {"id": 1, "title": "Welcome", "content": "Greetings", "created_at": "2025-01-01"}
+    ]
+    login_routes.get_supabase_client = lambda: DummyClient({"login_announcements": rows})
+    result = asyncio.run(login_routes.get_announcements())
+    assert result["announcements"][0]["title"] == "Welcome"


### PR DESCRIPTION
## Summary
- add Town Crier announcements to `login.html`
- style announcement widget in `login.css`
- load announcements dynamically from JS
- provide `/api/login` backend router for announcements and event logging
- register new router in `backend/main.py`
- add unit test for announcements API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6848696c7e488330b2e24a383952c1b9