### PR TITLE
Update README for backend requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ Install Python dependencies with:
 pip install -r dev_requirements.txt
 ```
 
+### Running the Local API
+
+The frontend expects the FastAPI backend to be available at
+`http://localhost:8000`. After installing the dependencies make sure to start the
+API server in a separate terminal:
+
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+When the backend is not running the static server used by `npm run serve` will
+return `index.html` for requests under `/api`, leading to browser console errors
+like `Invalid JSON from /api/resources`.
+
 ---
 
 ## Database Setup


### PR DESCRIPTION
## Summary
- document how to start the FastAPI backend
- explain why `/api` requests return HTML if the backend isn't running

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b4fc71820833090775ec79c8e4adc