### PR TITLE
Remove jsonb handling and flatten responses

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -161,17 +161,19 @@ async function loadAnnouncements() {
   if (!announcementList) return;
   try {
     const res = await fetch('/api/login/announcements');
-    const text = await res.text();
-    try {
-      const data = JSON.parse(text);
-      data.announcements.forEach((a) => {
-        const li = document.createElement('li');
-        li.textContent = `${a.title} - ${a.content}`;
-        announcementList.appendChild(li);
-      });
-    } catch (e) {
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const ctype = res.headers.get('content-type') || '';
+    if (!ctype.includes('application/json')) {
+      const text = await res.text();
       console.error('Invalid JSON from announcements:', text);
+      return;
     }
+    const announcements = await res.json();
+    announcements.forEach((a) => {
+      const li = document.createElement('li');
+      li.textContent = `${a.title} - ${a.content}`;
+      announcementList.appendChild(li);
+    });
   } catch (err) {
     console.error('Failed to load announcements', err);
   }

--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -194,12 +194,10 @@ async function loadRegions() {
   if (!regionEl || !infoEl) return;
 
   try {
-    const { regions = [] } = await safeJSONGet('/api/kingdom/regions');
+    const regions = await safeJSONGet('/api/kingdom/regions');
     regionEl.innerHTML = '<option value="">Select Region</option>';
 
     regions.forEach(region => {
-      region.resource_bonus = parseMaybeJSON(region.resource_bonus);
-      region.troop_bonus = parseMaybeJSON(region.troop_bonus);
       regionMap[region.region_code] = region;
 
       const opt = document.createElement('option');
@@ -234,7 +232,7 @@ async function loadAnnouncements() {
   const container = document.getElementById('announcements');
   if (!container) return;
   try {
-    const { announcements = [] } = await safeJSONGet('/api/login/announcements');
+    const announcements = await safeJSONGet('/api/login/announcements');
     container.innerHTML = announcements.map(a =>
       `<div class="announcement"><h4>${escapeHTML(a.title)}</h4><p>${escapeHTML(a.content)}</p></div>`
     ).join('');
@@ -289,10 +287,3 @@ function renderAvatarOptions() {
   if (vipLevel > 0 && custom) custom.classList.remove('hidden');
 }
 
-function parseMaybeJSON(raw) {
-  try {
-    return typeof raw === 'string' ? JSON.parse(raw) : raw || {};
-  } catch {
-    return {};
-  }
-}

--- a/backend/routers/login_routes.py
+++ b/backend/routers/login_routes.py
@@ -34,17 +34,9 @@ async def get_announcements():
     if getattr(res, "status_code", 200) >= 400:
         raise HTTPException(status_code=500, detail="Failed to fetch announcements.")
 
-    rows = getattr(res, "data", res) or []
-    announcements = [
-        {
-            "title": r.get("title", "Untitled"),
-            "content": r.get("content", ""),
-            "created_at": r.get("created_at"),
-        }
-        for r in rows
-    ]
+    announcements = getattr(res, "data", res) or []
 
-    return JSONResponse(content={"announcements": announcements}, status_code=200)
+    return JSONResponse(content=announcements, status_code=200)
 
 
 class EventPayload(BaseModel):

--- a/backend/routers/region.py
+++ b/backend/routers/region.py
@@ -17,16 +17,6 @@ async def get_regions():
     if getattr(res, "error", None):
         raise HTTPException(status_code=500, detail="Error fetching regions")
 
-    rows = getattr(res, "data", res) or []
-    regions = [
-        {
-            "region_code": r.get("region_code"),
-            "region_name": r.get("region_name"),
-            "description": r.get("description") or "",
-            "resource_bonus": r.get("resource_bonus") or {},
-            "troop_bonus": r.get("troop_bonus") or {},
-        }
-        for r in rows
-    ]
+    regions = getattr(res, "data", res) or []
 
-    return {"regions": regions}
+    return JSONResponse(content=regions)


### PR DESCRIPTION
## Summary
- simplify region fetching to return flat list
- refactor kingdom list_regions for new flat schema
- return raw announcement data in login routes
- update JS to work with flattened API responses
- parse announcements using `res.json()`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bfc1158c8833095fa247847fc01de