### PR TITLE
Implement health check endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -63,6 +63,7 @@ from .routers import (
     treaty_web,
     village_master as village_master_router,
     world_map,
+    health,
 )
 from .database import engine
 from .models import Base
@@ -134,6 +135,7 @@ app.include_router(profile_view.router)
 app.include_router(navbar.router)
 app.include_router(seasonal_effects.router)
 app.include_router(world_map.router)
+app.include_router(health.router)
 app.include_router(overview_router.router)
 app.include_router(signup_router.router)
 app.include_router(treaty_web.router)

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/health", tags=["health"])
+
+
+@router.get("/")
+async def health_check():
+    """Simple health check endpoint for uptime monitoring."""
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add new health router with simple `/api/health` endpoint
- register router in `backend/main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `backend` and `sqlalchemy`)*

------
https://chatgpt.com/codex/tasks/task_e_684969191e408330af853ef70d307922