### PR TITLE
Fix empty HTML elements

### DIFF
--- a/account_settings.html
+++ b/account_settings.html
@@ -177,7 +177,7 @@ Author: Deathsgift66
       <a href="legal.html">More</a>
     </div>
   </footer>
-  <div id="toast" class="toast-notification"></div>
+  <div id="toast" class="toast-notification" aria-live="polite"></div>
 </body>
 
 </html>

--- a/alliance_changelog.html
+++ b/alliance_changelog.html
@@ -75,7 +75,7 @@ Author: Deathsgift66
         <button onclick="fetchChangelog()">Refresh</button>
       </div>
       <div class="last-updated">Last updated: <span id="last-updated">--</span></div>
-      <ul id="changelog-list" class="timeline-feed"></ul>
+      <ul id="changelog-list" class="timeline-feed"><li>Loading...</li></ul>
     </section>
   </main>
 

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -81,16 +81,16 @@ Author: Deathsgift66
       </div>
 
       <div id="available-tab" class="tab-content active">
-        <div class="project-list" id="available-projects-list"></div>
+        <div class="project-list" id="available-projects-list"><!-- JS injects projects --></div>
       </div>
       <div id="in-progress-tab" class="tab-content">
-        <div class="project-list" id="in-progress-projects-list"></div>
+        <div class="project-list" id="in-progress-projects-list"><!-- JS injects projects --></div>
       </div>
       <div id="completed-tab" class="tab-content">
-        <div class="project-list" id="completed-projects-list"></div>
+        <div class="project-list" id="completed-projects-list"><!-- JS injects projects --></div>
       </div>
       <div id="catalogue-tab" class="tab-content">
-        <div class="project-list" id="catalogue-projects-list"></div>
+        <div class="project-list" id="catalogue-projects-list"><!-- JS injects projects --></div>
       </div>
     </div>
   </main>

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -111,12 +111,12 @@ Author: Deathsgift66
   <!-- Quest Modal -->
   <div id="quest-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-quest-title" aria-describedby="modal-quest-description" tabindex="-1">
     <div class="modal-content">
-      <button class="close-button wax-seal-btn" aria-label="Close quest details" title="Close Quest Details"></button>
-      <h3 id="modal-quest-title" class="quest-title-modal"></h3>
-      <p class="quest-type-modal"></p>
+      <button class="close-button wax-seal-btn" aria-label="Close quest details" title="Close Quest Details">×</button>
+      <h3 id="modal-quest-title" class="quest-title-modal">Quest Title</h3>
+      <p class="quest-type-modal">Type</p>
 
       <div class="modal-parchment-content">
-        <p id="modal-quest-description" class="quest-description"></p>
+        <p id="modal-quest-description" class="quest-description">Description</p>
 
         <div class="quest-details-section">
           <h4>Required Contributions:</h4>
@@ -132,11 +132,11 @@ Author: Deathsgift66
           </ul>
         </div>
 
-        <p class="time-limit-display">Time Left: <span id="modal-time-left"></span></p>
-        <p id="modal-quest-leader-note" class="quest-leader-note-modal"></p>
+        <p class="time-limit-display">Time Left: <span id="modal-time-left">--:--:--</span></p>
+        <p id="modal-quest-leader-note" class="quest-leader-note-modal">&nbsp;</p>
 
         <div class="modal-action-area">
-          <p id="role-check-message" class="role-check-message"></p>
+          <p id="role-check-message" class="role-check-message">&nbsp;</p>
           <button class="action-btn medieval-banner-btn accept-quest-btn hidden" id="accept-quest-button" title="Accept This Quest">Accept Quest</button>
           <button class="action-btn medieval-banner-btn claim-reward-btn hidden" id="claim-reward-button" title="Claim Quest Reward">Claim Reward</button>
         </div>


### PR DESCRIPTION
## Summary
- add loading placeholder in alliance changelog
- annotate empty project lists
- fill in quest modal placeholders
- add aria-live to toast in account settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684c1c076a988330aab3bd055d54c3e5