### PR TITLE
Fix broken PDF link

### DIFF
--- a/legal.html
+++ b/legal.html
@@ -81,7 +81,7 @@ Author: Deathsgift66
   <div>© 2025 Kingmaker’s Rise</div>
   <div>
     <a href="Assets/legal/PrivacyPolicy.pdf">Privacy Policy</a>
-    <a href="Assets/legal/TermsOfService.pdf">Terms of Service</a>
+    <a href="Assets/legal/TermsofService.pdf">Terms of Service</a>
     <a href="Assets/legal/EULA.pdf">EULA</a>
     <a href="legal.html">and more</a>
   </div>


### PR DESCRIPTION
## Summary
- fix broken TermsofService link in `legal.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c1c03a5508330a0604e605434b2df