### PR TITLE
Implement Alliance Quest progression and rewards

### DIFF
--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -137,6 +137,7 @@ Author: Deathsgift66
         <div class="modal-action-area">
           <p id="role-check-message" class="role-check-message"></p>
           <button class="action-btn medieval-banner-btn accept-quest-btn hidden" id="accept-quest-button" title="Accept This Quest">Accept Quest</button>
+          <button class="action-btn medieval-banner-btn claim-reward-btn hidden" id="claim-reward-button" title="Claim Quest Reward">Claim Reward</button>
         </div>
       </div>
     </div>

--- a/backend/models.py
+++ b/backend/models.py
@@ -699,6 +699,7 @@ class QuestAllianceTracking(Base):
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
     attempt_count = Column(Integer, default=1)
+    reward_claimed = Column(Boolean, default=False)
     started_by = Column(UUID(as_uuid=True), ForeignKey("users.user_id"))
 
 

--- a/tests/test_alliance_quests_router.py
+++ b/tests/test_alliance_quests_router.py
@@ -132,3 +132,75 @@ def test_detail_returns_tracking_and_contributions():
     assert res["quest_code"] == "q1"
     assert res["progress"] == 25
     assert len(res["contributions"]) == 1
+
+
+def test_progress_marks_completed_and_chains():
+    Session = setup_db()
+    db = Session()
+    uid = create_user(db)
+    db.add(
+        QuestAllianceCatalogue(
+            quest_code="q1",
+            name="One",
+            is_active=True,
+            rewards={"unlock_next": "q2"},
+        )
+    )
+    db.add(QuestAllianceCatalogue(quest_code="q2", name="Two", is_active=True))
+    db.add(
+        QuestAllianceTracking(
+            alliance_id=1,
+            quest_code="q1",
+            status="active",
+            progress=90,
+        )
+    )
+    db.commit()
+
+    alliance_quests.update_progress(
+        alliance_quests.ProgressPayload(quest_code="q1", amount=15),
+        user_id=uid,
+        db=db,
+    )
+    row = (
+        db.query(QuestAllianceTracking)
+        .filter_by(alliance_id=1, quest_code="q1")
+        .first()
+    )
+    assert row.status == "completed" and row.progress == 100
+    chained = (
+        db.query(QuestAllianceTracking)
+        .filter_by(alliance_id=1, quest_code="q2")
+        .first()
+    )
+    assert chained is not None and chained.status == "active"
+
+
+def test_claim_reward_sets_flag():
+    Session = setup_db()
+    db = Session()
+    uid = create_user(db)
+    db.add(
+        QuestAllianceCatalogue(quest_code="q3", name="Three", is_active=True)
+    )
+    db.add(
+        QuestAllianceTracking(
+            alliance_id=1,
+            quest_code="q3",
+            status="completed",
+            progress=100,
+        )
+    )
+    db.commit()
+
+    alliance_quests.claim_reward(
+        alliance_quests.ClaimPayload(quest_code="q3"),
+        user_id=uid,
+        db=db,
+    )
+    row = (
+        db.query(QuestAllianceTracking)
+        .filter_by(alliance_id=1, quest_code="q3")
+        .first()
+    )
+    assert row.reward_claimed is True


### PR DESCRIPTION
## Summary
- extend `QuestAllianceTracking` with `reward_claimed`
- allow restarting repeatable quests
- add progress update endpoint that can chain quests
- add reward claim endpoint for officers
- display reward categories and show claim button in quest modal
- tests for progress update and reward claiming

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several modules)*

------
https://chatgpt.com/codex/tasks/task_e_6848a00d10908330ac4db2dc1e21b01c