### PR TITLE
Add default noble at kingdom creation

### DIFF
--- a/docs/onboarding_setup.md
+++ b/docs/onboarding_setup.md
@@ -7,5 +7,6 @@ When a player signs up and completes the onboarding flow (`play.html` & `play.js
 3. **villages** – The first village associated with the kingdom.
 4. **kingdom_resources** – Resource ledger populated with the region's `resource_bonus` values.
 5. **kingdom_troop_slots** – Starting troop slot count of `20`. Regional `troop_bonus` values modify troop stats rather than slot count.
+6. **kingdom_nobles** – A default noble record is inserted so progression can begin immediately.
 
 Additional tables such as `kingdom_castle_progression` are initialized lazily on first access by the progression API.

--- a/services/kingdom_setup_service.py
+++ b/services/kingdom_setup_service.py
@@ -22,6 +22,9 @@ START_BUILDINGS = [
     "Warehouse",
 ]
 
+# Default noble created for every new kingdom
+DEFAULT_NOBLE_NAME = "Founding Noble"
+
 
 def create_kingdom_transaction(
     db: Session,
@@ -77,6 +80,14 @@ def create_kingdom_transaction(
                 "INSERT INTO kingdom_troop_slots (kingdom_id, base_slots) VALUES (:kid, 20)"
             ),
             {"kid": kingdom_id},
+        )
+
+        # Insert the first noble so progression can begin immediately
+        db.execute(
+            text(
+                "INSERT INTO kingdom_nobles (kingdom_id, noble_name) VALUES (:kid, :name)"
+            ),
+            {"kid": kingdom_id, "name": DEFAULT_NOBLE_NAME},
         )
 
         db.execute(


### PR DESCRIPTION
## Summary
- assign a starting noble when creating a kingdom
- document new noble record in onboarding docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6849d2a52d388330958584a7fad86611