### PR TITLE
Improve world map UI and backend

### DIFF
--- a/CSS/world_map.css
+++ b/CSS/world_map.css
@@ -74,12 +74,19 @@ body {
 }
 
 #map-stage {
+  position: relative;
   width: 100%;
-  height: 700px; /* Adjustable */
+  height: 70vh;
   border: 3px solid var(--gold);
   border-radius: 12px;
   box-shadow: 0 8px 16px var(--shadow);
   margin-bottom: 1rem;
+}
+
+#world-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
 .map-ui {
@@ -97,6 +104,26 @@ body {
   padding: 1.5rem;
   flex: 1;
   color: var(--ink);
+}
+
+.map-controls {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.map-controls button {
+  background: var(--gold);
+  color: var(--ink);
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-family: 'Cinzel', serif;
+  cursor: pointer;
+}
+
+.map-controls button:hover {
+  background: var(--highlight);
 }
 
 .modal {
@@ -117,5 +144,11 @@ body {
 
 .modal.hidden {
   display: none;
+}
+
+@media (max-width: 600px) {
+  #map-stage {
+    height: 50vh;
+  }
 }
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -56,6 +56,7 @@ from .routers import (
     profile_view,
     navbar,
     seasonal_effects,
+    world_map,
 )
 from .database import engine
 from .models import Base
@@ -123,6 +124,7 @@ app.include_router(legal.router)
 app.include_router(profile_view.router)
 app.include_router(navbar.router)
 app.include_router(seasonal_effects.router)
+app.include_router(world_map.router)
 app.include_router(overview_router.router)
 
 

--- a/backend/routers/world_map.py
+++ b/backend/routers/world_map.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..models import TerrainMap
+from ..security import verify_jwt_token
+
+router = APIRouter(prefix="/api/world-map", tags=["world-map"])
+
+
+@router.get("/tiles")
+def get_world_map_tiles(
+    db: Session = Depends(get_db),
+    user_id: str = Depends(verify_jwt_token),
+):
+    """Return the latest world map tile data."""
+    row = db.query(TerrainMap).order_by(TerrainMap.generated_at.desc()).first()
+    if not row:
+        return {"tile_map": {"tiles": []}, "map_width": 0, "map_height": 0}
+    return {
+        "tile_map": row.tile_map,
+        "map_width": row.map_width,
+        "map_height": row.map_height,
+    }

--- a/tests/test_world_map_router.py
+++ b/tests/test_world_map_router.py
@@ -1,0 +1,31 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.database import Base
+from backend.models import TerrainMap
+from backend.routers import world_map
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def test_get_world_map_tiles_returns_latest():
+    Session = setup_db()
+    db = Session()
+    db.add(
+        TerrainMap(
+            terrain_id=1,
+            tile_map={"tiles": [{"x": 0, "y": 0, "terrain_type": "plains"}]},
+            map_width=10,
+            map_height=10,
+        )
+    )
+    db.commit()
+
+    result = world_map.get_world_map_tiles(db=db, user_id="u1")
+    assert result["map_width"] == 10
+    assert result["tile_map"]["tiles"][0]["terrain_type"] == "plains"

--- a/world_map.html
+++ b/world_map.html
@@ -65,12 +65,16 @@ Author: Deathsgift66
   <section class="alliance-members-container">
 
     <!-- World Map Stage -->
-    <div id="map-stage"></div>
+    <div id="map-stage">
+      <canvas id="world-canvas" width="1200" height="800" aria-label="World Map Canvas"></canvas>
+    </div>
 
     <!-- Map UI -->
     <div class="map-ui">
       <div class="map-controls">
-        <!-- Zoom, Pan, Filters — JS will populate -->
+        <button id="zoom-in" class="btn">+</button>
+        <button id="zoom-out" class="btn">-</button>
+        <button id="center-map" class="btn">Center</button>
       </div>
       <div class="map-legend">
         <!-- Legend content — JS will populate -->


### PR DESCRIPTION
## Summary
- create FastAPI router to serve world map data
- register world map router
- add responsive canvas layout and controls
- style world map page and controls
- fetch map data securely from backend
- test router logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684871714bfc8330b6c48f6f1b45b40d