### PR TITLE
Sync documentation with latest schema

### DIFF
--- a/docs/kingdom_titles.md
+++ b/docs/kingdom_titles.md
@@ -28,4 +28,4 @@ ORDER BY awarded_at DESC;
 
 ## Active Title
 
-Players may select one title to show as their current badge. The `active_title` column on `kingdoms` stores this choice.
+Players may select one title to show as their current badge. The selection is typically saved in the `customizations` JSON column of the `kingdoms` table.

--- a/docs/player_messages.md
+++ b/docs/player_messages.md
@@ -9,27 +9,22 @@ The `player_messages` table stores direct player-to-player private mail. Each ro
 | `message_id` | Unique message ID (PK) |
 | `user_id` | Who sent the message (FK to `users.user_id`, `ON DELETE SET NULL`) |
 | `recipient_id` | Who received the message (FK to `users.user_id`, `ON DELETE SET NULL`) |
-| `subject` | Optional subject line |
 | `message` | Message text |
 | `sent_at` | When the message was sent |
 | `is_read` | Whether the recipient has read it |
-| `deleted_by_sender` | Soft-delete flag for sender |
-| `deleted_by_recipient` | Soft-delete flag for recipient |
-| `last_updated` | Timestamp of last update |
 
 ## Usage
 
 ### Sending a message
 ```sql
-INSERT INTO public.player_messages (user_id, recipient_id, subject, message)
-VALUES ('SENDER-UUID', 'RECIPIENT-UUID', 'Hello', 'Hello there!');
+INSERT INTO public.player_messages (user_id, recipient_id, message)
+VALUES ('SENDER-UUID', 'RECIPIENT-UUID', 'Hello there!');
 ```
 
 ### Listing inbox
 ```sql
 SELECT * FROM public.player_messages
 WHERE recipient_id = 'RECIPIENT-UUID'
-  AND deleted_by_recipient = false
 ORDER BY sent_at DESC
 LIMIT 50;
 ```
@@ -38,7 +33,6 @@ LIMIT 50;
 ```sql
 SELECT * FROM public.player_messages
 WHERE user_id = 'SENDER-UUID'
-  AND deleted_by_sender = false
 ORDER BY sent_at DESC
 LIMIT 50;
 ```
@@ -50,4 +44,4 @@ SET is_read = true
 WHERE message_id = ?;
 ```
 
-Messages should never be hard deleted. Use the deleted flags so players can recover messages and moderation can review disputes.
+Messages should never be hard deleted so moderation can review disputes if needed.

--- a/docs/policies_laws_catalogue.md
+++ b/docs/policies_laws_catalogue.md
@@ -11,22 +11,15 @@ This table defines every policy or law that can exist in the game. The catalogue
 | `name` | Display name. |
 | `description` | Full description of the rule. |
 | `effect_summary` | Short text summary for the UI. |
-| `category` | Grouping such as Economy, Military, Diplomacy, Religion. |
-| `modifiers` | JSON modifiers applied to game calculations. |
-| `unlock_at_level` | Minimum castle level required. |
-| `is_active` | Admin toggle to disable a rule. |
-| `created_at` | When the row was created. |
-| `last_updated` | Last time this row changed. |
 
 ## Usage
 
 Load available options for the Policies & Laws screen:
 ```sql
 SELECT * FROM public.policies_laws_catalogue
-WHERE is_active = true
-ORDER BY unlock_at_level, id;
+ORDER BY id;
 ```
 
-A player's selections are stored on the `users` table using `active_policy` and `active_laws[]`. When calculating effects, join to this catalogue and use the `modifiers` JSON to apply bonuses or penalties.
+A player's selections are stored on the `users` table using `active_policy` and `active_laws[]`. Use `effect_summary` to describe the impact in the UI and apply game logic accordingly.
 
 Only administrators should modify this catalogue so that gameplay rules remain consistent.

--- a/docs/project_alliance_catalogue.md
+++ b/docs/project_alliance_catalogue.md
@@ -6,13 +6,14 @@ The `project_alliance_catalogue` table defines every Alliance Project available 
 
 * Acts as a static catalogue managed by admins.
 * Each project describes how to unlock it, what it costs and what modifiers it provides.
-* Alliances reference a project via the `project_code` (sometimes called `project_key`).
+* Alliances reference a project via the `project_key` value.
 
 ## Table Structure
 
 | Column | Purpose |
 | --- | --- |
-| `project_code` | Short unique string identifier (primary key). |
+| `project_id` | Serial primary key. |
+| `project_key` | Short unique string identifier. |
 | `project_name` | Name shown to players. |
 | `description` | Detailed description. |
 | `category` | Project category such as `Military`, `Economic`, `Diplomatic`, `Special`. |
@@ -36,7 +37,7 @@ The `project_alliance_catalogue` table defines every Alliance Project available 
 ### Column breakdown
 
 * `project_id` – internal serial primary key.
-* `project_code` (or `project_key`) – stable external identifier used by other tables.
+* `project_key` – stable external identifier used by other tables.
 * `project_name` – display name in the UI.
 * `description` – long description of the project.
 * `category` – grouping for the UI such as economic, military or diplomatic.

--- a/docs/projects_alliance.md
+++ b/docs/projects_alliance.md
@@ -15,7 +15,7 @@ The `projects_alliance` table tracks every active or queued Alliance Project. Ea
 | `project_id` | Unique project instance identifier. Primary key. |
 | `alliance_id` | Alliance that owns this project. |
 | `name` | Project name (duplicated from catalogue). |
-| `project_key` | FK to `project_alliance_catalogue.project_code`. |
+| `project_key` | FK to `project_alliance_catalogue.project_key`. |
 | `progress` | Current build progress 0-100. |
 | `modifiers` | Bonuses applied when active. |
 | `start_time` | When construction started. |

--- a/docs/projects_player.md
+++ b/docs/projects_player.md
@@ -12,11 +12,6 @@ The `projects_player` table tracks every instance of a project that a kingdom ha
 | `power_score` | Contribution score used for rankings. |
 | `starts_at` | Timestamp when the project was started. |
 | `ends_at` | When the project finishes (`NULL` if permanent). |
-| `build_state` | `queued`, `building`, `completed` or `expired`. |
-| `is_active` | Whether the project effects are enabled. |
-| `started_by` | User who initiated the project. |
-| `last_updated` | Audit timestamp for modifications. |
-| `expires_at` | When temporary effects should expire. |
 
 ## Usage
 
@@ -44,7 +39,7 @@ Use the catalogue entry to determine build time, cost and modifiers.
 
 ### Completion and expiration
 
-When `ends_at` is reached apply the modifiers from the catalogue. If the project is temporary use `expires_at` to disable its effects later.
+When `ends_at` is reached apply the modifiers from the catalogue and mark the project complete.
 
 ## Best Practices
 
@@ -64,4 +59,4 @@ WHERE kingdom_id = ?
 
 1. Player starts a project → insert row with start and end timestamps.
 2. On game ticks or login check `ends_at` and apply bonuses.
-3. Expire temporary projects using `expires_at` and `is_active`.
+3. Expire temporary effects when `ends_at` has passed.

--- a/docs/unit_stats.md
+++ b/docs/unit_stats.md
@@ -8,7 +8,6 @@ This table defines the core attributes and functional roles for every unit type 
 | --- | --- |
 | `unit_type` | Unique ID for the unit (e.g. `archer`) |
 | `tier` | Tech progression level (1 basic, 5 advanced) |
-| `version_tag` | Schema version identifier |
 | `class` | General type: `infantry`, `ranged`, `cavalry`, `siege`, etc. |
 | `description` | Text shown in UI and encyclopedia |
 | `hp` | Health pool per unit |

--- a/docs/village_modifiers.md
+++ b/docs/village_modifiers.md
@@ -6,8 +6,7 @@ The `village_modifiers` table stores temporary or permanent bonuses applied to a
 
 | Column | Description |
 | --- | --- |
-| `modifier_id` | Primary key |
-| `village_id` | FK to `kingdom_villages.village_id` |
+| `village_id` | Primary key referencing `kingdom_villages.village_id` |
 | `resource_bonus` | JSON of resource boosts |
 | `troop_bonus` | JSON of combat bonuses |
 | `construction_speed_bonus` | Flat percent boost to build speed |


### PR DESCRIPTION
## Summary
- fix table structures in docs to match current SQL schema
- remove outdated columns and instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend', 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6849cb0aad108330a4bb72cf25c5b41d