### PR TITLE
Add minimal routers to entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,23 @@
-import uvicorn
-from backend.main import app
+"""Minimal FastAPI entrypoint for local development."""
+
+from fastapi import FastAPI
+
+# Import routers from the backend package. ``login_routes`` contains the
+# announcements endpoint, so alias it accordingly for clarity when including
+# the router below.
+from backend.routers import resources
+from backend.routers import login_routes as announcements
+from backend.routers import region
 
 
-if __name__ == "__main__":
+app = FastAPI()
+
+app.include_router(resources.router)
+app.include_router(announcements.router)
+app.include_router(region.router)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- create a simple FastAPI app in `main.py`
- include resources, announcements (login routes), and region routers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684bfa7d39888330a2c2c17d01ec27f1