### PR TITLE
Review API

### DIFF
--- a/backend/security.py
+++ b/backend/security.py
@@ -3,6 +3,8 @@ import json
 from uuid import UUID
 from fastapi import Header, HTTPException
 
+__all__ = ["verify_jwt_token"]
+
 
 def verify_jwt_token(
     authorization: str | None = Header(None),


### PR DESCRIPTION
## Summary
- export verify_jwt_token in security module for clarity

## Testing
- `python -m py_compile backend/security.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684abc0b50d083308c46e6faedcb73e3