### PR TITLE
Fix exception handling

### DIFF
--- a/backend/data.py
+++ b/backend/data.py
@@ -99,10 +99,12 @@ spy_missions: dict[int, list[dict]] = {}
 # Global settings loaded from the database
 global_game_settings: dict[str, object] = {}
 
+import logging
+
 try:  # pragma: no cover - SQLAlchemy optional in tests
     from sqlalchemy import text
     from .database import SessionLocal
-except Exception:  # pragma: no cover - fallback when deps missing
+except ImportError:  # pragma: no cover - fallback when deps missing
     text = lambda q: q  # type: ignore
     SessionLocal = None  # type: ignore
 
@@ -121,7 +123,7 @@ def load_game_settings() -> None:
         global_game_settings.clear()
         for key, value in rows:
             global_game_settings[key] = value
-    except Exception:
-        pass
+    except Exception as exc:
+        logging.error("Failed to load game settings: %s", exc)
     finally:
         session.close()

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Depends
+import logging
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 from pydantic import BaseModel

--- a/services/alliance_treaty_service.py
+++ b/services/alliance_treaty_service.py
@@ -1,7 +1,9 @@
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+except ImportError:  # pragma: no cover - fallback when SQLAlchemy isn't installed
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/audit_service.py
+++ b/services/audit_service.py
@@ -1,7 +1,9 @@
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+except ImportError:  # pragma: no cover - fallback when SQLAlchemy isn't installed
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/kingdom_achievement_service.py
+++ b/services/kingdom_achievement_service.py
@@ -1,7 +1,9 @@
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+except ImportError:  # pragma: no cover - fallback when SQLAlchemy isn't installed
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/kingdom_history_service.py
+++ b/services/kingdom_history_service.py
@@ -1,7 +1,9 @@
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+except ImportError:  # pragma: no cover - fallback when SQLAlchemy isn't installed
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/kingdom_quest_service.py
+++ b/services/kingdom_quest_service.py
@@ -1,11 +1,12 @@
 """Service functions for kingdom quest tracking."""
 
 from datetime import datetime, timedelta
+import logging
 
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/kingdom_setup_service.py
+++ b/services/kingdom_setup_service.py
@@ -1,10 +1,11 @@
 from typing import Optional
 import json
+import logging
 
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/kingdom_title_service.py
+++ b/services/kingdom_title_service.py
@@ -1,7 +1,9 @@
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+except ImportError:  # pragma: no cover - fallback when SQLAlchemy isn't installed
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/kingdom_treaty_service.py
+++ b/services/kingdom_treaty_service.py
@@ -1,7 +1,9 @@
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+except ImportError:  # pragma: no cover - fallback when SQLAlchemy isn't installed
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/research_service.py
+++ b/services/research_service.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 """Service functions for kingdom technology research tracking."""
 
 from datetime import datetime, timedelta
+import logging
 
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+except ImportError:  # pragma: no cover - fallback when SQLAlchemy isn't installed
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/spies_service.py
+++ b/services/spies_service.py
@@ -1,9 +1,11 @@
 """Database helpers for kingdom spy management."""
 
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+except ImportError:  # pragma: no cover - fallback when SQLAlchemy isn't installed
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/strategic_tick_service.py
+++ b/services/strategic_tick_service.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 """Automation helpers for periodic game state updates."""
 
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+except ImportError:  # pragma: no cover - fallback when SQLAlchemy isn't installed
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 
@@ -23,8 +25,8 @@ def _log_unified(db: Session, event_type: str, details: str) -> None:
             {"et": event_type, "de": details},
         )
         db.commit()
-    except Exception:  # pragma: no cover - ignore missing table
-        pass
+    except Exception as exc:  # pragma: no cover - ignore missing table
+        logging.warning("Unified logs unavailable: %s", exc)
 
 
 def _notify_event(db: Session, event_type: str, ref_id: int, info: str = "") -> None:
@@ -38,8 +40,8 @@ def _notify_event(db: Session, event_type: str, ref_id: int, info: str = "") -> 
             {"et": event_type, "rid": ref_id, "info": info},
         )
         db.commit()
-    except Exception:  # pragma: no cover - ignore missing table
-        pass
+    except Exception as exc:  # pragma: no cover - ignore missing table
+        logging.warning("Event notification log unavailable: %s", exc)
 
 
 def update_project_progress(db: Session) -> int:

--- a/services/tax_service.py
+++ b/services/tax_service.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 """Service functions for alliance tax collections."""
 
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback when SQLAlchemy isn't installed
+except ImportError:  # pragma: no cover - fallback when SQLAlchemy isn't installed
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/trade_log_service.py
+++ b/services/trade_log_service.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/training_catalog_service.py
+++ b/services/training_catalog_service.py
@@ -1,9 +1,11 @@
 """Helpers for reading the training_catalog table."""
 
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback if SQLAlchemy missing
+except ImportError:  # pragma: no cover - fallback if SQLAlchemy missing
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/training_history_service.py
+++ b/services/training_history_service.py
@@ -1,7 +1,9 @@
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/training_queue_service.py
+++ b/services/training_queue_service.py
@@ -1,7 +1,9 @@
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/vacation_mode_service.py
+++ b/services/vacation_mode_service.py
@@ -1,11 +1,12 @@
 from datetime import datetime, timedelta
 
 from fastapi import HTTPException
+import logging
 
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - fallback for tests
+except ImportError:  # pragma: no cover - fallback for tests
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 

--- a/services/vip_status_service.py
+++ b/services/vip_status_service.py
@@ -1,7 +1,9 @@
+import logging
+
 try:
     from sqlalchemy import text
     from sqlalchemy.orm import Session
-except Exception:  # pragma: no cover - SQLAlchemy optional
+except ImportError:  # pragma: no cover - SQLAlchemy optional
     text = lambda q: q  # type: ignore
     Session = object  # type: ignore
 from datetime import datetime


### PR DESCRIPTION
## Summary
- add logging and narrow import errors in service modules
- replace silent `pass` blocks with warning logs
- log error when game settings fail to load

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684c1c22040883308fbf144c54e1bd07