### PR TITLE
Add development requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ the records created during onboarding.
 - SPA-ready → Netlify optimized
 - No framework (Vanilla + Modules) → lean, fast
 
+
+## Development Setup
+
+Install Python dependencies with:
+```bash
+pip install -r dev_requirements.txt
+```
+
 ---
 
 ## Database Setup

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pytest
+pytest-asyncio
+httpx
+coverage


### PR DESCRIPTION
## Summary
- add `dev_requirements.txt` for installing test packages
- document dev install step in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68496a5d15e883308da7a23ea373ff74