### PR TITLE
Fix static mount order

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 from .routers import (
     admin,
     alliance_members,
@@ -147,3 +149,9 @@ app.include_router(signup_router.router)
 app.include_router(treaty_web.router)
 app.include_router(village_master_router.router)
 app.include_router(vacation_mode.router)
+
+# Serve static frontend after API routes so that catch-all paths don't intercept
+# API endpoints. We mount the repository root, which contains the static HTML
+# pages, at the application root path.
+BASE_DIR = Path(__file__).resolve().parent.parent
+app.mount("/", StaticFiles(directory=BASE_DIR, html=True), name="static")


### PR DESCRIPTION
## Summary
- mount static HTML after routers so API routes work

## Testing
- `pytest -q` *(fails: 47 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684b51f4f15c8330890300d6c6b51ca8