### PR TITLE
Centralize SQLAlchemy Base

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,13 +1,13 @@
 import os
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.orm import sessionmaker
+from .db_base import Base
 
 DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://postgres:postgres@localhost/postgres')
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-Base = declarative_base()
 
 
 def get_db():

--- a/backend/db_base.py
+++ b/backend/db_base.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/backend/models.py
+++ b/backend/models.py
@@ -13,7 +13,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.sql import func
-from .database import Base
+from backend.db_base import Base
 
 
 class Kingdom(Base):

--- a/models/progression.py
+++ b/models/progression.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
-from backend.database import Base
+from backend.db_base import Base
 
 
 class KingdomCastleProgression(Base):

--- a/tests/test_alliance_members_router.py
+++ b/tests/test_alliance_members_router.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import AllianceMember, Alliance
 from backend.routers.alliance_members import (
     promote,

--- a/tests/test_alliance_projects_router.py
+++ b/tests/test_alliance_projects_router.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytest
 
 from fastapi import HTTPException
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import (
     Alliance,
     ProjectAllianceCatalogue,

--- a/tests/test_alliance_quests_router.py
+++ b/tests/test_alliance_quests_router.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import (
     Alliance,
     User,

--- a/tests/test_alliance_vault_router.py
+++ b/tests/test_alliance_vault_router.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import Alliance, AllianceVault, AllianceVaultTransactionLog, TradeLog, User
 from backend.routers.alliance_vault import VaultTransaction, deposit, withdraw, summary
 

--- a/tests/test_alliance_wars_router.py
+++ b/tests/test_alliance_wars_router.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import User, AllianceWar, AllianceWarPreplan
 from backend.routers.alliance_wars import (
     list_wars,

--- a/tests/test_battle_router.py
+++ b/tests/test_battle_router.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from fastapi import HTTPException
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import WarScore
 from backend.routers.battle import get_battle_scoreboard
 

--- a/tests/test_black_market.py
+++ b/tests/test_black_market.py
@@ -2,7 +2,7 @@ import uuid
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import BlackMarketListing, TradeLog, User
 from backend.routers.black_market import (
     ListingPayload,

--- a/tests/test_conflicts_router.py
+++ b/tests/test_conflicts_router.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from fastapi import HTTPException
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import User
 from backend.routers import conflicts
 

--- a/tests/test_forgot_password_router.py
+++ b/tests/test_forgot_password_router.py
@@ -4,7 +4,7 @@ import uuid
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import User, Notification
 from backend.routers import forgot_password as fp
 

--- a/tests/test_leaderboard_router.py
+++ b/tests/test_leaderboard_router.py
@@ -2,7 +2,7 @@ import asyncio
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import Alliance, AllianceWar, AllianceWarScore
 from backend.routers import leaderboard
 

--- a/tests/test_messages_router.py
+++ b/tests/test_messages_router.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import sessionmaker
 
 import uuid
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import User, PlayerMessage
 from backend.routers.messages import (
     send_message,
@@ -15,7 +15,7 @@ from backend.routers.messages import (
 )
 
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import User, PlayerMessage
 from backend.routers import messages
 

--- a/tests/test_notifications_router.py
+++ b/tests/test_notifications_router.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import Notification, User
 from backend.routers.notifications import (
     NotificationAction,

--- a/tests/test_quests_router.py
+++ b/tests/test_quests_router.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import User, Kingdom, QuestKingdomTracking
 from backend.routers.quests_router import get_active_quests
 

--- a/tests/test_resources_router.py
+++ b/tests/test_resources_router.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import User, KingdomResources
 from backend.routers.resources import get_resources
 

--- a/tests/test_village_modifiers_router.py
+++ b/tests/test_village_modifiers_router.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import User, VillageModifier
 from backend.routers.village_modifiers import (
     ModifierPayload,

--- a/tests/test_war_model.py
+++ b/tests/test_war_model.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import War
 
 

--- a/tests/test_wars_tactical_model.py
+++ b/tests/test_wars_tactical_model.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import WarsTactical, War
 
 

--- a/tests/test_world_map_router.py
+++ b/tests/test_world_map_router.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database import Base
+from backend.db_base import Base
 from backend.models import TerrainMap
 from backend.routers import world_map
 


### PR DESCRIPTION
## Summary
- centralize `Base` declarative setup under `backend/db_base.py`
- update database and models to import from the new module
- fix imports across models and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6849b1de8a7c83309be839be3d6a13e6