### PR TITLE
Add region API endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -35,6 +35,7 @@ from .routers import (
     homepage,
     buildings,
     tutorial,
+    region,
     progression_router,
     villages_router,
     vip_status_router,
@@ -95,6 +96,7 @@ app.include_router(black_market_routes.router)
 app.include_router(news.router)
 app.include_router(tutorial.router)
 app.include_router(homepage.router)
+app.include_router(region.router)
 app.include_router(alliance_wars.router)
 app.include_router(notifications.router)
 app.include_router(battle.router)

--- a/backend/routers/region.py
+++ b/backend/routers/region.py
@@ -1,0 +1,32 @@
+"""Region API endpoints for kingdom onboarding and setup."""
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
+
+from ..supabase_client import get_supabase_client
+
+router = APIRouter(prefix="/api/kingdom", tags=["kingdom"])
+
+
+@router.get("/regions", response_class=JSONResponse)
+async def get_regions():
+    """Return all regions from the region catalogue."""
+    supabase = get_supabase_client()
+
+    res = supabase.table("region_catalogue").select("*").execute()
+    if getattr(res, "error", None):
+        raise HTTPException(status_code=500, detail="Error fetching regions")
+
+    rows = getattr(res, "data", res) or []
+    regions = [
+        {
+            "region_code": r.get("region_code"),
+            "region_name": r.get("region_name"),
+            "description": r.get("description") or "",
+            "resource_bonus": r.get("resource_bonus") or {},
+            "troop_bonus": r.get("troop_bonus") or {},
+        }
+        for r in rows
+    ]
+
+    return {"regions": regions}


### PR DESCRIPTION
## Summary
- add region listing endpoint for onboarding
- wire up new endpoint in backend main app
- test region endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684bf6e3901883309b303e6e20c3ce17