### PR TITLE
Fix login page JS bindings

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   announcementList = document.getElementById('announcement-list');
 
-  forgotLink = document.querySelector('.account-links a[href="forgot_password.html"]');
+  forgotLink = document.getElementById('forgot-password-link');
   modal = document.getElementById('forgot-password-modal');
   closeBtn = document.getElementById('close-forgot-btn');
   sendResetBtn = document.getElementById('send-reset-btn');

--- a/Javascript/supabaseClient.js
+++ b/Javascript/supabaseClient.js
@@ -6,7 +6,8 @@ Author: Deathsgift66
 */
 // Centralized Supabase Client — supports BOTH .env and fallback — used by all pages
 import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
-import { loadConfig } from './config.js';
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './config.js';
 
-const { SUPABASE_URL, SUPABASE_ANON_KEY } = await loadConfig();
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+// Initialize Supabase directly from the configuration constants
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+export { supabase };

--- a/login.html
+++ b/login.html
@@ -61,7 +61,7 @@ Author: Deathsgift66
 
   <div class="account-links">
     <a href="signup.html">Create Account</a> |
-    <a href="forgot_password.html">Forgot Password?</a>
+    <a href="#" id="forgot-password-link">Forgot Password?</a>
   </div>
 
   <div id="message" class="message"></div>


### PR DESCRIPTION
## Summary
- correct forgot password link to open modal instead of navigating
- adjust JS to grab link by id
- simplify Supabase client initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_684c257b6ec483308e2e3b7d0538ab3f