### PR TITLE
Add env example and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Example environment configuration for local development
+
+# Supabase Project URL
+VITE_SUPABASE_URL=https://your-supabase-url.supabase.co
+SUPABASE_URL=https://your-supabase-url.supabase.co
+
+# Supabase Public Anon Key
+VITE_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_ANON_KEY=your-anon-key
+
+# Optional: Supabase Service Role Key (if available)
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore environment file containing credentials
+.ENV
+
+# Node modules and Python caches
+node_modules/
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This repository contains the pre-alpha frontend and accompanying FastAPI backend
      ```
 
 2. **Environment Variables**
-   - Copy `.ENV` and update the Supabase credentials (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`).
+   - Copy `.env.example` to `.ENV` and update the Supabase credentials (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`).
    - If you have a service role key, set `SUPABASE_SERVICE_ROLE_KEY` as well.
 
 3. **Backend**

--- a/FILE_LIST.md
+++ b/FILE_LIST.md
@@ -1,7 +1,7 @@
 # Repository File List
 
 ## Environment Files
-- .ENV
+- .env.example
 
 ## HTML Files
 - account_settings.html

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ psql -f full_schema.sql
 
 ### Supabase Configuration
 
-Environment variables for the Supabase connection are loaded from the `.ENV` file at the project root. The key variables are:
+Environment variables for the Supabase connection are loaded from the `.ENV` file at the project root. Copy `.env.example` to `.ENV` and update it with your credentials. The key variables are:
 
 ```
 SUPABASE_URL


### PR DESCRIPTION
## Summary
- provide example environment file
- ignore `.ENV` credentials
- mention copying `.env.example` in README and AGENTS
- update file listing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849678782e08330a49d2eb303f1d301