### PR TITLE
Fix missing Session import in projects router

### DIFF
--- a/backend/routers/projects_router.py
+++ b/backend/routers/projects_router.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from ..data import castle_progression_state, kingdom_projects
 from ..security import verify_jwt_token
 from ..database import get_db
+from sqlalchemy.orm import Session
 from services.vacation_mode_service import check_vacation_mode
 
 router = APIRouter(prefix="/api/projects", tags=["projects"])


### PR DESCRIPTION
## Summary
- add missing `Session` import to `projects_router`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_684b2e1bbc58833088d5bb84e654498e