### PR TITLE
Add alliance vault deposit/withdraw permissions

### DIFF
--- a/Javascript/alliance_vault.js
+++ b/Javascript/alliance_vault.js
@@ -236,8 +236,10 @@ async function loadVaultHistory() {
 
   try {
     const actionFilter = document.getElementById('filter-action').value;
+    const daysFilter = document.getElementById('filter-days').value;
     const params = new URLSearchParams();
     if (actionFilter) params.append('action', actionFilter);
+    if (daysFilter) params.append('days', daysFilter);
     const res = await authFetch(`/api/vault/transactions?${params.toString()}`);
     const data = await res.json();
 

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -116,6 +116,14 @@ Author: Deathsgift66
             <option value="transfer">Transfers</option>
             <option value="trade">Trades</option>
           </select>
+          <label for="filter-days">Time:</label>
+          <select id="filter-days">
+            <option value="">All</option>
+            <option value="1">Last Day</option>
+            <option value="7">Last 7 Days</option>
+            <option value="30">Last 30 Days</option>
+            <option value="90">Last 90 Days</option>
+          </select>
           <button id="apply-trans-filter" class="action-btn">Apply</button>
         </div>
         <div class="transaction-table custom-scrollbar">


### PR DESCRIPTION
## Summary
- implement helper to fetch alliance info
- allow vault deposits and enforce withdrawal role requirement
- add date filter for vault transaction history
- expose new filter fields in vault HTML and JS
- update tests for vault router

## Testing
- `PYTHONPATH=. pytest tests/test_alliance_vault_router.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68488c7d7ee0833089e48009d8934bf5