### PR TITLE
Fix region dropdown docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ Update these values with your project credentials to enable API access.
 
 This will create all tables referenced by the frontend.
 
+After loading the base schema, apply the SQL files in the `migrations/` folder
+to keep your database up to date. These scripts also seed initial data.
+For example, run the regions migration to populate the `region_catalogue`
+table used on **play.html**:
+
+```bash
+psql -f migrations/2025_06_08_add_regions.sql
+```
+
+Without this migration the `/api/kingdom/regions` request will fail and the
+region dropdown will show "Failed to load".
+
 ---
 
 ## Testing


### PR DESCRIPTION
## Summary
- document that migrations must be applied for the `/api/kingdom/regions` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684b418543d483309070104349a5cee0