### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -75,6 +75,12 @@ app = FastAPI(title="Kingmaker's Rise API")
 Base.metadata.create_all(bind=engine)
 load_game_settings()
 
+
+@app.get("/api/health")
+async def healthcheck():
+    """Simple healthcheck endpoint for uptime monitoring."""
+    return {"status": "ok"}
+
 app.include_router(alliance_members.router)
 app.include_router(alliance_members_view.router)
 app.include_router(admin.router)

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -1,0 +1,7 @@
+import asyncio
+from backend.main import healthcheck
+
+
+def test_healthcheck_returns_ok():
+    result = asyncio.run(healthcheck())
+    assert result == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add a `/api/health` route to `backend/main.py`
- include new test for the healthcheck endpoint

## Testing
- `pip install -r requirements.txt` *(fails: externally-managed-environment)*
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496ac1ae248330890f62193f237009