### PR TITLE
Enhance alliance treaty features

### DIFF
--- a/backend/routers/compose.py
+++ b/backend/routers/compose.py
@@ -26,6 +26,8 @@ class NoticePayload(BaseModel):
 class TreatyPayload(BaseModel):
     partner_alliance_id: int
     treaty_type: str
+    notes: str | None = None
+    end_date: str | None = None
 
 
 class WarPayload(BaseModel):
@@ -97,10 +99,16 @@ def propose_treaty(
 
     db.execute(
         text(
-            "INSERT INTO alliance_treaties (alliance_id, treaty_type, partner_alliance_id, status) "
-            "VALUES (:aid, :type, :pid, 'proposed')"
+            "INSERT INTO alliance_treaties (alliance_id, treaty_type, partner_alliance_id, status, notes, end_date) "
+            "VALUES (:aid, :type, :pid, 'proposed', :notes, :ed)"
         ),
-        {"aid": aid, "type": payload.treaty_type, "pid": payload.partner_alliance_id},
+        {
+            "aid": aid,
+            "type": payload.treaty_type,
+            "pid": payload.partner_alliance_id,
+            "notes": payload.notes,
+            "ed": payload.end_date,
+        },
     )
     db.commit()
     log_action(db, user_id, "propose_treaty", payload.treaty_type)

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -69,9 +69,16 @@ Author: Deathsgift66
 
   <section class="treaty-list panel">
     <h2>Alliance Treaties</h2>
+    <label for="treaty-filter">Filter:</label>
+    <select id="treaty-filter">
+      <option value="">All</option>
+      <option value="active">Active</option>
+      <option value="expired">Expired</option>
+      <option value="proposed">Pending</option>
+    </select>
     <table class="treaties-table">
       <thead>
-        <tr><th>Type</th><th>Partner</th><th>Status</th><th>Signed</th><th>Actions</th></tr>
+        <tr><th>Type</th><th>Partner</th><th>Status</th><th>Signed</th><th>Expires</th><th>Actions</th></tr>
       </thead>
       <tbody id="treaty-rows" aria-live="polite"></tbody>
     </table>
@@ -87,6 +94,10 @@ Author: Deathsgift66
     </select>
     <label for="partner-alliance-id">Partner Alliance ID:</label>
     <input type="number" id="partner-alliance-id" />
+    <label for="treaty-notes">Notes:</label>
+    <textarea id="treaty-notes"></textarea>
+    <label for="treaty-end">End Date:</label>
+    <input type="date" id="treaty-end" />
     <button class="btn" onclick="proposeTreaty()">Submit Proposal</button>
   </section>
 </main>

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -485,8 +485,10 @@ CREATE TABLE public.alliance_treaties (
   alliance_id integer,
   treaty_type text,
   partner_alliance_id integer,
-  status text CHECK (status IN ('proposed','active','cancelled')) DEFAULT 'proposed',
+  status text CHECK (status IN ('proposed','active','cancelled','expired')) DEFAULT 'proposed',
   signed_at timestamp with time zone DEFAULT now(),
+  notes text,
+  end_date timestamp with time zone,
   CONSTRAINT alliance_treaties_pkey PRIMARY KEY (treaty_id),
   CONSTRAINT alliance_treaties_alliance_id_fkey FOREIGN KEY (alliance_id) REFERENCES public.alliances(alliance_id),
   CONSTRAINT alliance_treaties_partner_alliance_id_fkey FOREIGN KEY (partner_alliance_id) REFERENCES public.alliances(alliance_id)
@@ -496,8 +498,10 @@ CREATE TABLE public.kingdom_treaties (
   kingdom_id integer,
   treaty_type text,
   partner_kingdom_id integer,
-  status text CHECK (status IN ('proposed','active','cancelled')) DEFAULT 'proposed',
+  status text CHECK (status IN ('proposed','active','cancelled','expired')) DEFAULT 'proposed',
   signed_at timestamp with time zone,
+  notes text,
+  end_date timestamp with time zone,
   CONSTRAINT kingdom_treaties_pkey PRIMARY KEY (treaty_id),
   CONSTRAINT kingdom_treaties_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id),
   CONSTRAINT kingdom_treaties_partner_kingdom_id_fkey FOREIGN KEY (partner_kingdom_id) REFERENCES public.kingdoms(kingdom_id)

--- a/migrations/2025_06_20_add_treaty_notes_end_date.sql
+++ b/migrations/2025_06_20_add_treaty_notes_end_date.sql
@@ -1,0 +1,9 @@
+-- Migration: add notes and end_date columns to treaties
+ALTER TABLE public.alliance_treaties
+  ADD COLUMN notes text,
+  ADD COLUMN end_date timestamp with time zone,
+  ADD COLUMN status text CHECK (status IN ('proposed','active','cancelled','expired')) DEFAULT 'proposed';
+ALTER TABLE public.kingdom_treaties
+  ADD COLUMN notes text,
+  ADD COLUMN end_date timestamp with time zone,
+  ADD COLUMN status text CHECK (status IN ('proposed','active','cancelled','expired')) DEFAULT 'proposed';


### PR DESCRIPTION
## Summary
- extend treaty table schema with notes and end dates
- expose treaty filter and expiry handling in diplomacy APIs
- allow treaties to be renewed and cancelled via API
- update diplomacy center UI and JS to handle new form fields, filters and actions
- add migration for new treaty columns

## Testing
- `python -m py_compile backend/routers/diplomacy_center.py backend/routers/alliance_treaties_router.py backend/routers/compose.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68488fa6e20c8330a637ed99502a9216