### PR TITLE
Fix API base handling for dev

### DIFF
--- a/Javascript/apiHelper.js
+++ b/Javascript/apiHelper.js
@@ -1,5 +1,10 @@
 const originalFetch = window.fetch;
 
+// Base URL for API requests. When running the dev server on port 3000 we
+// assume the FastAPI backend is available on localhost:8000.
+const API_BASE =
+  window.API_BASE_URL || (location.port === '3000' ? 'http://localhost:8000' : '');
+
 function getOverlay() {
   let el = document.getElementById('loading-overlay');
   if (!el) {
@@ -27,7 +32,8 @@ window.fetch = async function(url, options) {
   const overlay = getOverlay();
   overlay.classList.add('visible');
   try {
-    const res = await originalFetch(url, options);
+    const fullUrl = url.startsWith('/api/') ? API_BASE + url : url;
+    const res = await originalFetch(fullUrl, options);
     overlay.classList.remove('visible');
     if (!res.ok) {
       const text = await res.text();

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@ Author: Deathsgift66
   <!-- Global Assets -->
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
+  <script type="module" src="Javascript/apiHelper.js"></script>
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/index.css" />


### PR DESCRIPTION
## Summary
- add API base handling to `apiHelper.js` so `/api` calls work in dev
- include `apiHelper.js` on homepage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684b4da288588330be483c656926491a