### PR TITLE
Fix play page script initialization

### DIFF
--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -42,7 +42,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     .eq('user_id', currentUser.id)
     .maybeSingle();
 
-  if (error && profile !== null) {
+  if (error) {
     console.error('❌ Error loading profile:', error);
     showToast('Failed to load profile.');
     return;
@@ -70,10 +70,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   await loadRegions();
   await loadAnnouncements();
   renderAvatarOptions();
-  bindEvents(profile);
+  bindEvents();
 });
 
-function bindEvents(profileExists) {
+function bindEvents() {
   const createBtn = document.getElementById('create-kingdom-btn');
   const bannerPreview = document.getElementById('banner-preview');
   const emblemPreview = document.getElementById('emblem-preview');
@@ -98,6 +98,8 @@ function bindEvents(profileExists) {
       emblemPreview.src = emblemEl.value.trim();
     });
   }
+
+  if (!createBtn) return;
 
   createBtn.addEventListener('click', async () => {
     const kNameEl = document.getElementById('kingdom-name-input');


### PR DESCRIPTION
## Summary
- adjust error logic when loading player profile
- remove unused parameter from `bindEvents` and guard button lookup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684b3b7609a0833089184154f1c44d55