### PR TITLE
Implement alliance creation and deletion

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from .routers import (
     admin,
     alliance_members,
     alliance_members_view,
+    alliance_management,
     alliance_projects,
     kingdom,
     conflicts,
@@ -78,6 +79,7 @@ load_game_settings()
 
 app.include_router(alliance_members.router)
 app.include_router(alliance_members_view.router)
+app.include_router(alliance_management.router)
 app.include_router(admin.router)
 app.include_router(admin_dashboard.router)
 app.include_router(alliance_projects.router)

--- a/backend/routers/alliance_management.py
+++ b/backend/routers/alliance_management.py
@@ -1,0 +1,115 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from backend.models import (
+    Alliance,
+    AllianceMember,
+    AllianceVault,
+    User,
+    Kingdom,
+    KingdomResources,
+)
+from ..security import verify_jwt_token
+from services.audit_service import log_action, log_alliance_activity
+
+router = APIRouter(prefix="/api/alliance", tags=["alliances"])
+
+CREATE_COST = {"wood": 1000, "stone": 1000, "gold": 500}
+
+
+class CreatePayload(BaseModel):
+    name: str
+    region: str | None = None
+
+
+class DeletePayload(BaseModel):
+    alliance_id: int | None = None
+
+
+@router.post("/create")
+def create_alliance(
+    payload: CreatePayload,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    user = db.query(User).filter_by(user_id=user_id).first()
+    if not user or not user.kingdom_id:
+        raise HTTPException(status_code=404, detail="Kingdom not found")
+    if user.alliance_id:
+        raise HTTPException(status_code=400, detail="Already in an alliance")
+
+    resources = (
+        db.query(KingdomResources)
+        .filter_by(kingdom_id=user.kingdom_id)
+        .first()
+    )
+    if not resources:
+        raise HTTPException(status_code=404, detail="Resources not found")
+
+    for res, cost in CREATE_COST.items():
+        if getattr(resources, res) < cost:
+            raise HTTPException(status_code=400, detail="Insufficient resources")
+
+    for res, cost in CREATE_COST.items():
+        setattr(resources, res, getattr(resources, res) - cost)
+
+    alliance = Alliance(
+        name=payload.name,
+        leader=user_id,
+        status="active",
+        region=payload.region or user.region,
+    )
+    db.add(alliance)
+    db.flush()
+
+    db.add(
+        AllianceMember(
+            alliance_id=alliance.alliance_id,
+            user_id=user_id,
+            username=user.username,
+            rank="Leader",
+            contribution=0,
+            status="active",
+        )
+    )
+    db.add(AllianceVault(alliance_id=alliance.alliance_id))
+
+    user.alliance_id = alliance.alliance_id
+    user.alliance_role = "Leader"
+    db.commit()
+
+    log_action(db, user_id, "create_alliance", payload.name)
+    log_alliance_activity(db, alliance.alliance_id, user_id, "Created", payload.name)
+
+    return {"alliance_id": alliance.alliance_id}
+
+
+@router.post("/delete")
+def delete_alliance(
+    payload: DeletePayload | None = None,
+    user_id: str = Depends(verify_jwt_token),
+    db: Session = Depends(get_db),
+):
+    user = db.query(User).filter_by(user_id=user_id).first()
+    if not user or not user.alliance_id:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+
+    aid = payload.alliance_id if payload and payload.alliance_id else user.alliance_id
+    alliance = db.query(Alliance).filter_by(alliance_id=aid).first()
+    if not alliance:
+        raise HTTPException(status_code=404, detail="Alliance not found")
+    if alliance.leader != user_id:
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+    db.query(AllianceMember).filter_by(alliance_id=aid).delete()
+    db.query(AllianceVault).filter_by(alliance_id=aid).delete()
+    db.query(Alliance).filter_by(alliance_id=aid).delete()
+    for member in db.query(User).filter(User.alliance_id == aid).all():
+        member.alliance_id = None
+        member.alliance_role = None
+    db.commit()
+
+    log_action(db, user_id, "delete_alliance", str(aid))
+    return {"status": "deleted"}

--- a/tests/test_alliance_management_router.py
+++ b/tests/test_alliance_management_router.py
@@ -1,0 +1,56 @@
+import uuid
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi import HTTPException
+
+from backend.db_base import Base
+from backend.models import User, Kingdom, KingdomResources, Alliance
+from backend.routers.alliance_management import (
+    create_alliance,
+    delete_alliance,
+    CreatePayload,
+    DeletePayload,
+)
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def create_user_with_resources(db):
+    uid = str(uuid.uuid4())
+    db.add(Kingdom(kingdom_id=1, user_id=uid, kingdom_name="K"))
+    db.add(KingdomResources(kingdom_id=1, wood=2000, stone=2000, gold=1000))
+    user = User(user_id=uid, username="t", display_name="T", email="t@test.com", kingdom_id=1)
+    db.add(user)
+    db.commit()
+    return uid
+
+
+def test_create_alliance_deducts_resources():
+    Session = setup_db()
+    db = Session()
+    uid = create_user_with_resources(db)
+    res = create_alliance(CreatePayload(name="A"), uid, db)
+    aid = res["alliance_id"]
+    alliance = db.query(Alliance).filter_by(alliance_id=aid).first()
+    assert alliance and alliance.name == "A"
+    resources = db.query(KingdomResources).filter_by(kingdom_id=1).first()
+    assert resources.wood == 1000 and resources.stone == 1000 and resources.gold == 500
+    user = db.query(User).filter_by(user_id=uid).first()
+    assert user.alliance_id == aid and user.alliance_role == "Leader"
+
+
+def test_delete_alliance_removes_records():
+    Session = setup_db()
+    db = Session()
+    uid = create_user_with_resources(db)
+    res = create_alliance(CreatePayload(name="B"), uid, db)
+    aid = res["alliance_id"]
+    delete_alliance(DeletePayload(alliance_id=aid), uid, db)
+    assert db.query(Alliance).filter_by(alliance_id=aid).first() is None
+    user = db.query(User).filter_by(user_id=uid).first()
+    assert user.alliance_id is None


### PR DESCRIPTION
## Summary
- add new `alliance_management` router for creating and deleting alliances
- register new router in `backend/main.py`
- test alliance creation cost deduction and alliance deletion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend' or 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6849d03986c883308ad1390851385fce