### PR TITLE
Add noble and knight management UI

### DIFF
--- a/Javascript/progression.js
+++ b/Javascript/progression.js
@@ -45,11 +45,80 @@ export async function viewKnights() {
   return res.json();
 }
 
+export async function nameNoble(nobleName) {
+  const res = await fetch('/api/progression/nobles', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ noble_name: nobleName })
+  });
+  if (!res.ok) throw new Error('Failed to name noble');
+  return res.json();
+}
+
+export async function renameNoble(oldName, newName) {
+  const res = await fetch('/api/progression/nobles/rename', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ old_name: oldName, new_name: newName })
+  });
+  if (!res.ok) throw new Error('Failed to rename noble');
+  return res.json();
+}
+
+export async function removeNoble(nobleName) {
+  const res = await fetch('/api/progression/nobles', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ noble_name: nobleName })
+  });
+  if (!res.ok) throw new Error('Failed to remove noble');
+  return res.json();
+}
+
+export async function nameKnight(knightName) {
+  const res = await fetch('/api/progression/knights', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ knight_name: knightName })
+  });
+  if (!res.ok) throw new Error('Failed to name knight');
+  return res.json();
+}
+
+export async function renameKnight(oldName, newName) {
+  const res = await fetch('/api/progression/knights/rename', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ old_name: oldName, new_name: newName })
+  });
+  if (!res.ok) throw new Error('Failed to rename knight');
+  return res.json();
+}
+
+export async function promoteKnightApi(knightName) {
+  const res = await fetch('/api/progression/knights/promote', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ knight_name: knightName })
+  });
+  if (!res.ok) throw new Error('Failed to promote knight');
+  return res.json();
+}
+
+export async function removeKnight(knightName) {
+  const res = await fetch('/api/progression/knights', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ knight_name: knightName })
+  });
+  if (!res.ok) throw new Error('Failed to remove knight');
+  return res.json();
+}
+
 // =========================
 // OPTIONAL DOM INTEGRATION
 // =========================
 document.addEventListener('DOMContentLoaded', async () => {
-  // Castle Progression
   const castleEl = document.getElementById('castle-progress');
   if (castleEl) {
     try {
@@ -64,51 +133,41 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   }
 
-  // Nobles
-  const noblesEl = document.getElementById('noble-list');
-  if (noblesEl) {
-    try {
-      const data = await viewNobles();
-      noblesEl.innerHTML = '';
-      const nobles = data.nobles || [];
-      if (nobles.length === 0) {
-        noblesEl.innerHTML = '<li>No nobles found.</li>';
-      } else {
-        nobles.forEach(n => {
-          const li = document.createElement('li');
-          li.textContent = n.name;
-          noblesEl.appendChild(li);
-        });
+  await renderNobles();
+  await renderKnights();
+
+  const nobleForm = document.getElementById('noble-form');
+  if (nobleForm) {
+    nobleForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const name = document.getElementById('new-noble-name').value.trim();
+      if (!name) return;
+      try {
+        await nameNoble(name);
+        nobleForm.reset();
+        await renderNobles();
+      } catch (err) {
+        alert('Failed to name noble');
       }
-    } catch (err) {
-      console.error('❌', err);
-      noblesEl.innerHTML = '<li>Failed to load nobles.</li>';
-    }
+    });
   }
 
-  // Knights
-  const knightsEl = document.getElementById('knight-list');
-  if (knightsEl) {
-    try {
-      const data = await viewKnights();
-      knightsEl.innerHTML = '';
-      const knights = data.knights || [];
-      if (knights.length === 0) {
-        knightsEl.innerHTML = '<li>No knights found.</li>';
-      } else {
-        knights.forEach(k => {
-          const li = document.createElement('li');
-          li.textContent = k.name;
-          knightsEl.appendChild(li);
-        });
+  const knightForm = document.getElementById('knight-form');
+  if (knightForm) {
+    knightForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const name = document.getElementById('new-knight-name').value.trim();
+      if (!name) return;
+      try {
+        await nameKnight(name);
+        knightForm.reset();
+        await renderKnights();
+      } catch (err) {
+        alert('Failed to name knight');
       }
-    } catch (err) {
-      console.error('❌', err);
-      knightsEl.innerHTML = '<li>Failed to load knights.</li>';
-    }
+    });
   }
 
-  // Upgrade Castle Button
   const upgradeBtn = document.getElementById('upgrade-castle-btn');
   if (upgradeBtn) {
     upgradeBtn.addEventListener('click', async () => {
@@ -132,4 +191,111 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   }
 });
+
+async function renderNobles() {
+  const noblesEl = document.getElementById('noble-list');
+  if (!noblesEl) return;
+  try {
+    const data = await viewNobles();
+    noblesEl.innerHTML = '';
+    const nobles = data.nobles || [];
+    if (nobles.length === 0) {
+      noblesEl.innerHTML = '<li>No nobles found.</li>';
+    } else {
+      nobles.forEach((n) => {
+        const li = document.createElement('li');
+        li.textContent = n.name || n;
+        const renameBtn = document.createElement('button');
+        renameBtn.textContent = 'Rename';
+        renameBtn.className = 'action-btn';
+        renameBtn.addEventListener('click', async () => {
+          const newName = prompt('New name for noble:', n.name || n);
+          if (!newName) return;
+          try {
+            await renameNoble(n.name || n, newName);
+            await renderNobles();
+          } catch {
+            alert('Failed to rename noble');
+          }
+        });
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = 'Remove';
+        removeBtn.className = 'action-btn';
+        removeBtn.addEventListener('click', async () => {
+          if (!confirm('Remove this noble?')) return;
+          try {
+            await removeNoble(n.name || n);
+            await renderNobles();
+          } catch {
+            alert('Failed to remove noble');
+          }
+        });
+        li.append(' ', renameBtn, ' ', removeBtn);
+        noblesEl.appendChild(li);
+      });
+    }
+  } catch (err) {
+    console.error('❌', err);
+    noblesEl.innerHTML = '<li>Failed to load nobles.</li>';
+  }
+}
+
+async function renderKnights() {
+  const knightsEl = document.getElementById('knight-list');
+  if (!knightsEl) return;
+  try {
+    const data = await viewKnights();
+    knightsEl.innerHTML = '';
+    const knights = data.knights || [];
+    if (knights.length === 0) {
+      knightsEl.innerHTML = '<li>No knights found.</li>';
+    } else {
+      knights.forEach((k) => {
+        const li = document.createElement('li');
+        li.textContent = k.name || k;
+        const promoteBtn = document.createElement('button');
+        promoteBtn.textContent = 'Promote';
+        promoteBtn.className = 'action-btn';
+        promoteBtn.addEventListener('click', async () => {
+          try {
+            await promoteKnightApi(k.name || k);
+            await renderKnights();
+          } catch {
+            alert('Failed to promote knight');
+          }
+        });
+        const renameBtn = document.createElement('button');
+        renameBtn.textContent = 'Rename';
+        renameBtn.className = 'action-btn';
+        renameBtn.addEventListener('click', async () => {
+          const newName = prompt('New name for knight:', k.name || k);
+          if (!newName) return;
+          try {
+            await renameKnight(k.name || k, newName);
+            await renderKnights();
+          } catch {
+            alert('Failed to rename knight');
+          }
+        });
+        const removeBtn = document.createElement('button');
+        removeBtn.textContent = 'Remove';
+        removeBtn.className = 'action-btn';
+        removeBtn.addEventListener('click', async () => {
+          if (!confirm('Remove this knight?')) return;
+          try {
+            await removeKnight(k.name || k);
+            await renderKnights();
+          } catch {
+            alert('Failed to remove knight');
+          }
+        });
+        li.append(' ', promoteBtn, ' ', renameBtn, ' ', removeBtn);
+        knightsEl.appendChild(li);
+      });
+    }
+  } catch (err) {
+    console.error('❌', err);
+    knightsEl.innerHTML = '<li>Failed to load knights.</li>';
+  }
+}
 

--- a/overview.html
+++ b/overview.html
@@ -100,12 +100,20 @@ Author: Deathsgift66
         <ul id="noble-list">
           <!-- JS will populate -->
         </ul>
+        <form id="noble-form">
+          <input type="text" id="new-noble-name" placeholder="Noble name" required />
+          <button type="submit" class="action-btn">Name Noble</button>
+        </form>
       </div>
       <div class="panel-card">
         <h3>Knights</h3>
         <ul id="knight-list">
           <!-- JS will populate -->
         </ul>
+        <form id="knight-form">
+          <input type="text" id="new-knight-name" placeholder="Knight name" required />
+          <button type="submit" class="action-btn">Name Knight</button>
+        </form>
       </div>
       <div class="panel-card">
         <h3>Active Modifiers</h3>


### PR DESCRIPTION
## Summary
- allow naming and managing nobles and knights from Overview
- add handlers for rename/remove/promote operations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6849d2a82fbc8330b6ae6edb7ac25d02