### PR TITLE
Align play onboarding fields with new schema

### DIFF
--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -80,8 +80,8 @@ function bindEvents() {
   const createBtn = document.getElementById('create-kingdom-btn');
   const bannerPreview = document.getElementById('banner-preview');
   const emblemPreview = document.getElementById('emblem-preview');
-  const bannerEl = document.getElementById('banner-image-input');
-  const emblemEl = document.getElementById('emblem-image-input');
+  const bannerEl = document.getElementById('banner_url');
+  const emblemEl = document.getElementById('emblem_url');
   const customAvatarEl = document.getElementById('custom-avatar-url');
 
   if (customAvatarEl) {
@@ -109,8 +109,8 @@ function bindEvents() {
     const titleEl = document.getElementById('ruler-title-input');
     const regionEl = document.getElementById('region-select');
     const villageEl = document.getElementById('village-name-input');
-    const bannerEl = document.getElementById('banner-image-input');
-    const emblemEl = document.getElementById('emblem-image-input');
+    const bannerEl = document.getElementById('banner_url');
+    const emblemEl = document.getElementById('emblem_url');
     if (bannerEl && bannerPreview) {
       bannerPreview.src = bannerEl.value;
     }
@@ -123,8 +123,8 @@ function bindEvents() {
     const rulerTitle = titleEl.value.trim();
     const region = regionEl.value;
     const villageName = villageEl.value.trim();
-    const bannerImage = bannerEl.value.trim();
-    const emblemImage = emblemEl.value.trim();
+    const bannerUrl = bannerEl.value.trim();
+    const emblemUrl = emblemEl.value.trim();
     const motto = mottoEl.value.trim();
 
     if (kingdomName.length < 3) {
@@ -155,8 +155,8 @@ function bindEvents() {
           ruler_title: rulerTitle || null,
           village_name: villageName,
           region,
-          banner_image: bannerImage || null,
-          emblem_image: emblemImage || null,
+          banner_url: bannerUrl || null,
+          emblem_url: emblemUrl || null,
           motto: motto || null
         })
       });

--- a/play.html
+++ b/play.html
@@ -68,8 +68,8 @@ Author: Deathsgift66
         </select>
         <div id="region-info" class="region-info"></div>
         <input type="text" id="village-name-input" placeholder="Starting Village Name" />
-        <input type="text" id="banner-image-input" placeholder="Banner Image URL (optional)" />
-        <input type="text" id="emblem-image-input" placeholder="Emblem Image URL (optional)" />
+        <input type="text" id="banner_url" placeholder="Banner URL (optional)" />
+        <input type="text" id="emblem_url" placeholder="Emblem URL (optional)" />
         <div class="image-preview-row">
           <img id="banner-preview" alt="Banner Preview" />
           <img id="emblem-preview" alt="Emblem Preview" />


### PR DESCRIPTION
## Summary
- update play onboarding inputs to use new `banner_url` and `emblem_url`
- update play.js to send new fields when creating kingdom

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684b48f564708330a84705f3996c004d