### PR TITLE
Implement admin war tools and battle UX updates

### DIFF
--- a/CSS/battle_live.css
+++ b/CSS/battle_live.css
@@ -154,6 +154,10 @@ body {
   .sidebar {
     width: 100%;
   }
+  .hud {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
   #battle-map {
     overflow-x: auto;
     grid-template-columns: repeat(60, minmax(12px, 1fr));

--- a/Javascript/admin_dashboard.js
+++ b/Javascript/admin_dashboard.js
@@ -251,6 +251,30 @@ async function updateKingdom() {
     alert('Failed to update kingdom');
   }
 }
+async function forceEndWar() {
+  const wid = document.getElementById("war-id").value;
+  if (!wid) return alert("Enter war ID");
+  try {
+    await postAdminAction("/api/admin/wars/force_end", { war_id: Number(wid) });
+    alert("War ended");
+  } catch (err) {
+    console.error("Force end failed:", err);
+    alert("Failed to end war");
+  }
+}
+
+async function rollbackCombatTick() {
+  const wid = document.getElementById("war-id").value;
+  if (!wid) return alert("Enter war ID");
+  try {
+    await postAdminAction("/api/admin/wars/rollback_tick", { war_id: Number(wid) });
+    alert("Tick rolled back");
+  } catch (err) {
+    console.error("Rollback failed:", err);
+    alert("Failed to rollback tick");
+  }
+}
+
 
 // 🧩 DOM Ready Hooks
 document.addEventListener('DOMContentLoaded', () => {
@@ -277,4 +301,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('load-logs-btn').addEventListener('click', loadAuditLogs);
   document.getElementById('toggle-flag-btn').addEventListener('click', toggleFlag);
   document.getElementById('update-kingdom-btn').addEventListener('click', updateKingdom);
+  document.getElementById("force-end-war-btn").addEventListener("click", forceEndWar);
+  document.getElementById("rollback-tick-btn").addEventListener("click", rollbackCombatTick);
 });

--- a/Javascript/battle_live.js
+++ b/Javascript/battle_live.js
@@ -7,6 +7,23 @@ Author: Deathsgift66
 // Live Battle Viewer — fetches terrain, units and combat logs
 
 import { supabase } from './supabaseClient.js';
+const UNIT_COUNTERS = { infantry: "archers", cavalry: "spearmen", archers: "infantry", mage: "infantry" };
+const TERRAIN_EFFECTS = { forest: "Defense bonus", river: "Slows movement", hill: "Ranged bonus" };
+function playTickSound() {
+  try {
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const osc = ctx.createOscillator();
+    osc.type = "square";
+    osc.frequency.value = 880;
+    osc.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.1);
+  } catch (e) {
+    console.error("audio", e);
+  }
+}
+
+
 
 // Retrieve war_id from URL (?war_id=123)
 const urlParams = new URLSearchParams(window.location.search);
@@ -110,6 +127,7 @@ function countdownTick() {
   if (timer <= 0) timer = tickInterval;
   document.getElementById('tick-timer').textContent = `${timer}s`;
   if (lastTick !== 0 && timer === tickInterval) {
+    playTickSound();
     loadUnits();
     loadCombatLogs();
     loadScoreboard();
@@ -158,6 +176,7 @@ function renderBattleMap(tileMap) {
       else if (type === 'river') tile.style.backgroundColor = '#1E90FF';
       else if (type === 'hill') tile.style.backgroundColor = '#8B4513';
       else tile.style.backgroundColor = 'var(--stone-panel)';
+      tile.title = `${type.charAt(0).toUpperCase() + type.slice(1)}: ${TERRAIN_EFFECTS[type] || ''}`;
       battleMap.appendChild(tile);
     }
   }
@@ -177,7 +196,8 @@ function renderUnits(units) {
     const unitDiv = document.createElement('div');
     unitDiv.className = 'unit-icon';
     unitDiv.textContent = unit.unit_type.charAt(0).toUpperCase();
-    unitDiv.title = `HP: ${unit.hp ?? '?'}  Morale: ${unit.morale ?? '?'}%`;
+    const counter = UNIT_COUNTERS[unit.unit_type] || 'none';
+    unitDiv.title = `HP: ${unit.hp ?? '?'}  Morale: ${unit.morale ?? '?'}%  Counters: ${counter}`;
     unitDiv.addEventListener('click', () => openOrderPanel(unit));
     tiles[index].appendChild(unitDiv);
     if (unit.morale !== undefined) {

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -129,6 +129,14 @@ Author: Deathsgift66
         <button id="update-kingdom-btn">Update</button>
       </section>
 
+      <!-- War Tools -->
+      <section class="war-management" aria-label="War Tools">
+        <h3>War Controls</h3>
+        <input id="war-id" type="number" placeholder="War ID" aria-label="War ID" />
+        <button id="force-end-war-btn">Force End War</button>
+        <button id="rollback-tick-btn">Rollback Combat Tick</button>
+      </section>
+
       <!-- Audit Logs -->
       <section class="audit-logs" aria-label="Audit Logs Section">
         <h3>Audit Logs</h3>

--- a/tests/test_admin_war_actions.py
+++ b/tests/test_admin_war_actions.py
@@ -1,0 +1,35 @@
+from backend.routers.admin_dashboard import force_end_war, rollback_combat_tick, WarAction
+
+class DummyResult:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+    def fetchall(self):
+        return self._rows
+    def fetchone(self):
+        return None
+
+class DummyDB:
+    def __init__(self):
+        self.queries = []
+    def execute(self, query, params=None):
+        self.queries.append((str(query), params))
+        return DummyResult()
+    def commit(self):
+        pass
+
+
+def test_force_end_war_updates_and_logs():
+    db = DummyDB()
+    force_end_war(WarAction(war_id=1), admin_user_id="a1", db=db)
+    executed = " ".join(db.queries[0][0].split()).lower()
+    assert "update wars_tactical" in executed
+    assert any("insert into audit_log" in q[0].lower() for q in db.queries)
+
+
+def test_rollback_combat_tick_updates_and_logs():
+    db = DummyDB()
+    rollback_combat_tick(WarAction(war_id=2), admin_user_id="a1", db=db)
+    executed = " ".join(db.queries[0][0].split()).lower()
+    assert "update wars_tactical" in executed
+    assert any("delete from combat_logs" in q[0].lower() for q in db.queries)
+    assert any("insert into audit_log" in q[0].lower() for q in db.queries)


### PR DESCRIPTION
## Summary
- add war management controls to admin dashboard
- support `/wars/force_end` and `/wars/rollback_tick` admin endpoints
- expose JS helpers for new admin actions
- show unit and terrain tooltips in battles
- play a short sound each tick and enhance mobile styling
- add tests for new admin war actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6848870b571c83309f8cd479b6372f85