### PR TITLE
Add server-side signup endpoint

### DIFF
--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -5,7 +5,6 @@ Date: June 2, 2025
 Author: Deathsgift66
 */
 
-import { supabase } from './supabaseClient.js';
 
 document.addEventListener("DOMContentLoaded", () => {
   const form = document.getElementById('signup-form');
@@ -90,36 +89,16 @@ async function handleSignup() {
   };
 
   try {
-    const { data, error } = await supabase.auth.signUp({
-      email: payload.email,
-      password: payload.password,
-      options: {
-        data: {
-          display_name: payload.display_name,
-          username: payload.username
-        }
-      }
+    const res = await fetch('/api/signup/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
     });
-
-    if (error) {
-      throw new Error(error.message);
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.detail || 'registration failed');
     }
-
-    const userId = data?.user?.id;
-    if (userId) {
-      await fetch('/api/signup/create_user', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          user_id: userId,
-          username: payload.username,
-          display_name: payload.display_name,
-          kingdom_name: payload.kingdom_name,
-          email: payload.email
-        })
-      });
-    }
-
+  
     showToast("Sign-Up successful! Redirecting to login...");
     setTimeout(() => {
       window.location.href = 'login.html';

--- a/tests/test_signup_router.py
+++ b/tests/test_signup_router.py
@@ -1,0 +1,67 @@
+import uuid
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi import HTTPException
+
+from backend.db_base import Base
+from backend.models import User
+from backend.routers import signup
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+class DummyAdmin:
+    def __init__(self, user_id="u1", error=False):
+        self._user_id = user_id
+        self._error = error
+
+    def create_user(self, **_kwargs):
+        if self._error:
+            raise Exception("fail")
+        return {"user": {"id": self._user_id}}
+
+
+class DummyClient:
+    def __init__(self, user_id="u1", error=False):
+        self.auth = type("auth", (), {"admin": DummyAdmin(user_id, error)})()
+
+
+def test_register_creates_user_row():
+    Session = setup_db()
+    db = Session()
+    signup.get_supabase_client = lambda: DummyClient("newid")
+    payload = signup.RegisterPayload(
+        email="e@example.com",
+        password="pass",
+        username="user",
+        kingdom_name="Realm",
+        display_name="user",
+    )
+    res = signup.register(payload, db=db)
+    assert res["user_id"] == "newid"
+    user = db.query(User).get("newid")
+    assert user.email == "e@example.com"
+
+
+def test_register_handles_error():
+    Session = setup_db()
+    db = Session()
+    signup.get_supabase_client = lambda: DummyClient(error=True)
+    payload = signup.RegisterPayload(
+        email="x@x.com",
+        password="p",
+        username="u",
+        kingdom_name="k",
+        display_name="u",
+    )
+    try:
+        signup.register(payload, db=db)
+    except HTTPException as e:
+        assert e.status_code == 500
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- move signup process server-side to ensure `auth.users` row is created before inserting to `public.users`
- call new `/api/signup/register` endpoint from the signup form
- test server-side registration logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684c2c875d448330aaab1cd574398c80