### PR TITLE
Improve progression fetch handling and docs

### DIFF
--- a/Javascript/progressionGlobal.js
+++ b/Javascript/progressionGlobal.js
@@ -11,8 +11,11 @@ export async function fetchAndStorePlayerProgression(userId) {
     const res = await fetch('/api/progression/summary', {
       headers: { 'X-User-ID': userId }
     });
+    if (!res.ok ||
+        !res.headers.get('content-type')?.includes('application/json')) {
+      throw new Error('Invalid response from backend');
+    }
     const data = await res.json();
-    if (!res.ok) throw new Error(data.error || 'Failed to fetch progression');
 
     window.playerProgression = {
       castleLevel: data.castle_level,

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ python main.py
 When the backend is not running the static server used by `npm run serve` will
 return `index.html` for requests under `/api`, leading to browser console errors
 like `Invalid JSON from /api/resources`.
+If the API is up you can verify everything works by visiting
+`http://localhost:8000/api/progression/summary` in your browser. A JSON object
+should be returned.
 
 ---
 
@@ -121,6 +124,11 @@ MASTER_ROLLBACK_PASSWORD
 Update these values with your project credentials to enable API access. Then copy
 `env.example.js` to `env.js` so the frontend can access the public values at
 runtime.
+
+When calling Supabase REST endpoints directly you must include the project's
+`apikey` and a valid `Authorization` bearer token in the request headers. The
+included JavaScript modules rely on the Supabase client which sets these
+automatically.
 
 This will create all tables referenced by the frontend.
 


### PR DESCRIPTION
## Summary
- guard against invalid API responses in `progressionGlobal.js`
- document verifying `/api/progression/summary` in the README
- mention required headers for direct Supabase REST calls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684c941a594483308625feaf9d60aee5