### PR TITLE
Add cost_to_produce to building catalogue

### DIFF
--- a/FINAL_SCHEMA_DOCUMENTATION.md
+++ b/FINAL_SCHEMA_DOCUMENTATION.md
@@ -336,6 +336,8 @@ CREATE TABLE public.building_catalogue (
   unlock_at_level integer DEFAULT 1,
   created_at timestamp with time zone DEFAULT now(),
   last_updated timestamp with time zone DEFAULT now(),
+  cost_to_produce jsonb DEFAULT '{}'::jsonb,
+  efficiency_multiplier numeric DEFAULT 1.0,
   CONSTRAINT building_catalogue_pkey PRIMARY KEY (building_id)
 );
 

--- a/db_schema.sql
+++ b/db_schema.sql
@@ -105,7 +105,9 @@ CREATE TABLE building_catalogue (
     is_repeatable     BOOLEAN DEFAULT FALSE,
     unlock_at_level   INTEGER DEFAULT 0,
     created_at        TIMESTAMPTZ DEFAULT now(),
-    last_updated      TIMESTAMPTZ DEFAULT now()
+    last_updated      TIMESTAMPTZ DEFAULT now(),
+    cost_to_produce   JSONB DEFAULT '{}'::jsonb,
+    efficiency_multiplier NUMERIC DEFAULT 1.0
 );
 
 CREATE TABLE kingdom_buildings (

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -329,6 +329,8 @@ CREATE TABLE public.building_catalogue (
   unlock_at_level integer DEFAULT 1,
   created_at timestamp with time zone DEFAULT now(),
   last_updated timestamp with time zone DEFAULT now(),
+  cost_to_produce jsonb DEFAULT '{}'::jsonb,
+  efficiency_multiplier numeric DEFAULT 1.0,
   CONSTRAINT building_catalogue_pkey PRIMARY KEY (building_id)
 );
 

--- a/migrations/2025_06_15_add_building_catalogue_extended.sql
+++ b/migrations/2025_06_15_add_building_catalogue_extended.sql
@@ -18,5 +18,7 @@ CREATE TABLE public.building_catalogue (
     is_repeatable    BOOLEAN DEFAULT FALSE,
     unlock_at_level  INTEGER DEFAULT 0,
     created_at       TIMESTAMPTZ DEFAULT now(),
-    last_updated     TIMESTAMPTZ DEFAULT now()
+    last_updated     TIMESTAMPTZ DEFAULT now(),
+    cost_to_produce  JSONB DEFAULT '{}'::jsonb,
+    efficiency_multiplier NUMERIC DEFAULT 1.0
 );


### PR DESCRIPTION
## Summary
- extend `building_catalogue` table schema
- update migration script and schemas to include `cost_to_produce` and `efficiency_multiplier`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_684adcf4aff48330b6eda8d8f8d8f90d