### PR TITLE
Fix static file mounting order

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
 from .routers import (
     admin,
     alliance_members,
@@ -147,3 +148,11 @@ app.include_router(signup_router.router)
 app.include_router(treaty_web.router)
 app.include_router(village_master_router.router)
 app.include_router(vacation_mode.router)
+
+# Mount static frontend after all API routes so that API endpoints take
+# precedence over static files.
+app.mount(
+    "/",
+    StaticFiles(directory=".", html=True),
+    name="static",
+)


### PR DESCRIPTION
## Summary
- mount static frontend after registering all API routes

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b51fbf16083309fbb7fb756d12edb