### PR TITLE
Add cancel/reset UI for buildings and training queue

### DIFF
--- a/Javascript/train_troops.js
+++ b/Javascript/train_troops.js
@@ -143,9 +143,16 @@ function renderTrainingQueue(queue) {
     card.innerHTML = `
       <h4>${escapeHTML(entry.unit_name)} x ${entry.quantity}</h4>
       <p>Ends In: <span class="countdown">${formatTime(endsIn)}</span></p>
+      <button class="action-btn cancel-btn" data-qid="${entry.queue_id}">Cancel</button>
     `;
 
     queueEl.appendChild(card);
+  });
+  queueEl.querySelectorAll('.cancel-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const qid = parseInt(btn.dataset.qid, 10);
+      cancelTraining(qid);
+    });
   });
   startQueueTimers();
 }
@@ -218,6 +225,24 @@ async function trainTroop(unitId) {
   } catch (err) {
     console.error("❌ Error training troop:", err);
     showToast(err.message || "Failed to train troop.");
+  }
+}
+
+async function cancelTraining(queueId) {
+  if (!confirm('Cancel this training order?')) return;
+  try {
+    const res = await fetch('/api/training_queue/cancel', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ queue_id: queueId })
+    });
+    const result = await res.json();
+    if (!res.ok) throw new Error(result.error || 'Failed');
+    showToast(result.message || 'Training cancelled');
+    await loadGrandMusterHall();
+  } catch (err) {
+    console.error('❌ Error cancelling training:', err);
+    showToast(err.message || 'Failed to cancel');
   }
 }
 

--- a/tests/test_buildings_reset_router.py
+++ b/tests/test_buildings_reset_router.py
@@ -1,0 +1,44 @@
+from backend.routers.buildings import reset_build, BuildingActionPayload
+from fastapi import HTTPException
+
+class DummyResult:
+    def __init__(self, row=None):
+        self._row = row
+    def fetchone(self):
+        return self._row
+    def mappings(self):
+        return self
+
+class DummyDB:
+    def __init__(self):
+        self.calls = []
+    def execute(self, query, params=None):
+        q = str(query)
+        self.calls.append((q, params))
+        if "SELECT kingdom_id" in q:
+            return DummyResult((1,))
+        return DummyResult()
+    def commit(self):
+        pass
+
+def test_reset_build_updates_level():
+    db = DummyDB()
+    payload = BuildingActionPayload(village_id=1, building_id=2)
+    reset_build(payload, user_id="u1", db=db)
+    executed = " ".join(db.calls[1][0].split()).lower()
+    assert "update village_buildings" in executed
+    assert "level = 0" in executed
+
+def test_reset_build_forbidden():
+    class ForbiddenDB(DummyDB):
+        def execute(self, query, params=None):
+            if "SELECT kingdom_id" in str(query):
+                return DummyResult((2,))
+            return super().execute(query, params)
+    db = ForbiddenDB()
+    try:
+        reset_build(BuildingActionPayload(village_id=1, building_id=2), user_id="u1", db=db)
+    except HTTPException as e:
+        assert e.status_code == 403
+    else:
+        assert False, "Expected HTTPException"

--- a/tests/test_training_queue_router.py
+++ b/tests/test_training_queue_router.py
@@ -1,4 +1,10 @@
-from backend.routers.training_queue import start_training, list_queue, TrainOrderPayload
+from backend.routers.training_queue import (
+    start_training,
+    list_queue,
+    cancel_order,
+    TrainOrderPayload,
+    CancelPayload,
+)
 
 class DummyResult:
     def __init__(self, row=None, rows=None):
@@ -22,6 +28,8 @@ class DummyDB:
             return DummyResult((1,))
         if q.strip().startswith("INSERT INTO training_queue"):
             return DummyResult((5,))
+        if q.strip().startswith("UPDATE training_queue"):
+            return DummyResult()
         if "FROM training_queue" in q:
             return DummyResult(rows=self.rows)
         return DummyResult()
@@ -42,4 +50,11 @@ def test_list_queue_returns_rows():
     res = list_queue(user_id="u1", db=db)
     assert len(res["queue"]) == 1
     assert res["queue"][0]["unit_name"] == "Knight"
+
+
+def test_cancel_order_updates_row():
+    db = DummyDB()
+    cancel_order(CancelPayload(queue_id=2), user_id="u1", db=db)
+    executed = " ".join(db.executed[-1][0].split()).lower()
+    assert "update training_queue" in executed
 


### PR DESCRIPTION
## Summary
- support resetting a building level in backend
- allow cancelling training queue orders in backend
- add reset/cancel buttons on Buildings page
- add cancel button for training queue entries
- cover new endpoints with tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend', missing sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6849da5183f4833092e8c7ecd41ec4b0