### PR TITLE
Add alliance leaderboard metrics

### DIFF
--- a/Javascript/leaderboard.js
+++ b/Javascript/leaderboard.js
@@ -10,6 +10,23 @@ import { supabase } from './supabaseClient.js';
 
 let currentTab = "kingdoms";
 
+const headers = {
+  kingdoms: ["Rank", "Kingdom", "Ruler", "Power", "Economy"],
+  alliances: [
+    "Rank",
+    "Alliance",
+    "Military",
+    "Economy",
+    "Diplomacy",
+    "Wins",
+    "Losses",
+    "Prestige",
+    "Apply",
+  ],
+  wars: ["Rank", "Kingdom", "Ruler", "Wins", "Losses"],
+  economy: ["Rank", "Kingdom", "Ruler", "Trade", "Market %"],
+};
+
 document.addEventListener("DOMContentLoaded", async () => {
   // ✅ Bind logout
   const logoutBtn = document.getElementById("logout-btn");
@@ -61,20 +78,27 @@ function setupTabs() {
 // ✅ Load Leaderboard
 async function loadLeaderboard(type) {
   const tbody = document.getElementById("leaderboard-body");
+  const headerRow = document.getElementById("leaderboard-headers");
+
+  const cols = headers[type] ? headers[type].length : 5;
 
   tbody.innerHTML = `
-    <tr><td colspan="5">Loading leaderboard...</td></tr>
+    <tr><td colspan="${cols}">Loading leaderboard...</td></tr>
   `;
 
   try {
     const res = await fetch(`/api/leaderboard/${type}`);
     const data = await res.json();
 
+    if (headers[type]) {
+      headerRow.innerHTML = headers[type].map(h => `<th>${h}</th>`).join("");
+    }
+
     tbody.innerHTML = "";
 
     if (!data.entries || data.entries.length === 0) {
       tbody.innerHTML = `
-        <tr><td colspan="5">No results available.</td></tr>
+        <tr><td colspan="${cols}">No results available.</td></tr>
       `;
       return;
     }
@@ -95,8 +119,12 @@ async function loadLeaderboard(type) {
         row.innerHTML = `
           <td>${index + 1}</td>
           <td>${escapeHTML(entry.alliance_name)}</td>
-          <td>${entry.member_count}</td>
-          <td>${entry.total_power}</td>
+          <td>${entry.military_score}</td>
+          <td>${entry.economy_score}</td>
+          <td>${entry.diplomacy_score}</td>
+          <td>${entry.war_wins}</td>
+          <td>${entry.war_losses}</td>
+          <td>${entry.prestige_score ?? '—'}</td>
           <td>
             <button class="action-btn apply-btn" data-alliance-id="${entry.alliance_id}" data-alliance-name="${escapeHTML(entry.alliance_name)}">Apply</button>
           </td>
@@ -139,7 +167,7 @@ async function loadLeaderboard(type) {
   } catch (err) {
     console.error(`❌ Error loading ${type} leaderboard:`, err);
     tbody.innerHTML = `
-      <tr><td colspan="5">Failed to load leaderboard.</td></tr>
+      <tr><td colspan="${cols}">Failed to load leaderboard.</td></tr>
     `;
   }
 }

--- a/backend/routers/leaderboard.py
+++ b/backend/routers/leaderboard.py
@@ -4,13 +4,89 @@ from ..security import verify_jwt_token
 
 
 from ..supabase_client import get_supabase_client
+from ..database import get_db
+from sqlalchemy.orm import Session
+from sqlalchemy import func, case, or_
+from ..models import Alliance, AllianceWar, AllianceWarScore
 
 router = APIRouter(prefix="/api/leaderboard", tags=["leaderboard"])
 
 
 @router.get("/{type}")
-async def leaderboard(type: str, user_id: str = Depends(verify_jwt_token)):
-    """Return leaderboard data from Supabase."""
+async def leaderboard(
+    type: str,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    """Return leaderboard data."""
+    if type == "alliances":
+        win_case = case(
+            (
+                (AllianceWar.attacker_alliance_id == Alliance.alliance_id)
+                & (AllianceWarScore.victor == "attacker"),
+                1,
+            ),
+            (
+                (AllianceWar.defender_alliance_id == Alliance.alliance_id)
+                & (AllianceWarScore.victor == "defender"),
+                1,
+            ),
+            else_=0,
+        )
+        loss_case = case(
+            (
+                (AllianceWar.attacker_alliance_id == Alliance.alliance_id)
+                & (AllianceWarScore.victor == "defender"),
+                1,
+            ),
+            (
+                (AllianceWar.defender_alliance_id == Alliance.alliance_id)
+                & (AllianceWarScore.victor == "attacker"),
+                1,
+            ),
+            else_=0,
+        )
+
+        rows = (
+            db.query(
+                Alliance.alliance_id,
+                Alliance.name.label("alliance_name"),
+                Alliance.military_score,
+                Alliance.economy_score,
+                Alliance.diplomacy_score,
+                func.coalesce(func.sum(win_case), 0).label("war_wins"),
+                func.coalesce(func.sum(loss_case), 0).label("war_losses"),
+            )
+            .outerjoin(
+                AllianceWar,
+                or_(
+                    AllianceWar.attacker_alliance_id == Alliance.alliance_id,
+                    AllianceWar.defender_alliance_id == Alliance.alliance_id,
+                ),
+            )
+            .outerjoin(
+                AllianceWarScore,
+                AllianceWarScore.alliance_war_id == AllianceWar.alliance_war_id,
+            )
+            .group_by(Alliance.alliance_id)
+            .order_by(Alliance.military_score.desc())
+            .limit(50)
+            .all()
+        )
+        entries = [
+            {
+                "alliance_id": r.alliance_id,
+                "alliance_name": r.alliance_name,
+                "military_score": r.military_score or 0,
+                "economy_score": r.economy_score or 0,
+                "diplomacy_score": r.diplomacy_score or 0,
+                "war_wins": r.war_wins or 0,
+                "war_losses": r.war_losses or 0,
+            }
+            for r in rows
+        ]
+        return {"entries": entries}
+
     table_map = {
         "kingdoms": "leaderboard_kingdoms",
         "alliances": "leaderboard_alliances",

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -75,7 +75,7 @@ Author: Deathsgift66
       <!-- JS will dynamically populate based on active tab -->
       <table class="leaderboard-table">
         <thead>
-          <tr>
+          <tr id="leaderboard-headers">
             <th>Rank</th>
             <th>Player / Alliance</th>
             <th>Score</th>

--- a/tests/test_leaderboard_router.py
+++ b/tests/test_leaderboard_router.py
@@ -1,0 +1,28 @@
+import asyncio
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.database import Base
+from backend.models import Alliance, AllianceWar, AllianceWarScore
+from backend.routers import leaderboard
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def test_alliance_leaderboard_returns_stats():
+    Session = setup_db()
+    db = Session()
+    db.add(Alliance(alliance_id=1, name="A", military_score=10, economy_score=5, diplomacy_score=2))
+    db.add(Alliance(alliance_id=2, name="B", military_score=8, economy_score=7, diplomacy_score=3))
+    db.add(AllianceWar(alliance_war_id=1, attacker_alliance_id=1, defender_alliance_id=2))
+    db.add(AllianceWarScore(alliance_war_id=1, attacker_score=5, defender_score=2, victor="attacker"))
+    db.commit()
+
+    result = asyncio.run(leaderboard.leaderboard("alliances", user_id="u1", db=db))
+    assert result["entries"][0]["war_wins"] == 1
+    assert result["entries"][0]["military_score"] == 10


### PR DESCRIPTION
## Summary
- add dynamic header row for leaderboard table
- show additional alliance metrics on leaderboard
- compute alliance stats in leaderboard router
- test alliance leaderboard logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68488db22e3883308f390c9b4175ed89