### PR TITLE
Fix missing SQLAlchemy Session import

### DIFF
--- a/backend/routers/market.py
+++ b/backend/routers/market.py
@@ -1,4 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
 from ..security import verify_jwt_token
 from ..database import get_db
 from services.vacation_mode_service import check_vacation_mode


### PR DESCRIPTION
## Summary
- import Session in `market` router to satisfy dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy`)*

------
https://chatgpt.com/codex/tasks/task_e_684b2ca518188330b32c05cf60758ddb