### PR TITLE
Add missing Kingdom page links

### DIFF
--- a/navbar.html
+++ b/navbar.html
@@ -19,6 +19,8 @@ Author: Deathsgift66
       <a href="village.html">Single Village</a>
       <a href="quests.html">Quests</a>
       <a href="projects.html">Projects</a>
+      <a href="kingdom_history.html">Kingdom History</a>
+      <a href="kingdom_achievements.html">Achievements</a>
       <a href="policies_laws.html">Policies & Laws</a>
       <a href="seasonal_effects.html">Seasonal Effects</a>
       <div class="menu-section-header">War</div>


### PR DESCRIPTION
## Summary
- add `kingdom_history.html` and `kingdom_achievements.html` to the navbar
- keep admin-only links hidden for non-admin users via existing logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend', 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68487e113ba48330a1fcc156a54f63f5