### PR TITLE
Enhance treaty web page with realtime backend API

### DIFF
--- a/CSS/treaty_web.css
+++ b/CSS/treaty_web.css
@@ -121,3 +121,25 @@ body {
   color: #1a1a1a;
 }
 
+.legend-panel {
+  position: fixed;
+  top: 4rem;
+  right: 1rem;
+  background: rgba(251, 240, 217, 0.95);
+  border: 3px solid var(--gold);
+  border-radius: 12px;
+  box-shadow: 0 4px 12px var(--shadow);
+  padding: 1rem;
+  color: var(--ink);
+  z-index: var(--z-index-modal);
+}
+
+@media (max-width: 600px) {
+  .treaty-controls {
+    flex-direction: column;
+  }
+  .network-area {
+    height: 400px;
+  }
+}
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -56,6 +56,7 @@ from .routers import (
     profile_view,
     navbar,
     seasonal_effects,
+    treaty_web,
 )
 from .database import engine
 from .models import Base
@@ -124,6 +125,7 @@ app.include_router(profile_view.router)
 app.include_router(navbar.router)
 app.include_router(seasonal_effects.router)
 app.include_router(overview_router.router)
+app.include_router(treaty_web.router)
 
 
 

--- a/backend/routers/treaty_web.py
+++ b/backend/routers/treaty_web.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends
+from ..security import verify_jwt_token
+
+
+def get_supabase_client():
+    try:
+        from supabase import create_client
+    except ImportError as e:  # pragma: no cover
+        raise RuntimeError("supabase client library not installed") from e
+    import os
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
+    if not url or not key:
+        raise RuntimeError("Supabase credentials not configured")
+    return create_client(url, key)
+
+
+router = APIRouter(prefix="/api/treaty_web", tags=["treaty_web"])
+
+
+@router.get("/data")
+def treaty_web_data(user_id: str = Depends(verify_jwt_token)):
+    """Return alliances, kingdoms and treaty records for the treaty web."""
+    supabase = get_supabase_client()
+    alliances = (
+        supabase.table("alliances").select("alliance_id,name").execute()
+    )
+    kingdoms = (
+        supabase.table("users").select("kingdom_id,kingdom_name").execute()
+    )
+    treaties = supabase.table("alliance_treaties").select("*").execute()
+    return {
+        "alliances": getattr(alliances, "data", alliances) or [],
+        "kingdoms": getattr(kingdoms, "data", kingdoms) or [],
+        "treaties": getattr(treaties, "data", treaties) or [],
+    }

--- a/treaty_web.html
+++ b/treaty_web.html
@@ -89,12 +89,14 @@ Author: Deathsgift66
 </main>
 
 <!-- Footer -->
-<footer class="site-footer">
-  <div>© 2025 Kingmaker’s Rise</div>
-  <div>
-    <a href="legal.html">View Legal Documents</a>
-  </div>
-</footer>
+  <footer class="site-footer">
+    <div>© 2025 Kingmaker’s Rise</div>
+    <div>
+      <a href="legal.html">View Legal Documents</a>
+    </div>
+  </footer>
+
+  <div id="toast" class="toast-notification"></div>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement new FastAPI router for treaty web data
- wire treaty web router into backend app
- update treaty web JS to load data from backend and subscribe to updates
- add responsive legend styles
- expose toast container in treaty web page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6848716301988330a4333c3f0130d1c6