### PR TITLE
Add alliance war UI and backend actions

### DIFF
--- a/Javascript/alliance_home.js
+++ b/Javascript/alliance_home.js
@@ -41,6 +41,7 @@ function populateAlliance(data) {
   renderAchievements(data.achievements);
   renderActivity(data.activity);
   renderDiplomacy(data.treaties);
+  renderActiveBattles(data.wars);
   renderWarScore(data.wars);
 }
 
@@ -127,13 +128,32 @@ function renderDiplomacy(treaties) {
   });
 }
 
+function renderActiveBattles(wars) {
+  const container = document.getElementById('active-battles-list');
+  if (!container) return;
+  container.innerHTML = '';
+  const active = wars.filter(w => w.war_status === 'active');
+  if (active.length === 0) {
+    container.textContent = 'No active battles.';
+    return;
+  }
+  active.forEach(w => {
+    const div = document.createElement('div');
+    div.classList.add('battle-entry');
+    div.textContent = `War ${w.alliance_war_id} — ${w.war_status}`;
+    container.appendChild(div);
+  });
+}
+
 function renderWarScore(wars) {
   const container = document.getElementById('war-score-summary');
   if (!container) return;
   container.innerHTML = '';
   wars.forEach(w => {
     const div = document.createElement('div');
-    div.textContent = `War ${w.alliance_war_id}: ${w.attacker_score} - ${w.defender_score}`;
+    const att = w.attacker_score ?? 0;
+    const def = w.defender_score ?? 0;
+    div.textContent = `War ${w.alliance_war_id}: Attacker ${att} vs Defender ${def}`;
     container.appendChild(div);
   });
 }

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -115,6 +115,11 @@ Author: Deathsgift66
           <!-- JS injects quest cards -->
         </div>
       </section>
+      <section class="panel active-battles" aria-labelledby="active-battles-heading">
+        <h2 id="active-battles-heading">Active Battles</h2>
+        <div id="active-battles-list"></div>
+      </section>
+
 
       <section class="panel war-score" aria-labelledby="war-score-heading">
         <h2 id="war-score-heading">War Score</h2>

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -90,6 +90,11 @@ Author: Deathsgift66
     <div id="tab-active" class="tab-section active" aria-label="Active Wars">
       <h2>Ongoing Alliance Wars</h2>
       <p>Monitor active wars, view progress, and manage your alliance's battle efforts.</p>
+        <div id="declare-war-ui">
+          <label>Target Alliance ID: <input type="number" id="target-alliance-id"></label>
+          <button id="declare-alliance-war-btn" class="action-btn">Declare War</button>
+        </div>
+        <div id="pending-wars-list"></div>
       <div id="wars-container" aria-live="polite">
         <!-- War cards injected by JavaScript -->
       </div>


### PR DESCRIPTION
## Summary
- show active battles on alliance home
- extend war score summary display
- allow alliances to declare or accept wars via UI
- log alliance war declarations and return pending wars
- cover new backend endpoints with tests

## Testing
- `pytest -q` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68488704250c833091f179cd2ef7f41b