### PR TITLE
Fix missing type annotations

### DIFF
--- a/backend/battle_engine/engine.py
+++ b/backend/battle_engine/engine.py
@@ -77,7 +77,7 @@ class FogOfWar:
 
 
 class CombatResolver:
-    def resolve(self, war: WarState, logs: List[Dict]):
+    def resolve(self, war: WarState, logs: List[Dict]) -> None:
         """Very simplified combat resolution."""
         units_by_pos: Dict[Tuple[int, int], List[Unit]] = {}
         for u in war.units:
@@ -117,7 +117,7 @@ class CombatResolver:
 
 
 class BattleTickHandler:
-    def __init__(self):
+    def __init__(self) -> None:
         self.terrain_generator = TerrainGenerator()
         self.fog = FogOfWar()
         self.combat = CombatResolver()

--- a/services/kingdom_achievement_service.py
+++ b/services/kingdom_achievement_service.py
@@ -6,7 +6,9 @@ except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
     Session = object  # type: ignore
 
 
-def award_achievement(db: Session, kingdom_id: int, achievement_code: str):
+def award_achievement(
+    db: Session, kingdom_id: int, achievement_code: str
+) -> dict | None:
     """Award an achievement if not already earned.
 
     Returns the reward JSON if newly awarded, otherwise ``None``.
@@ -43,7 +45,7 @@ def award_achievement(db: Session, kingdom_id: int, achievement_code: str):
     return reward_row[0] if reward_row else None
 
 
-def list_achievements(db: Session, kingdom_id: int):
+def list_achievements(db: Session, kingdom_id: int) -> list[dict]:
     """Return all achievements with unlock status for a kingdom."""
     rows = db.execute(
         text(


### PR DESCRIPTION
## Summary
- annotate return types in `CombatResolver.resolve` and `BattleTickHandler.__init__`
- annotate service functions returning achievements

## Testing
- `ruff check backend/battle_engine/engine.py services/kingdom_achievement_service.py --select ANN`
- `pytest` *(fails: 48 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684c1c1c24d4833086d24173ea87575c