### PR TITLE
Implement alliance role enforcement

### DIFF
--- a/backend/routers/alliance_members.py
+++ b/backend/routers/alliance_members.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 from ..database import get_db
 from ..models import AllianceMember
 from services.audit_service import log_action
+from services.role_service import AllianceRole, require_role
 
 router = APIRouter(prefix="/api/alliance_members", tags=["alliance_members"])
 
@@ -116,6 +117,7 @@ def promote(
     user_id: str = Depends(get_current_user_id),
     db: Session = Depends(get_db),
 ):
+    require_role(db, user_id, {AllianceRole.LEADER, AllianceRole.OFFICER})
     member = (
         db.query(AllianceMember)
         .filter(
@@ -158,6 +160,7 @@ def remove(
     user_id: str = Depends(get_current_user_id),
     db: Session = Depends(get_db),
 ):
+    require_role(db, user_id, {AllianceRole.LEADER, AllianceRole.OFFICER})
     member = (
         db.query(AllianceMember)
         .filter(

--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -6,6 +6,7 @@ from ..database import get_db
 from ..models import AllianceVault, AllianceVaultTransactionLog, User
 from services.audit_service import log_action
 from services.trade_log_service import record_trade
+from services.role_service import AllianceRole, require_role
 
 router = APIRouter(prefix="/api/alliance-vault", tags=["alliance_vault"])
 # Secondary router mirroring simplified REST style endpoints used by the
@@ -133,6 +134,7 @@ def withdraw(
     user_id: str = Depends(get_current_user_id),
     db: Session = Depends(get_db),
 ):
+    require_role(db, user_id, {AllianceRole.LEADER, AllianceRole.OFFICER})
     supabase = get_supabase_client()
     alliance_res = (
         supabase.table("users")

--- a/backend/routers/alliance_wars.py
+++ b/backend/routers/alliance_wars.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from ..database import get_db
 from .progression_router import get_user_id, get_kingdom_id
 from services.audit_service import log_action, log_alliance_activity
+from services.role_service import AllianceRole, require_role
 from ..models import Notification
 
 router = APIRouter(prefix="/api/alliance-wars", tags=["alliance_wars"])
@@ -52,7 +53,7 @@ def declare_war(
     user_id: str = Depends(get_user_id),
     db: Session = Depends(get_db),
 ):
-    attacker = get_alliance_id(db, user_id)
+    attacker, _ = require_role(db, user_id, {AllianceRole.LEADER, AllianceRole.OFFICER})
     row = db.execute(
         text(
             "INSERT INTO alliance_wars (attacker_alliance_id, defender_alliance_id, phase, war_status) "

--- a/migrations/2025_06_28_enable_alliance_rls.sql
+++ b/migrations/2025_06_28_enable_alliance_rls.sql
@@ -1,0 +1,78 @@
+-- Migration: enable row level security on alliance tables
+
+ALTER TABLE public.alliances ENABLE ROW LEVEL SECURITY;
+CREATE POLICY alliance_read_own ON public.alliances
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.alliance_members m
+      WHERE m.alliance_id = alliances.alliance_id
+        AND m.user_id = auth.uid()
+    )
+  );
+
+ALTER TABLE public.alliance_members ENABLE ROW LEVEL SECURITY;
+CREATE POLICY alliance_members_self ON public.alliance_members
+  FOR ALL USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+ALTER TABLE public.alliance_roles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY alliance_roles_read ON public.alliance_roles
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.alliance_members m
+      WHERE m.alliance_id = alliance_roles.alliance_id
+        AND m.user_id = auth.uid()
+    )
+  );
+
+ALTER TABLE public.alliance_vault ENABLE ROW LEVEL SECURITY;
+CREATE POLICY alliance_vault_rw ON public.alliance_vault
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM public.alliance_members m
+      WHERE m.alliance_id = alliance_vault.alliance_id
+        AND m.user_id = auth.uid()
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.alliance_members m
+      WHERE m.alliance_id = alliance_vault.alliance_id
+        AND m.user_id = auth.uid()
+    )
+  );
+
+ALTER TABLE public.alliance_vault_transaction_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY alliance_vault_log_read ON public.alliance_vault_transaction_log
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.alliance_members m
+      WHERE m.alliance_id = alliance_vault_transaction_log.alliance_id
+        AND m.user_id = auth.uid()
+    )
+  );
+
+ALTER TABLE public.alliance_treaties ENABLE ROW LEVEL SECURITY;
+CREATE POLICY alliance_treaties_access ON public.alliance_treaties
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM public.alliance_members m
+      WHERE m.alliance_id IN (alliance_treaties.alliance_id, alliance_treaties.partner_alliance_id)
+        AND m.user_id = auth.uid()
+    )
+  ) WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.alliance_members m
+      WHERE m.alliance_id = alliance_treaties.alliance_id
+        AND m.user_id = auth.uid()
+    )
+  );
+
+ALTER TABLE public.alliance_wars ENABLE ROW LEVEL SECURITY;
+CREATE POLICY alliance_wars_access ON public.alliance_wars
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.alliance_members m
+      WHERE m.alliance_id IN (alliance_wars.attacker_alliance_id, alliance_wars.defender_alliance_id)
+        AND m.user_id = auth.uid()
+    )
+  );

--- a/services/role_service.py
+++ b/services/role_service.py
@@ -1,0 +1,30 @@
+from typing import Iterable, Tuple
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+class AllianceRole:
+    LEADER = "Leader"
+    OFFICER = "Officer"
+    MEMBER = "Member"
+    APPLICANT = "Applicant"
+    BANNED = "Banned"
+
+
+def get_user_alliance_role(db: Session, user_id: str) -> Tuple[int, str]:
+    row = db.execute(
+        text("SELECT alliance_id, alliance_role FROM users WHERE user_id = :uid"),
+        {"uid": user_id},
+    ).fetchone()
+    if not row or row[0] is None:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+    aid, role = row
+    return aid, role or AllianceRole.MEMBER
+
+
+def require_role(db: Session, user_id: str, allowed: Iterable[str]) -> Tuple[int, str]:
+    aid, role = get_user_alliance_role(db, user_id)
+    if role not in allowed:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    return aid, role

--- a/tests/test_alliance_members_router.py
+++ b/tests/test_alliance_members_router.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from backend.database import Base
-from backend.models import AllianceMember
+from backend.models import AllianceMember, User
 from backend.routers.alliance_members import promote, RankPayload
 
 
@@ -17,6 +17,7 @@ def test_promote_updates_rank():
     Session = setup_db()
     db = Session()
     db.add(AllianceMember(alliance_id=1, user_id="u1", username="A", rank="Member"))
+    db.add(User(user_id="admin", username="admin", email="a@example.com", alliance_id=1, alliance_role="Leader"))
     db.commit()
 
     promote(RankPayload(user_id="u1", alliance_id=1, new_rank="Leader"), user_id="admin", db=db)

--- a/tests/test_alliance_vault_router.py
+++ b/tests/test_alliance_vault_router.py
@@ -21,6 +21,8 @@ def create_user(db):
         username="tester",
         display_name="Test User",
         email="t@example.com",
+        alliance_id=1,
+        alliance_role="Leader",
     )
     db.add(user)
     db.commit()
@@ -34,7 +36,8 @@ def test_deposit_and_withdraw():
 
     deposit(
         VaultTransaction(alliance_id=1, resource="wood", amount=100, user_id=user_id),
-        db,
+        user_id=user_id,
+        db=db,
     )
     vault = db.query(AllianceVault).filter_by(alliance_id=1).first()
     assert vault.wood == 100
@@ -45,7 +48,8 @@ def test_deposit_and_withdraw():
 
     withdraw(
         VaultTransaction(alliance_id=1, resource="wood", amount=40, user_id=user_id),
-        db,
+        user_id=user_id,
+        db=db,
     )
     vault = db.query(AllianceVault).filter_by(alliance_id=1).first()
     assert vault.wood == 60

--- a/tests/test_alliance_wars_router.py
+++ b/tests/test_alliance_wars_router.py
@@ -29,6 +29,7 @@ def seed_user(db):
         email="t@example.com",
         kingdom_id=1,
         alliance_id=1,
+        alliance_role="Leader",
     )
     db.add(user)
     db.commit()


### PR DESCRIPTION
## Summary
- add helper for alliance roles
- restrict promotion, kick, vault withdraw and war declaration
- enable row level security on alliance tables
- update tests for new role checks

## Testing
- `pytest tests/test_alliance_members_router.py::test_promote_updates_rank -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68488c4f18b083309fc1d83d61a7f06f