### PR TITLE
Fix missing Session definition

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -11,9 +11,12 @@ DATABASE_URL = os.getenv("DATABASE_URL")
 if DATABASE_URL:
     engine = create_engine(DATABASE_URL)
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    # Provide a backward compatible alias used in some modules/tests
+    Session = SessionLocal
 else:
     engine = None
     SessionLocal = None
+    Session = None  # type: ignore
     logging.warning("DATABASE_URL not set; SQLAlchemy engine disabled")
 
 


### PR DESCRIPTION
## Summary
- ensure `Session` is defined by aliasing it to `SessionLocal`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_684b2fb7710c8330b58ca8ec16e29999