### PR TITLE
Refactor to Supabase client

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,16 +1,27 @@
+"""Optional SQLAlchemy database engine for migrations and tests."""
+
+import logging
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from .db_base import Base
 
-DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://postgres:postgres@localhost/postgres')
+DATABASE_URL = os.getenv("DATABASE_URL")
 
-engine = create_engine(DATABASE_URL)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+if DATABASE_URL:
+    engine = create_engine(DATABASE_URL)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+else:
+    engine = None
+    SessionLocal = None
+    logging.warning("DATABASE_URL not set; SQLAlchemy engine disabled")
 
 
 
 def get_db():
+    if SessionLocal is None:
+        raise RuntimeError("DATABASE_URL not configured")
+
     db = SessionLocal()
     try:
         yield db

--- a/backend/main.py
+++ b/backend/main.py
@@ -71,8 +71,9 @@ from .data import load_game_settings
 
 app = FastAPI(title="Kingmaker's Rise API")
 
-# Ensure tables exist
-Base.metadata.create_all(bind=engine)
+# Ensure tables exist when an engine is configured
+if engine:
+    Base.metadata.create_all(bind=engine)
 load_game_settings()
 
 app.include_router(alliance_members.router)

--- a/backend/supabase_client.py
+++ b/backend/supabase_client.py
@@ -1,20 +1,31 @@
+"""Supabase client configuration for the API."""
+
+from __future__ import annotations
+
+import logging
 import os
 
 
-def get_supabase_client():
-    """Return a configured Supabase client or raise if unavailable."""
-    try:  # pragma: no cover - optional dependency
-        from supabase import create_client
-    except ImportError as e:  # pragma: no cover - library missing
-        raise RuntimeError("supabase client library not installed") from e
+try:  # pragma: no cover - optional dependency
+    from supabase import create_client
+except ImportError as e:  # pragma: no cover - library missing
+    raise RuntimeError("supabase client library not installed") from e
 
-    url = os.getenv("SUPABASE_URL")
-    key = (
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-        or os.getenv("SUPABASE_KEY")
-        or os.getenv("SUPABASE_ANON_KEY")
-    )
-    if not url or not key:
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+
+if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
+    logging.error("Supabase credentials missing; set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY")
+    supabase = None
+else:
+    supabase = create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+
+def get_supabase_client() -> "create_client":
+    """Return the configured Supabase client or raise if unavailable."""
+
+    if supabase is None:
         raise RuntimeError("Supabase credentials not configured")
+    return supabase
 
-    return create_client(url, key)


### PR DESCRIPTION
## Summary
- use SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in a shared client
- disable SQLAlchemy engine unless DATABASE_URL provided
- gate table creation on an available engine
- rewrite messages router to use Supabase queries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6849b4a0a6448330aa01f03cb7d07730