### PR TITLE
Add noble houses feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ the records created during onboarding.
 ✅ Kingdoms master table documented in [docs/kingdoms.md](docs/kingdoms.md)
 ✅ Terrain map integration documented in [docs/terrain_map.md](docs/terrain_map.md)
 ✅ Final schema summary in [FINAL_SCHEMA_DOCUMENTATION.md](FINAL_SCHEMA_DOCUMENTATION.md)
+✅ Noble houses documented in [docs/noble_houses.md](docs/noble_houses.md)
 
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -185,6 +185,20 @@ class TradeLog(Base):
     )
 
 
+class NobleHouse(Base):
+    """Represents a noble house or family."""
+
+    __tablename__ = "noble_houses"
+
+    house_id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    motto = Column(Text)
+    crest = Column(Text)
+    region = Column(String)
+    description = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
 class ProjectPlayerCatalogue(Base):
     __tablename__ = "project_player_catalogue"
 

--- a/backend/routers/noble_houses.py
+++ b/backend/routers/noble_houses.py
@@ -1,0 +1,80 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..models import NobleHouse
+
+router = APIRouter(prefix="/api/noble_houses", tags=["noble_houses"])
+
+
+class HousePayload(BaseModel):
+    name: str
+    motto: str | None = None
+    crest: str | None = None
+    region: str | None = None
+    description: str | None = None
+
+
+def _serialize(row: NobleHouse) -> dict:
+    return {
+        "house_id": row.house_id,
+        "name": row.name,
+        "motto": row.motto,
+        "crest": row.crest,
+        "region": row.region,
+        "description": row.description,
+    }
+
+
+@router.get("")
+def list_houses(db: Session = Depends(get_db)):
+    rows = db.query(NobleHouse).all()
+    return {"houses": [_serialize(r) for r in rows]}
+
+
+@router.get("/{house_id}")
+def get_house(house_id: int, db: Session = Depends(get_db)):
+    row = db.query(NobleHouse).filter_by(house_id=house_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="House not found")
+    return _serialize(row)
+
+
+@router.post("")
+def create_house(payload: HousePayload, db: Session = Depends(get_db)):
+    house = NobleHouse(
+        name=payload.name,
+        motto=payload.motto,
+        crest=payload.crest,
+        region=payload.region,
+        description=payload.description,
+    )
+    db.add(house)
+    db.commit()
+    db.refresh(house)
+    return {"house_id": house.house_id}
+
+
+@router.put("/{house_id}")
+def update_house(house_id: int, payload: HousePayload, db: Session = Depends(get_db)):
+    house = db.query(NobleHouse).filter_by(house_id=house_id).first()
+    if not house:
+        raise HTTPException(status_code=404, detail="House not found")
+    house.name = payload.name
+    house.motto = payload.motto
+    house.crest = payload.crest
+    house.region = payload.region
+    house.description = payload.description
+    db.commit()
+    return {"message": "updated"}
+
+
+@router.delete("/{house_id}")
+def delete_house(house_id: int, db: Session = Depends(get_db)):
+    house = db.query(NobleHouse).filter_by(house_id=house_id).first()
+    if not house:
+        raise HTTPException(status_code=404, detail="House not found")
+    db.delete(house)
+    db.commit()
+    return {"message": "deleted"}

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -1078,3 +1078,14 @@ CREATE TABLE kingdom_temples (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+-- Noble Houses ------------------------------------------------------------
+CREATE TABLE noble_houses (
+    house_id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    motto TEXT,
+    crest TEXT,
+    region TEXT,
+    description TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+

--- a/docs/noble_houses.md
+++ b/docs/noble_houses.md
@@ -1,0 +1,20 @@
+# Noble Houses
+
+This document outlines the table used to store player-created noble houses or families.
+These groups are largely social, letting players band together under a shared banner.
+
+## Table: `noble_houses`
+
+| Column | Meaning |
+| --- | --- |
+| `house_id` | Primary key for the house |
+| `name` | Display name |
+| `motto` | Optional motto or catch phrase |
+| `crest` | URL or identifier for the house crest |
+| `region` | Home region or origin |
+| `description` | Free text description |
+| `created_at` | Timestamp when the house was founded |
+
+### Usage
+- Houses can be created via `/api/noble_houses`.
+- The CRUD API allows listing, updating and deleting houses.

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -1190,3 +1190,14 @@ CREATE TABLE public.wars_tactical (
   CONSTRAINT wars_tactical_submitted_by_fkey FOREIGN KEY (submitted_by) REFERENCES public.users(user_id),
   CONSTRAINT wars_tactical_terrain_id_fkey FOREIGN KEY (terrain_id) REFERENCES public.terrain_map(terrain_id)
 );
+
+-- Noble Houses ------------------------------------------------------------
+CREATE TABLE public.noble_houses (
+  house_id serial PRIMARY KEY,
+  name text NOT NULL,
+  motto text,
+  crest text,
+  region text,
+  description text,
+  created_at timestamp with time zone DEFAULT now()
+);

--- a/tests/test_noble_houses_router.py
+++ b/tests/test_noble_houses_router.py
@@ -1,0 +1,38 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.db_base import Base
+from backend.routers.noble_houses import (
+    create_house,
+    list_houses,
+    get_house,
+    update_house,
+    delete_house,
+    HousePayload,
+)
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def test_full_crud_flow():
+    Session = setup_db()
+    db = Session()
+
+    res = create_house(HousePayload(name="Stark"), db=db)
+    hid = res["house_id"]
+
+    house = get_house(hid, db=db)
+    assert house["name"] == "Stark"
+
+    update_house(hid, HousePayload(name="Stark", motto="Winter is Coming"), db=db)
+    updated = get_house(hid, db=db)
+    assert updated["motto"] == "Winter is Coming"
+
+    result = delete_house(hid, db=db)
+    assert result["message"] == "deleted"
+    assert list_houses(db=db)["houses"] == []


### PR DESCRIPTION
## Summary
- model noble houses
- create `noble_houses` table in SQL schemas
- add CRUD router for houses
- document houses mechanic
- provide unit test for router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6849d2a796a883308bcd39a1c1ce3d3d