### PR TITLE
Fix login form and JS

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -99,7 +99,10 @@ async function handleLogin(e) {
     if (error) {
       showMessage('error', error.message);
     } else {
-      // ✅ Successful login — simply redirect to setup/play page
+      // ✅ Successful login — fetch progression and redirect
+      if (data && data.user) {
+        await fetchAndStorePlayerProgression(data.user.id);
+      }
       showMessage('success', 'Login successful! Redirecting...');
       setTimeout(() => {
         window.location.href = 'play.html';

--- a/login.html
+++ b/login.html
@@ -49,7 +49,7 @@ Author: Deathsgift66
   <h1 class="login-title">Kingmaker's Rise</h1>
   <p class="login-subtitle">Enter the Realm</p>
 
-  <form id="login-form" class="login-form">
+    <form id="login-form" class="login-form" method="post" action="#">
 
     <label for="login-id">Email or Ruler Name</label>
     <input type="text" id="login-id" name="login-id" required />


### PR DESCRIPTION
## Summary
- avoid leaking credentials in URL by making login form submit via POST
- fetch player progression on successful login before redirecting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*
- `pip install sqlalchemy` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_684c235897f08330972ffdb34dacbf70