### PR TITLE
Fix progression API availability

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from backend.routers import resources
 from backend.routers import login_routes as announcements
 from backend.routers import region
+from backend.routers import progression_router
 
 
 app = FastAPI()
@@ -15,6 +16,7 @@ app = FastAPI()
 app.include_router(resources.router)
 app.include_router(announcements.router)
 app.include_router(region.router)
+app.include_router(progression_router.router)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual start


### PR DESCRIPTION
## Summary
- include the progression router in `main.py`

## Testing
- `pytest` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_684c8ddc1b70833093a7d1034dea3fbd