### PR TITLE
Finalize war schema relationships

### DIFF
--- a/FINAL_SCHEMA_DOCUMENTATION.md
+++ b/FINAL_SCHEMA_DOCUMENTATION.md
@@ -347,6 +347,7 @@ CREATE TABLE public.combat_logs (
   CONSTRAINT combat_logs_pkey PRIMARY KEY (combat_id),
   CONSTRAINT combat_logs_war_id_fkey FOREIGN KEY (war_id) REFERENCES public.wars_tactical(war_id)
 );
+CREATE INDEX combat_logs_war_id_idx ON public.combat_logs(war_id);
 
 CREATE TABLE public.game_settings (
   setting_key text NOT NULL,
@@ -986,10 +987,12 @@ CREATE TABLE public.unit_movements (
   CONSTRAINT unit_movements_war_id_fkey FOREIGN KEY (war_id) REFERENCES public.wars_tactical(war_id),
   CONSTRAINT unit_movements_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id)
 );
+CREATE INDEX unit_movements_war_id_idx ON public.unit_movements(war_id);
 
 CREATE TABLE public.unit_stats (
   unit_type text NOT NULL,
   tier integer NOT NULL,
+  version_tag text DEFAULT 'v1',
   class text NOT NULL,
   description text,
   hp integer NOT NULL,
@@ -1131,6 +1134,7 @@ CREATE TABLE public.war_scores (
   CONSTRAINT war_scores_pkey PRIMARY KEY (war_id),
   CONSTRAINT war_scores_war_id_fkey FOREIGN KEY (war_id) REFERENCES public.wars_tactical(war_id)
 );
+CREATE INDEX war_scores_war_id_idx ON public.war_scores(war_id);
 
 CREATE TABLE public.wars (
   war_id integer NOT NULL DEFAULT nextval('wars_war_id_seq'::regclass),
@@ -1179,6 +1183,7 @@ CREATE TABLE public.wars_tactical (
   weather text,
   submitted_by uuid,
   CONSTRAINT wars_tactical_pkey PRIMARY KEY (war_id),
+  CONSTRAINT wars_tactical_war_id_fkey FOREIGN KEY (war_id) REFERENCES public.wars(war_id) ON DELETE CASCADE,
   CONSTRAINT wars_tactical_attacker_kingdom_id_fkey FOREIGN KEY (attacker_kingdom_id) REFERENCES public.kingdoms(kingdom_id),
   CONSTRAINT wars_tactical_defender_kingdom_id_fkey FOREIGN KEY (defender_kingdom_id) REFERENCES public.kingdoms(kingdom_id),
   CONSTRAINT wars_tactical_submitted_by_fkey FOREIGN KEY (submitted_by) REFERENCES public.users(user_id),

--- a/backend/models.py
+++ b/backend/models.py
@@ -267,7 +267,7 @@ class ProjectsAllianceInProgress(Base):
 
 class WarsTactical(Base):
     __tablename__ = "wars_tactical"
-    war_id = Column(Integer, primary_key=True)
+    war_id = Column(Integer, ForeignKey("wars.war_id"), primary_key=True)
     attacker_kingdom_id = Column(Integer, ForeignKey("kingdoms.kingdom_id"))
     defender_kingdom_id = Column(Integer, ForeignKey("kingdoms.kingdom_id"))
     phase = Column(String)
@@ -291,7 +291,7 @@ class WarsTactical(Base):
 class UnitMovement(Base):
     __tablename__ = "unit_movements"
     movement_id = Column(Integer, primary_key=True)
-    war_id = Column(Integer, ForeignKey("wars_tactical.war_id"))
+    war_id = Column(Integer, ForeignKey("wars_tactical.war_id"), index=True)
     kingdom_id = Column(Integer, ForeignKey("kingdoms.kingdom_id"))
     unit_type = Column(String)
     unit_level = Column(Integer)
@@ -318,7 +318,7 @@ class UnitMovement(Base):
 class CombatLog(Base):
     __tablename__ = "combat_logs"
     combat_id = Column(Integer, primary_key=True)
-    war_id = Column(Integer, ForeignKey("wars_tactical.war_id"))
+    war_id = Column(Integer, ForeignKey("wars_tactical.war_id"), index=True)
     tick_number = Column(Integer)
     event_type = Column(String)
     attacker_unit_id = Column(Integer)
@@ -462,7 +462,7 @@ class BattleResolutionLog(Base):
 
 class WarScore(Base):
     __tablename__ = "war_scores"
-    war_id = Column(Integer, ForeignKey("wars_tactical.war_id"), primary_key=True)
+    war_id = Column(Integer, ForeignKey("wars_tactical.war_id"), primary_key=True, index=True)
     attacker_score = Column(Integer, default=0)
     defender_score = Column(Integer, default=0)
     victor = Column(String)
@@ -492,6 +492,7 @@ class UnitStat(Base):
     __tablename__ = "unit_stats"
     unit_type = Column(String, primary_key=True)
     tier = Column(Integer)
+    version_tag = Column(String, default="v1")
     hp = Column(Integer)
     damage = Column(Integer)
     defense = Column(Integer)

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -201,6 +201,7 @@ CREATE TABLE kingdom_troop_slots (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     last_updated TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+CREATE INDEX unit_movements_war_id_idx ON unit_movements (war_id);
 
 -- CASTLE PROGRESSION ------------------------------------------------------
 CREATE TABLE kingdom_castle_progression (
@@ -895,7 +896,7 @@ CREATE TYPE war_phase AS ENUM ('alert', 'planning', 'live', 'resolved');
 CREATE TYPE war_status AS ENUM ('active', 'paused', 'ended');
 
 CREATE TABLE wars_tactical (
-    war_id SERIAL PRIMARY KEY,
+    war_id SERIAL PRIMARY KEY REFERENCES wars(war_id) ON DELETE CASCADE,
     attacker_kingdom_id INTEGER REFERENCES kingdoms(kingdom_id),
     defender_kingdom_id INTEGER REFERENCES kingdoms(kingdom_id),
     phase war_phase DEFAULT 'alert',
@@ -968,6 +969,7 @@ CREATE TABLE combat_logs (
     notes TEXT,
     timestamp TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+CREATE INDEX combat_logs_war_id_idx ON combat_logs (war_id);
 
 CREATE TABLE war_preplans (
     preplan_id SERIAL PRIMARY KEY,

--- a/docs/unit_stats.md
+++ b/docs/unit_stats.md
@@ -8,6 +8,7 @@ This table defines the core attributes and functional roles for every unit type 
 | --- | --- |
 | `unit_type` | Unique ID for the unit (e.g. `archer`) |
 | `tier` | Tech progression level (1 basic, 5 advanced) |
+| `version_tag` | Schema version identifier |
 | `class` | General type: `infantry`, `ranged`, `cavalry`, `siege`, etc. |
 | `description` | Text shown in UI and encyclopedia |
 | `hp` | Health pool per unit |

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -195,6 +195,7 @@ CREATE TABLE public.combat_logs (
   CONSTRAINT combat_logs_pkey PRIMARY KEY (combat_id),
   CONSTRAINT combat_logs_war_id_fkey FOREIGN KEY (war_id) REFERENCES public.wars_tactical(war_id)
 );
+CREATE INDEX combat_logs_war_id_idx ON public.combat_logs(war_id);
 CREATE TABLE public.kingdom_buildings (
   kingdom_id integer NOT NULL,
   building_id integer NOT NULL,
@@ -726,9 +727,11 @@ CREATE TABLE public.unit_movements (
   CONSTRAINT unit_movements_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id),
   CONSTRAINT unit_movements_issued_by_fkey FOREIGN KEY (issued_by) REFERENCES public.users(user_id)
 );
+CREATE INDEX unit_movements_war_id_idx ON public.unit_movements(war_id);
 CREATE TABLE public.unit_stats (
   unit_type text NOT NULL,
   tier integer NOT NULL,
+  version_tag text DEFAULT 'v1',
   class text NOT NULL,
   description text,
   hp integer NOT NULL,
@@ -798,6 +801,7 @@ CREATE TABLE public.war_scores (
   CONSTRAINT war_scores_pkey PRIMARY KEY (war_id),
   CONSTRAINT war_scores_war_id_fkey FOREIGN KEY (war_id) REFERENCES public.wars_tactical(war_id)
 );
+CREATE INDEX war_scores_war_id_idx ON public.war_scores(war_id);
 CREATE TABLE public.wars (
   war_id integer NOT NULL DEFAULT nextval('wars_war_id_seq'::regclass),
   attacker_id uuid,
@@ -848,6 +852,7 @@ CREATE TABLE public.wars_tactical (
   weather text,
   submitted_by uuid,
   CONSTRAINT wars_tactical_pkey PRIMARY KEY (war_id),
+  CONSTRAINT wars_tactical_war_id_fkey FOREIGN KEY (war_id) REFERENCES public.wars(war_id) ON DELETE CASCADE,
   CONSTRAINT wars_tactical_attacker_kingdom_id_fkey FOREIGN KEY (attacker_kingdom_id) REFERENCES public.kingdoms(kingdom_id),
   CONSTRAINT wars_tactical_defender_kingdom_id_fkey FOREIGN KEY (defender_kingdom_id) REFERENCES public.kingdoms(kingdom_id)
 );

--- a/migrations/2025_06_27_finalize_war_indexes.sql
+++ b/migrations/2025_06_27_finalize_war_indexes.sql
@@ -1,0 +1,15 @@
+-- Migration: finalize foreign keys and add indexes
+
+-- Link tactical wars to primary wars table
+ALTER TABLE public.wars_tactical
+  ADD CONSTRAINT wars_tactical_war_id_fkey
+  FOREIGN KEY (war_id) REFERENCES public.wars(war_id) ON DELETE CASCADE;
+
+-- Index frequently queried war_id columns
+CREATE INDEX IF NOT EXISTS combat_logs_war_id_idx ON public.combat_logs(war_id);
+CREATE INDEX IF NOT EXISTS war_scores_war_id_idx ON public.war_scores(war_id);
+CREATE INDEX IF NOT EXISTS unit_movements_war_id_idx ON public.unit_movements(war_id);
+
+-- Add version_tag to unit_stats for schema versioning
+ALTER TABLE public.unit_stats
+  ADD COLUMN version_tag text DEFAULT 'v1';

--- a/tests/test_wars_tactical_model.py
+++ b/tests/test_wars_tactical_model.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from backend.database import Base
-from backend.models import WarsTactical
+from backend.models import WarsTactical, War
 
 
 def test_wars_tactical_model_creation():
@@ -11,7 +11,10 @@ def test_wars_tactical_model_creation():
     Base.metadata.create_all(engine)
     db = Session()
 
-    wt = WarsTactical(attacker_kingdom_id=1, defender_kingdom_id=2, phase="alert")
+    base_war = War(attacker_name="A", defender_name="B", status="active")
+    db.add(base_war)
+    db.flush()
+    wt = WarsTactical(war_id=base_war.war_id, attacker_kingdom_id=1, defender_kingdom_id=2, phase="alert")
     db.add(wt)
     db.commit()
 


### PR DESCRIPTION
## Summary
- link tactical wars to wars table
- add indexes for war-related tables
- track unit stat versions with a new column
- document schema updates
- adjust model tests for FK requirement

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488715a8408330bff839fc09b80bf0