### PR TITLE
Enhance alliance home data display

### DIFF
--- a/CSS/alliance_home.css
+++ b/CSS/alliance_home.css
@@ -137,6 +137,23 @@ section h2 {
   border-bottom: 1px solid var(--gold);
 }
 
+/* Top Contributors */
+#top-contrib-list {
+  list-style: none;
+  padding: 0;
+}
+.top-contrib-entry {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+.contrib-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+}
+
 
 /* Mobile Responsive */
 @media (max-width: 768px) {

--- a/Javascript/alliance_home.js
+++ b/Javascript/alliance_home.js
@@ -30,13 +30,30 @@ function populateAlliance(data) {
   if (!a) return;
   setText('alliance-name', a.name);
   setText('alliance-leader', a.leader);
+  setText('alliance-region', a.region);
+  setText('alliance-founded', formatDate(a.created_at));
+  setText('alliance-level', a.level);
   setText('alliance-status', a.status);
   setText('alliance-members', a.member_count);
+  setText('alliance-wars-count', a.wars_count);
+  setText('alliance-treaties-count', a.treaties_count);
+  setText('alliance-military', a.military_score);
+  setText('alliance-economy', a.economy_score);
+  setText('alliance-diplomacy', a.diplomacy_score);
   const banner = document.getElementById('alliance-banner-img');
   if (banner) banner.src = a.banner || 'Assets/banner.png';
 
+  if (data.vault) {
+    setText('alliance-fortification', data.vault.fortification_level ?? 0);
+    setText('alliance-army', data.vault.army_count ?? 0);
+    setText('vault-gold', data.vault.gold ?? 0);
+    setText('vault-food', data.vault.food ?? 0);
+    setText('vault-ore', data.vault.iron_ore ?? 0);
+  }
+
   renderProjects(data.projects);
   renderMembers(data.members);
+  renderTopContributors(data.members);
   renderQuests(data.quests);
   renderAchievements(data.achievements);
   renderActivity(data.activity);
@@ -70,6 +87,32 @@ function renderMembers(members) {
       <td>${m.contribution}</td>
       <td>${m.status}</td>`;
     body.appendChild(row);
+  });
+}
+
+function renderTopContributors(members) {
+  const list = document.getElementById('top-contrib-list');
+  if (!list) return;
+  list.innerHTML = '';
+  if (!members.length) {
+    list.innerHTML = '<li>No data.</li>';
+    return;
+  }
+  const top = [...members]
+    .sort((a, b) => (b.contribution || 0) - (a.contribution || 0))
+    .slice(0, 5);
+  top.forEach(m => {
+    const li = document.createElement('li');
+    li.classList.add('top-contrib-entry');
+    const img = document.createElement('img');
+    img.classList.add('contrib-avatar');
+    img.src = m.avatar || 'Assets/default_avatar.png';
+    img.alt = m.username;
+    li.appendChild(img);
+    const span = document.createElement('span');
+    span.textContent = ` ${m.username} - ${m.contribution}`;
+    li.appendChild(span);
+    list.appendChild(li);
   });
 }
 

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -70,8 +70,39 @@ Author: Deathsgift66
       </div>
       <p><strong>Name:</strong> <span id="alliance-name">Loading...</span></p>
       <p><strong>Leader:</strong> <span id="alliance-leader">Loading...</span></p>
+      <p><strong>Region:</strong> <span id="alliance-region">Loading...</span></p>
+      <p><strong>Founded:</strong> <span id="alliance-founded">Loading...</span></p>
+      <p><strong>Level:</strong> <span id="alliance-level">Loading...</span></p>
       <p><strong>Members:</strong> <span id="alliance-members">Loading...</span></p>
       <p><strong>Status:</strong> <span id="alliance-status">Loading...</span></p>
+      <p><strong>Wars:</strong> <span id="alliance-wars-count">0</span></p>
+      <p><strong>Treaties:</strong> <span id="alliance-treaties-count">0</span></p>
+    </section>
+
+    <!-- Alliance Stats -->
+    <section class="panel alliance-stats" aria-labelledby="stats-heading">
+      <h2 id="stats-heading">Alliance Stats</h2>
+      <p><strong>Military Score:</strong> <span id="alliance-military">0</span></p>
+      <p><strong>Economy Score:</strong> <span id="alliance-economy">0</span></p>
+      <p><strong>Diplomacy Score:</strong> <span id="alliance-diplomacy">0</span></p>
+      <p><strong>Fortification Level:</strong> <span id="alliance-fortification">0</span></p>
+      <p><strong>Total Donated Army:</strong> <span id="alliance-army">0</span></p>
+    </section>
+
+    <!-- Vault Snapshot -->
+    <section class="panel vault-snapshot" aria-labelledby="vault-heading">
+      <h2 id="vault-heading">Vault Snapshot</h2>
+      <p><strong>Gold:</strong> <span id="vault-gold">0</span></p>
+      <p><strong>Food:</strong> <span id="vault-food">0</span></p>
+      <p><strong>Ore:</strong> <span id="vault-ore">0</span></p>
+    </section>
+
+    <!-- Top Contributors -->
+    <section class="panel top-contributors" aria-labelledby="top-contrib-heading">
+      <h2 id="top-contrib-heading">Top Contributors</h2>
+      <ul id="top-contrib-list">
+        <li>Loading...</li>
+      </ul>
     </section>
 
     <!-- Active Projects -->

--- a/backend/routers/alliance_home.py
+++ b/backend/routers/alliance_home.py
@@ -26,7 +26,7 @@ def alliance_details(
 
     # Members list with usernames
     member_rows = (
-        db.query(AllianceMember, User.username)
+        db.query(AllianceMember, User.username, User.profile_picture_url)
         .join(User, AllianceMember.user_id == User.user_id)
         .filter(AllianceMember.alliance_id == aid)
         .order_by(AllianceMember.rank, AllianceMember.contribution.desc())
@@ -36,12 +36,13 @@ def alliance_details(
         {
             "user_id": str(m.user_id),
             "username": username,
+            "avatar": avatar,
             "rank": m.rank,
             "contribution": m.contribution,
             "status": m.status,
             "crest": m.crest,
         }
-        for m, username in member_rows
+        for m, username, avatar in member_rows
     ]
 
     # Vault resources


### PR DESCRIPTION
## Summary
- extend alliance home API to include member avatars
- show additional alliance info and stats
- render vault snapshot and top contributor list
- style top contributors list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68488c6a24cc833097fa98531f4044b2