### PR TITLE
Optimize navbar loader

### DIFF
--- a/Javascript/navLoader.js
+++ b/Javascript/navLoader.js
@@ -15,8 +15,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     const html = await response.text();
     target.innerHTML = html;
 
-    // Re-init dropdown logic and profile loader
-    await import("./navDropdown.js");
-    await import("./navbar.js");
+    // Re-init dropdown logic and profile loader in parallel
+    await Promise.all([
+      import("./navDropdown.js"),
+      import("./navbar.js"),
+    ]);
   }
 });


### PR DESCRIPTION
## Summary
- make nav dropdown and navbar scripts load in parallel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68487f9d712883309d99cdd4b69166f4