### PR TITLE
Improve training troops page with backend queue

### DIFF
--- a/CSS/train_troops.css
+++ b/CSS/train_troops.css
@@ -191,3 +191,17 @@ body {
 .site-footer a:hover {
   color: var(--gold);
 }
+
+@media (max-width: 800px) {
+  .main-content {
+    flex-direction: column;
+  }
+  .toggle-section {
+    grid-template-columns: 1fr;
+  }
+  .controls-bar {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -44,6 +44,7 @@ from .routers import (
     legal,
     trade_logs,
     training_history,
+    training_queue,
     village_modifiers,
     settings_router,
     alliance_home,
@@ -109,6 +110,7 @@ app.include_router(progression_router.router)
 app.include_router(policies_laws_router.router)
 app.include_router(trade_logs.router)
 app.include_router(training_history.router)
+app.include_router(training_queue.router)
 app.include_router(village_modifiers.router)
 app.include_router(settings_router.router)
 app.include_router(alliance_home.router)

--- a/backend/routers/training_queue.py
+++ b/backend/routers/training_queue.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..security import verify_jwt_token
+from ..database import get_db
+from .progression_router import get_kingdom_id
+from services.training_queue_service import add_training_order, fetch_queue
+
+router = APIRouter(prefix="/api/training_queue", tags=["training_queue"])
+
+
+class TrainOrderPayload(BaseModel):
+    unit_id: int
+    unit_name: str
+    quantity: int
+    base_training_seconds: int = 60
+
+
+@router.post("/start")
+def start_training(
+    payload: TrainOrderPayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    kid = get_kingdom_id(db, user_id)
+    qid = add_training_order(
+        db,
+        kingdom_id=kid,
+        unit_id=payload.unit_id,
+        unit_name=payload.unit_name,
+        quantity=payload.quantity,
+        base_training_seconds=payload.base_training_seconds,
+    )
+    return {"queue_id": qid}
+
+
+@router.get("")
+def list_queue(
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    kid = get_kingdom_id(db, user_id)
+    rows = fetch_queue(db, kid)
+    return {"queue": rows}
+

--- a/tests/test_training_queue_router.py
+++ b/tests/test_training_queue_router.py
@@ -1,0 +1,45 @@
+from backend.routers.training_queue import start_training, list_queue, TrainOrderPayload
+
+class DummyResult:
+    def __init__(self, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+    def fetchone(self):
+        return self._row
+    def fetchall(self):
+        return self._rows
+    def scalar(self):
+        return self._row[0] if self._row else None
+
+class DummyDB:
+    def __init__(self):
+        self.executed = []
+        self.rows = []
+    def execute(self, query, params=None):
+        q = str(query)
+        self.executed.append((q, params))
+        if "FROM kingdoms" in q:
+            return DummyResult((1,))
+        if q.strip().startswith("INSERT INTO training_queue"):
+            return DummyResult((5,))
+        if "FROM training_queue" in q:
+            return DummyResult(rows=self.rows)
+        return DummyResult()
+    def commit(self):
+        pass
+
+
+def test_start_training_returns_id():
+    db = DummyDB()
+    payload = TrainOrderPayload(unit_id=2, unit_name="Archer", quantity=5, base_training_seconds=60)
+    res = start_training(payload, user_id="u1", db=db)
+    assert res["queue_id"] == 5
+
+
+def test_list_queue_returns_rows():
+    db = DummyDB()
+    db.rows = [(1, "Knight", 10, "2025-06-10", "queued")]
+    res = list_queue(user_id="u1", db=db)
+    assert len(res["queue"]) == 1
+    assert res["queue"][0]["unit_name"] == "Knight"
+


### PR DESCRIPTION
## Summary
- add new `/api/training_queue` backend with secure start/list endpoints
- register the router with the API
- enhance Grand Muster Hall JS for live updates and new API
- make training troops CSS responsive
- test training queue router

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*
- `pytest -q` *(fails to collect tests due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684870c0bf6083309e1287420275f519