### PR TITLE
Add auth headers for protected API calls

### DIFF
--- a/Javascript/black_market.js
+++ b/Javascript/black_market.js
@@ -53,7 +53,12 @@ async function loadResources() {
 }
 
 async function loadListings() {
-  const res = await fetch('/api/black-market/listings');
+  const res = await fetch('/api/black-market/listings', {
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'X-User-ID': userId
+    }
+  });
   const data = await res.json();
   listings = data.listings || [];
   renderListings();
@@ -122,7 +127,12 @@ async function confirmPurchase() {
 }
 
 async function loadHistory() {
-  const res = await fetch(`/api/black-market/history?kingdom_id=${kingdomId}`);
+  const res = await fetch(`/api/black-market/history?kingdom_id=${kingdomId}`, {
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'X-User-ID': userId
+    }
+  });
   const data = await res.json();
   const container = document.getElementById('purchaseHistory');
   container.innerHTML = '';

--- a/Javascript/conflicts.js
+++ b/Javascript/conflicts.js
@@ -7,6 +7,9 @@ Description: Dynamic conflict listing with filters and sorting.
 
 import { supabase } from './supabaseClient.js';
 
+let accessToken = null;
+let userId = null;
+
 const REFRESH_MS = 30000;
 let conflicts = [];
 let currentFilter = 'all';
@@ -20,6 +23,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     window.location.href = 'login.html';
     return;
   }
+  accessToken = session.access_token;
+  userId = session.user.id;
   setupControls();
   await loadConflicts();
   startAutoRefresh();
@@ -55,7 +60,12 @@ async function loadConflicts() {
   if (!tbody) return;
   tbody.innerHTML = '<tr><td colspan="10">Loading conflicts...</td></tr>';
   try {
-    const res = await fetch('/api/conflicts/overview');
+    const res = await fetch('/api/conflicts/overview', {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'X-User-ID': userId
+      }
+    });
     const data = await res.json();
     conflicts = data.wars || [];
     applyFilters();


### PR DESCRIPTION
## Summary
- ensure market, conflicts, battle_live and training fetch calls send JWT auth
- store user session data for conflicts, live battles and training pages
- confirm RLS policies exist for Supabase tables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684ab9aafccc8330ad25581afbf2d7b1