### PR TITLE
Fix login announcements fetch

### DIFF
--- a/login.html
+++ b/login.html
@@ -30,6 +30,7 @@ Author: Deathsgift66
 
   <!-- Page-Specific Assets -->
   <link rel="stylesheet" href="CSS/login.css" />
+  <script type="module" src="Javascript/apiHelper.js"></script>
   <script defer type="module" src="Javascript/login.js"></script>
 
   <!-- Global Assets -->


### PR DESCRIPTION
## Summary
- include `apiHelper.js` on `login.html` so `/api` requests go to the backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684c7ccc5a588330aed21775d86821fe