### PR TITLE
Fix DOM element references

### DIFF
--- a/play.html
+++ b/play.html
@@ -62,6 +62,7 @@ Author: Deathsgift66
       <div id="setup-step" class="onboard-step">
         <h3>Kingdom Setup</h3>
         <input type="text" id="kingdom-name-input" placeholder="Kingdom Name" readonly />
+        <input type="text" id="ruler-title-input" placeholder="Ruler Title (optional)" />
         <select id="region-select">
           <option value="">Select Region</option>
         </select>
@@ -74,6 +75,14 @@ Author: Deathsgift66
             <input type="text" id="custom-avatar-url" placeholder="Custom Avatar URL" />
           </div>
           <img id="avatar-preview" class="avatar-preview" src="Assets/avatars/default_avatar_emperor.png" alt="Avatar Preview" />
+          <label>Banner URL
+            <input type="text" id="banner_url" placeholder="Banner Image URL" />
+          </label>
+          <img id="banner-preview" src="Assets/profile_background.png" alt="Banner Preview" class="banner-img" />
+          <label>Emblem URL
+            <input type="text" id="emblem_url" placeholder="Emblem Image URL" />
+          </label>
+          <img id="emblem-preview" src="Assets/avatars/default_avatar_emperor.png" alt="Emblem Preview" class="emblem-img" />
         </div>
         <button id="create-kingdom-btn" class="btn">Create Kingdom</button>
       </div>


### PR DESCRIPTION
## Summary
- add missing inputs for kingdom setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684c1b5c9d4c83308602c8cdcdcadb39