### PR TITLE
Implement battle overlays and preplan editing

### DIFF
--- a/CSS/battle_live.css
+++ b/CSS/battle_live.css
@@ -26,6 +26,7 @@ body {
 
 #battle-map {
   display: grid;
+  position: relative;
   grid-template-columns: repeat(60, 20px);
   grid-template-rows: repeat(20, 20px);
   gap: 1px;
@@ -51,6 +52,19 @@ body {
   font-size: 12px;
   color: #fff;
   text-align: center;
+}
+
+.morale-bar {
+  height: 3px;
+  background: var(--low-morale);
+}
+
+.fog-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  display: none;
 }
 
 .hud {

--- a/CSS/battle_replay.css
+++ b/CSS/battle_replay.css
@@ -113,6 +113,7 @@ body {
 /* Battlefield Grid */
 #battlefield-grid {
   display: grid;
+  position: relative;
   grid-template-columns: repeat(60, 20px);
   grid-template-rows: repeat(20, 20px);
   gap: 1px;
@@ -132,6 +133,19 @@ body {
   font-size: 12px;
   color: #fff;
   text-align: center;
+}
+
+.morale-bar {
+  height: 3px;
+  background: var(--low-morale);
+}
+
+.fog-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  display: none;
 }
 
 /* Combat Log Feed */

--- a/CSS/preplan_editor.css
+++ b/CSS/preplan_editor.css
@@ -23,6 +23,36 @@ body {
   margin: var(--padding-md) 0;
 }
 
+.editor-controls {
+  display: flex;
+  gap: var(--gap-default);
+  margin-bottom: var(--padding-md);
+}
+
+.preplan-grid {
+  display: grid;
+  grid-template-columns: repeat(60, 20px);
+  grid-template-rows: repeat(20, 20px);
+  gap: 1px;
+  margin-bottom: var(--padding-md);
+  border: 1px solid var(--gold);
+  position: relative;
+}
+
+.grid-tile {
+  width: 20px;
+  height: 20px;
+  background: var(--stone-panel);
+}
+
+.grid-tile.path {
+  background: var(--accent);
+}
+
+.grid-tile.fallback {
+  background: var(--gold);
+}
+
 .scoreboard div {
   font-size: var(--font-lg);
   text-align: center;

--- a/Javascript/battle_live.js
+++ b/Javascript/battle_live.js
@@ -80,10 +80,12 @@ async function loadCombatLogs() {
 let lastTick = 0;
 let tickInterval = 300;
 let logsTick = 0;
+let statusData = null;
 async function loadStatus() {
   try {
     const res = await fetch(`/api/battle/status/${warId}`);
     const data = await res.json();
+    statusData = data;
     lastTick = data.battle_tick;
     tickInterval = data.tick_interval_seconds;
     document.getElementById('weather').textContent = data.weather;
@@ -175,9 +177,23 @@ function renderUnits(units) {
     const unitDiv = document.createElement('div');
     unitDiv.className = 'unit-icon';
     unitDiv.textContent = unit.unit_type.charAt(0).toUpperCase();
+    unitDiv.title = `HP: ${unit.hp ?? '?'}  Morale: ${unit.morale ?? '?'}%`;
     unitDiv.addEventListener('click', () => openOrderPanel(unit));
     tiles[index].appendChild(unitDiv);
+    if (unit.morale !== undefined) {
+      const morale = document.createElement('div');
+      morale.className = 'morale-bar';
+      morale.style.width = unit.morale + '%';
+      tiles[index].appendChild(morale);
+    }
   });
+
+  const fog = document.getElementById('fog-overlay');
+  if (statusData?.fog_of_war) {
+    fog.style.display = 'block';
+  } else {
+    fog.style.display = 'none';
+  }
 }
 
 function renderCombatLog(logs) {

--- a/Javascript/battle_replay.js
+++ b/Javascript/battle_replay.js
@@ -114,9 +114,26 @@ export function renderTick(tick) {
     const index = u.position_y * 60 + u.position_x;
     const node = grid.selectAll('div.tile').nodes()[index];
     if (node) {
-      d3.select(node).append('div').attr('class', 'unit-icon').text(u.icon);
+      const unitDiv = d3.select(node)
+        .append('div')
+        .attr('class', 'unit-icon')
+        .text(u.icon)
+        .attr('title', `HP: ${u.hp ?? '?'}  Morale: ${u.morale ?? '?'}%`);
+      if (u.morale !== undefined) {
+        d3.select(node)
+          .append('div')
+          .attr('class', 'morale-bar')
+          .style('width', `${u.morale}%`);
+      }
     }
   });
+
+  const fog = document.getElementById('fog-overlay');
+  if (replayData.fog_of_war) {
+    fog.style.display = 'block';
+  } else {
+    fog.style.display = 'none';
+  }
 
   const logs = replayData.combat_logs.filter(l => l.tick === tick);
   const feed = d3.select('#combat-log-entries').html('');
@@ -167,4 +184,6 @@ export function resetReplay() {
   playTimeline = null;
   currentTick = 0;
   renderTick(0);
+  const fog = document.getElementById('fog-overlay');
+  if (fog) fog.style.display = replayData?.fog_of_war ? 'block' : 'none';
 }

--- a/Javascript/battle_resolution.js
+++ b/Javascript/battle_resolution.js
@@ -48,6 +48,7 @@ async function loadResolution(silent = false) {
   const casualty = document.getElementById('casualty-report');
   const lootBox = document.getElementById('loot-summary');
   const participantsBox = document.getElementById('participant-breakdown');
+  const statBox = document.getElementById('stat-changes');
   const replayBtn = document.getElementById('replay-button');
   const lastUpdated = document.getElementById('last-updated');
 
@@ -56,6 +57,7 @@ async function loadResolution(silent = false) {
   timeline.innerHTML = '';
   casualty.innerHTML = '';
   lootBox.innerHTML = '';
+  statBox.innerHTML = '';
   participantsBox.innerHTML = '';
   replayBtn.innerHTML = '';
 
@@ -141,16 +143,43 @@ async function loadResolution(silent = false) {
       lootBox.innerHTML += '<p>No loot.</p>';
     }
 
+    if (resolution.rewards) {
+      const rewards = document.createElement('div');
+      rewards.innerHTML = '<h4>Rewards</h4>';
+      const rList = document.createElement('ul');
+      for (const [name, val] of Object.entries(resolution.rewards)) {
+        const li = document.createElement('li');
+        li.textContent = `${name}: ${val}`;
+        rList.appendChild(li);
+      }
+      rewards.appendChild(rList);
+      lootBox.appendChild(rewards);
+    }
+
     // Participant breakdown
     participantsBox.innerHTML = '<h3>Participants</h3>';
+    const totalUnitsAll = movements.reduce((s, m) => s + (m.quantity || 0), 0) || 1;
     participants.forEach(k => {
       const box = document.createElement('div');
       box.className = 'participant-box';
       const units = movements.filter(m => m.kingdom_id === k.kingdom_id);
       const total = units.reduce((sum, u) => sum + (u.quantity || 0), 0);
-      box.innerHTML = `<strong>${k.kingdom_name}</strong><br>Units Sent: ${total}`;
+      const contrib = ((total / totalUnitsAll) * 100).toFixed(1);
+      box.innerHTML = `<strong>${k.kingdom_name}</strong><br>Units Sent: ${total}<br>Contribution: ${contrib}%`;
       participantsBox.appendChild(box);
     });
+
+    // Stat changes
+    if (resolution.stat_changes) {
+      statBox.innerHTML = '<h3>Stat Changes</h3>';
+      const list = document.createElement('ul');
+      for (const [stat, val] of Object.entries(resolution.stat_changes)) {
+        const li = document.createElement('li');
+        li.textContent = `${stat}: ${val > 0 ? '+' : ''}${val}`;
+        list.appendChild(li);
+      }
+      statBox.appendChild(list);
+    }
 
     // Replay button
     replayBtn.innerHTML = `<a href="battle_replay.html?war_id=${warId}" class="royal-button">Replay Battle</a>`;

--- a/Javascript/preplan_editor.js
+++ b/Javascript/preplan_editor.js
@@ -4,15 +4,60 @@ document.addEventListener('DOMContentLoaded', async () => {
   const saveBtn = document.getElementById('save-plan');
   const warInput = document.getElementById('war-id');
   const planArea = document.getElementById('preplan-json');
+  const grid = document.getElementById('preplan-grid');
+  const fallbackBtn = document.getElementById('fallback-mode');
+  const pathBtn = document.getElementById('path-mode');
+  const clearPathBtn = document.getElementById('clear-path');
   const scoreDiv = document.getElementById('scoreboard-display');
+  let editMode = null;
   let channel;
+  let plan = {};
+
+  renderGrid();
+
+  function renderGrid() {
+    grid.innerHTML = '';
+    for (let y = 0; y < 20; y++) {
+      for (let x = 0; x < 60; x++) {
+        const tile = document.createElement('div');
+        tile.className = 'grid-tile';
+        tile.dataset.x = x;
+        tile.dataset.y = y;
+        tile.addEventListener('click', () => handleTile(x, y));
+        if (plan.patrol_path?.some(p => p.x === x && p.y === y)) {
+          tile.classList.add('path');
+        }
+        if (plan.fallback_point && plan.fallback_point.x === x && plan.fallback_point.y === y) {
+          tile.classList.add('fallback');
+        }
+        grid.appendChild(tile);
+      }
+    }
+  }
+
+  function handleTile(x, y) {
+    if (editMode === 'fallback') {
+      plan.fallback_point = { x, y };
+    } else if (editMode === 'path') {
+      if (!plan.patrol_path) plan.patrol_path = [];
+      plan.patrol_path.push({ x, y });
+    }
+    updatePlanArea();
+    renderGrid();
+  }
+
+  function updatePlanArea() {
+    planArea.value = JSON.stringify(plan, null, 2);
+  }
 
   async function loadPlan() {
     const warId = warInput.value;
     if (!warId) return;
     const res = await fetch(`/api/alliance-wars/preplan?alliance_war_id=${warId}`);
     const data = await res.json();
-    planArea.value = JSON.stringify(data.plan || {}, null, 2);
+    plan = data.plan || {};
+    updatePlanArea();
+    renderGrid();
   }
 
   async function updateScoreDisplay(score) {
@@ -42,16 +87,30 @@ document.addEventListener('DOMContentLoaded', async () => {
     await loadScore();
   });
 
+  fallbackBtn.addEventListener('click', () => {
+    editMode = 'fallback';
+  });
+  pathBtn.addEventListener('click', () => {
+    editMode = 'path';
+  });
+  clearPathBtn.addEventListener('click', () => {
+    plan.patrol_path = [];
+    renderGrid();
+    updatePlanArea();
+  });
+
+  planArea.addEventListener('input', () => {
+    try {
+      plan = JSON.parse(planArea.value || '{}');
+      renderGrid();
+    } catch {
+      // ignore invalid JSON while typing
+    }
+  });
+
   saveBtn.addEventListener('click', async () => {
     const warId = warInput.value;
     if (!warId) return alert('Enter war ID');
-    let plan;
-    try {
-      plan = JSON.parse(planArea.value || '{}');
-    } catch {
-      alert('Invalid JSON');
-      return;
-    }
     await fetch('/api/alliance-wars/preplan/submit', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/battle_live.html
+++ b/battle_live.html
@@ -75,6 +75,7 @@ Author: Deathsgift66
     <div class="battle-container">
       <div id="battle-map" class="battle-map" aria-label="Battle Map">
         <!-- Tiles + units rendered by JS -->
+        <div id="fog-overlay" class="fog-overlay" aria-hidden="true"></div>
       </div>
       <aside class="sidebar">
         <div id="combat-log" class="combat-log" aria-label="Combat Log" aria-live="polite">

--- a/battle_replay.html
+++ b/battle_replay.html
@@ -89,6 +89,7 @@ Author: Deathsgift66
 
       <section id="battlefield-grid" class="battlefield-grid" aria-label="Battlefield Grid">
         <!-- Tiles rendered by JS -->
+        <div id="fog-overlay" class="fog-overlay" aria-hidden="true"></div>
       </section>
 
       <section id="battle-outcome" class="battle-outcome" aria-label="Battle Outcome Summary">

--- a/battle_resolution.html
+++ b/battle_resolution.html
@@ -74,6 +74,7 @@ Author: Deathsgift66
       <section id="combat-timeline"></section>
       <section id="casualty-report"></section>
       <section id="loot-summary"></section>
+      <section id="stat-changes"></section>
       <section id="participant-breakdown"></section>
       <section id="replay-button"></section>
       <section id="refresh-info">

--- a/preplan_editor.html
+++ b/preplan_editor.html
@@ -50,6 +50,12 @@ Author: Deathsgift66
       <input id="war-id" type="number" min="1" />
     </div>
     <textarea id="preplan-json" rows="8" aria-label="Preplan JSON"></textarea>
+    <div class="editor-controls">
+      <button id="fallback-mode" class="btn">Set Fallback Point</button>
+      <button id="path-mode" class="btn">Draw Patrol Path</button>
+      <button id="clear-path" class="btn">Clear Path</button>
+    </div>
+    <div id="preplan-grid" class="preplan-grid" aria-label="Patrol Grid"></div>
     <button id="save-plan" class="btn">Save Plan</button>
   </section>
   <section class="scoreboard panel">


### PR DESCRIPTION
## Summary
- show fog-of-war overlay on battle grid
- add unit tooltips and morale bars in battle live and replay
- display stat changes and rewards in battle resolution
- enable patrol path and fallback point editing in preplan editor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6848870f35048330b825429d5fd37e2a