### PR TITLE
Enhance play page onboarding and secure route

### DIFF
--- a/CSS/play.css
+++ b/CSS/play.css
@@ -195,6 +195,21 @@ body {
   cursor: not-allowed;
 }
 
+.image-preview-row {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.image-preview-row img {
+  max-width: 120px;
+  max-height: 80px;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid var(--gold);
+}
+
 #continue-btn {
   padding: 0.7rem 1.5rem;
   font-size: 1rem;
@@ -226,4 +241,19 @@ body {
 
 .toast-notification.show {
   opacity: 1;
+}
+
+.announcements-container {
+  margin-top: 2rem;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 1rem;
+  border: 1px solid var(--gold);
+  border-radius: 12px;
+  width: 100%;
+  max-width: 600px;
+}
+
+.announcement h4 {
+  margin-bottom: 0.25rem;
+  color: var(--gold);
 }

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -10,6 +10,7 @@ from ..services.research_service import start_research as db_start_research
 from ..services.kingdom_quest_service import start_quest as db_start_quest
 from ..services.kingdom_setup_service import create_kingdom_transaction
 from .progression_router import get_user_id
+from ..security import verify_jwt_token
 
 router = APIRouter(prefix="/api/kingdom", tags=["kingdom"])
 
@@ -48,7 +49,7 @@ class KingdomCreatePayload(BaseModel):
 @router.post("/create")
 def create_kingdom(
     payload: KingdomCreatePayload,
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),
 ):
     try:

--- a/play.html
+++ b/play.html
@@ -69,9 +69,14 @@ Author: Deathsgift66
         <input type="text" id="village-name-input" placeholder="Starting Village Name" />
         <input type="text" id="banner-image-input" placeholder="Banner Image URL (optional)" />
         <input type="text" id="emblem-image-input" placeholder="Emblem Image URL (optional)" />
+        <div class="image-preview-row">
+          <img id="banner-preview" alt="Banner Preview" />
+          <img id="emblem-preview" alt="Emblem Preview" />
+        </div>
         <textarea id="motto-input" placeholder="Motto or Flavor Text"></textarea>
-        <button id="create-kingdom-btn">Create Kingdom</button>
+        <button id="create-kingdom-btn" class="btn">Create Kingdom</button>
       </div>
+      <section id="announcements" class="announcements-container"></section>
     </section>
     <div id="toast" class="toast-notification"></div>
   </main>


### PR DESCRIPTION
## Summary
- add banner/emblem preview and announcements section in `play.html`
- style new preview row and announcement panel in `play.css`
- update `play.js` with real-time image preview, announcement loading and token-based requests
- secure `/api/kingdom/create` with JWT verification

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68486c4caf9c83309f3b11dc612fa435