### PR TITLE
Remove motto input from onboarding

### DIFF
--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -117,7 +117,6 @@ function bindEvents() {
     if (emblemEl && emblemPreview) {
       emblemPreview.src = emblemEl.value;
     }
-    const mottoEl = document.getElementById('motto-input');
 
     const kingdomName = kNameEl.value.trim();
     const rulerTitle = titleEl ? titleEl.value.trim() : null;
@@ -125,7 +124,6 @@ function bindEvents() {
     const villageName = villageEl.value.trim();
     const bannerUrl = bannerEl ? bannerEl.value.trim() : null;
     const emblemUrl = emblemEl ? emblemEl.value.trim() : null;
-    const motto = mottoEl.value.trim();
 
     if (kingdomName.length < 3) {
       showToast('Kingdom name must be at least 3 characters.');
@@ -156,8 +154,7 @@ function bindEvents() {
           village_name: villageName,
           region,
           banner_url: bannerUrl || null,
-          emblem_url: emblemUrl || null,
-          motto: motto || null
+          emblem_url: emblemUrl || null
         })
       });
 

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -97,7 +97,7 @@ def create_kingdom(
             payload.ruler_title,
             payload.banner_image,
             payload.emblem_image,
-            payload.motto,
+            payload.motto or "From Ashes, Kingdoms Rise",
         )
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/play.html
+++ b/play.html
@@ -75,7 +75,6 @@ Author: Deathsgift66
           </div>
           <img id="avatar-preview" class="avatar-preview" src="Assets/avatars/default_avatar_emperor.png" alt="Avatar Preview" />
         </div>
-        <textarea id="motto-input" placeholder="Motto or Flavor Text"></textarea>
         <button id="create-kingdom-btn" class="btn">Create Kingdom</button>
       </div>
       <section id="announcements" class="announcements-container"></section>


### PR DESCRIPTION
## Summary
- remove motto textarea from onboarding UI
- drop motto parameter from kingdom creation request
- default motto to "From Ashes, Kingdoms Rise" server-side

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684b8971b1208330a015299f902140eb