### PR TITLE
Insert user row at signup

### DIFF
--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -90,7 +90,7 @@ async function handleSignup() {
   };
 
   try {
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email: payload.email,
       password: payload.password,
       options: {
@@ -103,6 +103,21 @@ async function handleSignup() {
 
     if (error) {
       throw new Error(error.message);
+    }
+
+    const userId = data?.user?.id;
+    if (userId) {
+      await fetch('/api/signup/create_user', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_id: userId,
+          username: payload.username,
+          display_name: payload.display_name,
+          kingdom_name: payload.kingdom_name,
+          email: payload.email
+        })
+      });
     }
 
     showToast("Sign-Up successful! Redirecting to login...");


### PR DESCRIPTION
## Summary
- create `/api/signup/create_user` backend endpoint
- call this endpoint after successful signup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -q -r dev_requirements.txt` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684c2a0bded48330b23d1b0a9bb76b86