### PR TITLE
Fix CI paths and define Kingdom model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ jobs:
         run: pip install -r requirements.txt
       - name: Run tests
         run: |
-          export PYTHONPATH=$(pwd)
+          echo "PYTHONPATH=$PWD" >> $GITHUB_ENV
           pytest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
           source venv/bin/activate
           pip install -r dev_requirements.txt
 
+      - name: Set PYTHONPATH
+        run: echo "PYTHONPATH=$PWD" >> $GITHUB_ENV
+
       - name: Run tests
         run: |
           source venv/bin/activate

--- a/backend/models.py
+++ b/backend/models.py
@@ -43,6 +43,14 @@ class User(Base):
     )
 
 
+class Kingdom(Base):
+    __tablename__ = "kingdoms"
+
+    kingdom_id = Column(Integer, primary_key=True)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.user_id"))
+    kingdom_name = Column(String)
+
+
 class PlayerMessage(Base):
     __tablename__ = "player_messages"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-python_paths = .
+addopts = --import-mode=importlib


### PR DESCRIPTION
## Summary
- add `PYTHONPATH` setup step in GitHub Actions
- remove invalid `python_paths` from pytest.ini
- add minimal `Kingdom` model

## Testing
- `pip install fastapi==0.110.1 --break-system-packages` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496ef8b4408330acd916c0abefd3ac