### PR TITLE
Fix BaseModel import

### DIFF
--- a/backend/routers/admin_dashboard.py
+++ b/backend/routers/admin_dashboard.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 from typing import Any, Optional
+from pydantic import BaseModel
 
 from ..database import get_db
 from .progression_router import get_user_id


### PR DESCRIPTION
## Summary
- add missing BaseModel import in `admin_dashboard` router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68496ba366ec833092cdc8616f4fd827