### PR TITLE
Implement alliance member enhancements

### DIFF
--- a/CSS/alliance_members.css
+++ b/CSS/alliance_members.css
@@ -105,6 +105,15 @@ h2 {
   background-color: rgba(255, 255, 255, 0.04);
 }
 
+.leader-row td {
+  background-color: rgba(212, 179, 115, 0.2);
+}
+
+.crest-icon {
+  width: 32px;
+  height: 32px;
+}
+
 /* Action Buttons */
 .members-table button {
   background: var(--accent);

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -74,6 +74,7 @@ Author: Deathsgift66
           <caption class="sr-only">Current alliance members</caption>
           <thead>
             <tr>
+              <th scope="col">Crest</th>
               <th scope="col">Name</th>
               <th scope="col">Rank</th>
               <th scope="col">Role</th>
@@ -88,7 +89,7 @@ Author: Deathsgift66
           </thead>
           <tbody id="members-list" aria-live="polite">
             <tr>
-              <td colspan="10">Loading members...</td>
+              <td colspan="11">Loading members...</td>
             </tr>
           </tbody>
         </table>

--- a/tests/test_alliance_members_router.py
+++ b/tests/test_alliance_members_router.py
@@ -2,8 +2,13 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from backend.database import Base
-from backend.models import AllianceMember
-from backend.routers.alliance_members import promote, RankPayload
+from backend.models import AllianceMember, Alliance
+from backend.routers.alliance_members import (
+    promote,
+    RankPayload,
+    transfer_leadership,
+    TransferLeadershipPayload,
+)
 
 
 def setup_db():
@@ -31,3 +36,20 @@ from backend.routers.alliance_members import get_current_user_id
 def test_get_current_user_id_raises():
     with pytest.raises(HTTPException):
         get_current_user_id(None)
+
+
+def test_transfer_leadership_changes_leader():
+    Session = setup_db()
+    db = Session()
+    db.add(Alliance(alliance_id=1, name="Test", leader="u1"))
+    db.add(AllianceMember(alliance_id=1, user_id="u1", username="A", rank="Leader"))
+    db.add(AllianceMember(alliance_id=1, user_id="u2", username="B", rank="Member"))
+    db.commit()
+
+    transfer_leadership(TransferLeadershipPayload(new_leader_id="u2"), user_id="u1", db=db)
+    alliance = db.query(Alliance).filter_by(alliance_id=1).first()
+    assert alliance.leader == "u2"
+    m1 = db.query(AllianceMember).filter_by(user_id="u1").first()
+    m2 = db.query(AllianceMember).filter_by(user_id="u2").first()
+    assert m1.rank == "Co-Leader"
+    assert m2.rank == "Leader"


### PR DESCRIPTION
## Summary
- show crests on the members page
- highlight the leader row
- allow the alliance leader to transfer leadership
- add new transfer endpoint and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several modules)*

------
https://chatgpt.com/codex/tasks/task_e_68488c74e9a08330af037d7fb3ab5b30