### PR TITLE
Fix imports and update pytest config

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -40,7 +40,7 @@ from .routers import (
     admin_dashboard,
     account_settings,
     spies_router,
-    policies_laws_router,
+    policies_laws as policies_laws_router,
     overview as overview_router,
     legal,
     trade_logs,

--- a/backend/models.py
+++ b/backend/models.py
@@ -16,6 +16,18 @@ from sqlalchemy.sql import func
 from .database import Base
 
 
+class Kingdom(Base):
+    """Minimal kingdom model for tests and basic relations."""
+
+    __tablename__ = "kingdoms"
+
+    kingdom_id = Column(Integer, primary_key=True)
+    user_id = Column(UUID(as_uuid=True))
+    kingdom_name = Column(String, nullable=False)
+    region = Column(String)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
 class User(Base):
     __tablename__ = "users"
     user_id = Column(UUID(as_uuid=True), primary_key=True)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-python_paths = .
+addopts = --import-mode=importlib


### PR DESCRIPTION
## Summary
- define a minimal `Kingdom` model used in tests
- import the correct policies router in `main.py`
- switch pytest config to importlib mode

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68496d2245c08330ae5279da0e896b58