### PR TITLE
Implement updated announcements endpoint

### DIFF
--- a/tests/test_login_router.py
+++ b/tests/test_login_router.py
@@ -1,5 +1,7 @@
 import asyncio
 from backend.routers import login_routes
+from fastapi.responses import JSONResponse
+import json
 
 class DummyTable:
     def __init__(self, data=None):
@@ -23,6 +25,8 @@ def test_announcements_returned():
     rows = [
         {"id": 1, "title": "Welcome", "content": "Greetings", "created_at": "2025-01-01"}
     ]
-    login_routes.get_supabase_client = lambda: DummyClient({"login_announcements": rows})
-    result = asyncio.run(login_routes.get_announcements())
-    assert result["announcements"][0]["title"] == "Welcome"
+    login_routes.get_supabase_client = lambda: DummyClient({"announcements": rows})
+    resp = asyncio.run(login_routes.get_announcements())
+    assert isinstance(resp, JSONResponse)
+    data = json.loads(resp.body.decode())
+    assert data["announcements"][0]["title"] == "Welcome"


### PR DESCRIPTION
## Summary
- update login announcements endpoint to pull from `announcements` table
- adapt login router unit test for new JSON response format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy`)*

------
https://chatgpt.com/codex/tasks/task_e_684bf755c89883308d87dd9abcb73e01