### PR TITLE
Fix announcements fetch message

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -178,7 +178,10 @@ async function loadAnnouncements() {
     const ctype = res.headers.get('content-type') || '';
     if (!ctype.includes('application/json')) {
       const text = await res.text();
-      console.error('Invalid JSON from announcements:', text);
+      console.error(
+        'Announcements endpoint returned non-JSON. Is the API running?'
+      );
+      console.debug(text.slice(0, 150));
       return;
     }
     const announcements = await res.json();


### PR DESCRIPTION
## Summary
- clarify login error when the API isn't running

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_684c7e08f9a4833082ef5618cc8699ee