### PR TITLE
Clean up unused imports

### DIFF
--- a/backend/battle_engine/engine.py
+++ b/backend/battle_engine/engine.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 import random
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Tuple, Dict, Optional
+from typing import List, Tuple, Dict
 
 
 class TerrainType(str, Enum):

--- a/backend/battle_engine/manager.py
+++ b/backend/battle_engine/manager.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Dict, List
 
 from .engine import BattleTickHandler, WarState

--- a/backend/battle_engine/movement.py
+++ b/backend/battle_engine/movement.py
@@ -1,7 +1,5 @@
 """Utility functions for tactical unit movement."""
 
-from __future__ import annotations
-
 from typing import Any, Dict, List
 
 # Database interface for persisting movement state

--- a/backend/battle_engine/resolver_full.py
+++ b/backend/battle_engine/resolver_full.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Full combat resolver processing kingdom and alliance wars."""
 
 from typing import Any, Dict, List

--- a/backend/battle_engine/targeting.py
+++ b/backend/battle_engine/targeting.py
@@ -1,7 +1,5 @@
 """Utilities for selecting combat targets and applying unit counters."""
 
-from __future__ import annotations
-
 from typing import Any, Dict, List
 
 # Database interface for counters

--- a/backend/battle_engine/vision.py
+++ b/backend/battle_engine/vision.py
@@ -1,7 +1,5 @@
 """Utility functions for unit vision calculations."""
 
-from __future__ import annotations
-
 from typing import Any, Dict, List
 
 # Database interface for unit vision updates

--- a/backend/database.py
+++ b/backend/database.py
@@ -4,7 +4,6 @@ import logging
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from .db_base import Base
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Lightweight database helper used by the battle engine."""
 
 from typing import Any, Iterable, List, Mapping

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,1 +1,1 @@
-from . import village_master
+

--- a/backend/routers/alliance_changelog.py
+++ b/backend/routers/alliance_changelog.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Header
+from fastapi import APIRouter, Depends, HTTPException
 
 from datetime import datetime
 from .progression_router import get_user_id

--- a/backend/routers/alliance_management.py
+++ b/backend/routers/alliance_management.py
@@ -8,7 +8,6 @@ from backend.models import (
     AllianceMember,
     AllianceVault,
     User,
-    Kingdom,
     KingdomResources,
 )
 from ..security import verify_jwt_token

--- a/backend/routers/alliance_quests.py
+++ b/backend/routers/alliance_quests.py
@@ -1,15 +1,13 @@
 from datetime import datetime, timedelta
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Header
-from sqlalchemy import text
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
 from ..database import get_db
 from backend.models import (
     User,
-    Alliance,
     QuestAllianceCatalogue,
     QuestAllianceTracking,
     QuestAllianceContribution,

--- a/backend/routers/battle.py
+++ b/backend/routers/battle.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
@@ -9,11 +7,9 @@ from backend import models
 from ..security import verify_jwt_token
 
 from ..battle_engine import (
-    BattleTickHandler,
     TerrainGenerator,
     WarState,
     Unit,
-    WarManager,
     war_manager,
 )
 

--- a/backend/routers/changelog.py
+++ b/backend/routers/changelog.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from ..security import verify_jwt_token
 
 

--- a/backend/routers/diplomacy.py
+++ b/backend/routers/diplomacy.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Header
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 

--- a/backend/routers/diplomacy_center.py
+++ b/backend/routers/diplomacy_center.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import text
-from datetime import datetime, timezone
 from sqlalchemy.orm import Session
 
 from ..database import get_db

--- a/backend/routers/forgot_password.py
+++ b/backend/routers/forgot_password.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import hashlib
 import os
 import time

--- a/backend/routers/kingdom.py
+++ b/backend/routers/kingdom.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from fastapi import APIRouter, HTTPException, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel

--- a/backend/routers/kingdom_achievements.py
+++ b/backend/routers/kingdom_achievements.py
@@ -1,6 +1,5 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
-from sqlalchemy import text
 
 from ..database import get_db
 from .progression_router import get_user_id, get_kingdom_id

--- a/backend/routers/kingdom_history.py
+++ b/backend/routers/kingdom_history.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, Depends, Query, HTTPException
-from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from ..database import get_db

--- a/backend/routers/messages.py
+++ b/backend/routers/messages.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from fastapi import APIRouter, Depends, HTTPException, Header
 from pydantic import BaseModel
 

--- a/backend/supabase_client.py
+++ b/backend/supabase_client.py
@@ -1,7 +1,5 @@
 """Supabase client configuration for the API."""
 
-from __future__ import annotations
-
 import logging
 import os
 


### PR DESCRIPTION
## Summary
- remove unused imports in backend modules
- drop side-effect import from routers package
- clean up future annotations imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684c1b48f1fc833092341087f9c07d27