### PR TITLE
Enhance spies UI and backend

### DIFF
--- a/CSS/spies.css
+++ b/CSS/spies.css
@@ -1,0 +1,63 @@
+/*
+Project Name: Kingmakers Rise Frontend
+File Name: spies.css
+Date: June 2, 2025
+Author: Deathsgift66
+*/
+@import url("./root_theme.css");
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: url('../Assets/train_troops_background.png') no-repeat center center fixed, var(--stone-bg);
+  background-size: cover;
+  color: var(--parchment);
+}
+
+.main-centered-container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--padding-lg);
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-default);
+  box-sizing: border-box;
+}
+
+.spy-panel {
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+  border: 1px solid var(--gold);
+  border-radius: var(--border-radius);
+  padding: var(--padding-md);
+  box-shadow: 0 4px 12px var(--shadow);
+}
+
+.spy-panel h2 {
+  font-family: var(--font-header);
+  color: var(--gold);
+  margin-top: 0;
+}
+
+#realtime-indicator {
+  font-size: var(--font-sm);
+  font-family: var(--font-body);
+  color: var(--text-highlight);
+}
+
+#realtime-indicator.connected { color: var(--success); }
+#realtime-indicator.disconnected { color: var(--error); }
+
+@media (max-width: 700px) {
+  .main-centered-container {
+    padding: var(--padding-md);
+  }
+  .spy-panel {
+    padding: var(--padding-sm);
+  }
+}

--- a/Javascript/spies.js
+++ b/Javascript/spies.js
@@ -1,16 +1,31 @@
 import { supabase } from './supabaseClient.js';
 
+let currentUserId = null;
+let realtimeChannel = null;
+
 document.addEventListener('DOMContentLoaded', async () => {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) {
+    window.location.href = 'login.html';
+    return;
+  }
+  currentUserId = session.user.id;
+
+  const trainBtn = document.getElementById('train-btn');
+  if (trainBtn) trainBtn.addEventListener('click', trainSpies);
+
   await loadSpies();
   await loadMissions();
+  subscribeRealtime();
 });
 
 async function loadSpies() {
   const infoEl = document.getElementById('spy-info');
   infoEl.textContent = 'Loading...';
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-    const res = await fetch('/api/kingdom/spies', { headers: { 'X-User-ID': user.id } });
+    const res = await fetch('/api/kingdom/spies', {
+      headers: { 'X-User-ID': currentUserId }
+    });
     const data = await res.json();
     infoEl.innerHTML = `
       <div>Spy Level: ${data.spy_level}</div>
@@ -30,8 +45,9 @@ async function loadMissions() {
   const listEl = document.getElementById('missions');
   listEl.textContent = 'Loading missions...';
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-    const res = await fetch('/api/kingdom/spy_missions', { headers: { 'X-User-ID': user.id } });
+    const res = await fetch('/api/kingdom/spy_missions', {
+      headers: { 'X-User-ID': currentUserId }
+    });
     const data = await res.json();
     listEl.innerHTML = '';
     (data.missions || []).forEach(m => {
@@ -43,4 +59,44 @@ async function loadMissions() {
   } catch (e) {
     listEl.textContent = 'Failed to load missions';
   }
+}
+
+async function trainSpies() {
+  const qty = parseInt(document.getElementById('train-qty').value, 10);
+  if (!qty) return;
+  const res = await fetch('/api/kingdom/spies/train', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-User-ID': currentUserId
+    },
+    body: JSON.stringify({ quantity: qty })
+  });
+  if (res.ok) {
+    document.getElementById('train-qty').value = '';
+    await loadSpies();
+  }
+}
+
+function subscribeRealtime() {
+  realtimeChannel = supabase
+    .channel('spies-' + currentUserId)
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'spy_missions', filter: `kingdom_id=eq.${currentUserId}` }, loadMissions)
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'kingdom_spies', filter: `kingdom_id=eq.${currentUserId}` }, loadSpies)
+    .subscribe(status => {
+      const indicator = document.getElementById('realtime-indicator');
+      if (indicator) {
+        if (status === 'SUBSCRIBED') {
+          indicator.textContent = 'Live';
+          indicator.className = 'connected';
+        } else {
+          indicator.textContent = 'Offline';
+          indicator.className = 'disconnected';
+        }
+      }
+    });
+
+  window.addEventListener('beforeunload', () => {
+    if (realtimeChannel) supabase.removeChannel(realtimeChannel);
+  });
 }

--- a/backend/routers/navbar.py
+++ b/backend/routers/navbar.py
@@ -30,9 +30,12 @@ def navbar_profile(user_id: str = Depends(verify_jwt_token)):
         .single()
         .execute()
     )
-    user = getattr(user_res, "data", user_res)
-    if not user:
+    result = getattr(user_res, "data", None)
+    if result is None and isinstance(user_res, dict):
+        result = user_res.get("data")
+    if not result:
         raise HTTPException(status_code=404, detail="User not found")
+    user = result
 
     msg_res = (
         supabase.table("player_messages")

--- a/backend/routers/spies_router.py
+++ b/backend/routers/spies_router.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from ..database import get_db
-from .progression_router import get_user_id, get_kingdom_id
+from .progression_router import get_kingdom_id
+from ..security import verify_jwt_token
 from services import spies_service
 
 router = APIRouter(prefix="/api/kingdom", tags=["spies"])
@@ -17,7 +18,7 @@ class TrainPayload(BaseModel):
     quantity: int
 
 @router.get("/spies")
-async def get_spy_info(user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+async def get_spy_info(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     return spies_service.get_spy_record(db, kid)
 
@@ -25,7 +26,7 @@ async def get_spy_info(user_id: str = Depends(get_user_id), db: Session = Depend
 @router.post("/spies/train")
 async def train_spies(
     payload: TrainPayload,
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),
 ):
     kid = get_kingdom_id(db, user_id)
@@ -35,7 +36,7 @@ async def train_spies(
 @router.post("/spy_missions")
 async def launch_spy_mission(
     payload: SpyMissionPayload,
-    user_id: str = Depends(get_user_id),
+    user_id: str = Depends(verify_jwt_token),
     db: Session = Depends(get_db),
 ):
     kid = get_kingdom_id(db, user_id)
@@ -45,7 +46,7 @@ async def launch_spy_mission(
     return {"message": "Mission launched", "mission_id": mission_id}
 
 @router.get("/spy_missions")
-async def list_spy_missions(user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+async def list_spy_missions(user_id: str = Depends(verify_jwt_token), db: Session = Depends(get_db)):
     kid = get_kingdom_id(db, user_id)
     missions = spies_service.list_spy_missions(db, kid)
     return {"missions": missions}

--- a/spies.html
+++ b/spies.html
@@ -6,6 +6,7 @@
   <title>Spies | Kingmaker's Rise</title>
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
+  <link rel="stylesheet" href="CSS/spies.css" />
   <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/spies.js"></script>
@@ -15,9 +16,17 @@
 <script>fetch('navbar.html').then(r=>r.text()).then(h=>{document.getElementById('navbar-container').innerHTML=h});</script>
 <header class="kr-top-banner">Spies</header>
 <main class="main-centered-container" aria-label="Spy Interface">
-  <section class="alliance-members-container">
-    <h2>Your Spy Network</h2>
+  <section class="spy-panel">
+    <h2>Your Spy Network <span id="realtime-indicator" aria-live="polite">Connecting...</span></h2>
     <div id="spy-info"></div>
+    <div class="train-controls">
+      <input type="number" id="train-qty" min="1" placeholder="Train amount" />
+      <button id="train-btn" class="btn">Train</button>
+    </div>
+  </section>
+
+  <section class="spy-panel">
+    <h2>Active Missions</h2>
     <div id="missions"></div>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- create dedicated medieval theme CSS for spies page
- implement responsive spies HTML layout with realtime indicator
- add training controls and Supabase realtime logic in spies.js
- secure spies API routes with JWT token verification
- patch navbar profile route to handle dict-based responses

## Testing
- `PYTHONPATH=. pytest -q tests/test_navbar_router.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError for supabase etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6848708ffc3c83308d55be33f3ce5517