### PR TITLE
Update to schema version 6.12.2025.5.54

### DIFF
--- a/FINAL_SCHEMA_DOCUMENTATION.md
+++ b/FINAL_SCHEMA_DOCUMENTATION.md
@@ -1003,7 +1003,7 @@ CREATE INDEX unit_movements_war_id_idx ON public.unit_movements(war_id);
 CREATE TABLE public.unit_stats (
   unit_type text NOT NULL,
   tier integer NOT NULL,
-  version_tag text DEFAULT 'v1',
+  version_tag text DEFAULT 'v6.12.2025.5.54',
   class text NOT NULL,
   description text,
   hp integer NOT NULL,

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Date: **June 2, 2025**
 ---
 
 **For testers:**  
-Current deployed version → `v6.2.25`  
+Current deployed version → `v6.12.2025.5.54`
 Pre-Alpha build — **feature-complete** FrontEnd.
 
 ---

--- a/backend/models.py
+++ b/backend/models.py
@@ -525,7 +525,7 @@ class UnitStat(Base):
     __tablename__ = "unit_stats"
     unit_type = Column(String, primary_key=True)
     tier = Column(Integer)
-    version_tag = Column(String, default="v1")
+    version_tag = Column(String, default="v6.12.2025.5.54")
     hp = Column(Integer)
     damage = Column(Integer)
     defense = Column(Integer)

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -997,7 +997,7 @@ CREATE INDEX unit_movements_war_id_idx ON public.unit_movements(war_id);
 CREATE TABLE public.unit_stats (
   unit_type text NOT NULL,
   tier integer NOT NULL,
-  version_tag text DEFAULT 'v1',
+  version_tag text DEFAULT 'v6.12.2025.5.54',
   class text NOT NULL,
   description text,
   hp integer NOT NULL,

--- a/migrations/2025_06_27_finalize_war_indexes.sql
+++ b/migrations/2025_06_27_finalize_war_indexes.sql
@@ -12,4 +12,4 @@ CREATE INDEX IF NOT EXISTS unit_movements_war_id_idx ON public.unit_movements(wa
 
 -- Add version_tag to unit_stats for schema versioning
 ALTER TABLE public.unit_stats
-  ADD COLUMN version_tag text DEFAULT 'v1';
+  ADD COLUMN version_tag text DEFAULT 'v6.12.2025.5.54';

--- a/villages.html
+++ b/villages.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <!--
   Villages Overview - Player List
-  Final SSS-Tier PRODUCTION VERSION — 6.2.25
+  Final SSS-Tier PRODUCTION VERSION — 6.12.2025.5.54
   Author: Deathsgift66
 -->
 <head>


### PR DESCRIPTION
## Summary
- update README with new release version
- reflect new version in villages.html banner
- set `version_tag` defaults to v6.12.2025.5.54 throughout schema
- sync migration file and SQL docs with new default value

## Testing
- `npm test` *(passes: prints "No tests defined")*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684aa3d27664833096c49b6cd808edd1