### PR TITLE
Add GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r dev_requirements.txt
+
+      - name: Run tests
+        run: |
+          source venv/bin/activate
+          pytest


### PR DESCRIPTION
## Summary
- add workflow to run pytest on pushes and PRs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68496a98393c8330be5df8cf7f596dd0