### PR TITLE
Fix navbar path and broken article link

### DIFF
--- a/Javascript/alliance_members.js
+++ b/Javascript/alliance_members.js
@@ -116,7 +116,7 @@ async function renderMembers(data) {
 
     row.innerHTML = `
       <td><img src="../images/crests/${escapeHTML(member.crest || 'default.png')}" class="crest-icon" alt="Crest"></td>
-      <td><a href="kingdom_profile.html?kingdom_id=${member.kingdom_id}">${escapeHTML(member.username)}</a>${member.is_vip ? ' ⭐' : ''}</td>
+      <td><a href="profile.html?kingdom_id=${member.kingdom_id}">${escapeHTML(member.username)}</a>${member.is_vip ? ' ⭐' : ''}</td>
       <td title="${escapeHTML(RANK_TOOLTIPS[member.rank] || '')}">${escapeHTML(member.rank)}</td>
       <td>${showFull ? escapeHTML(member.role || '—') : '—'}</td>
       <td>${showFull ? escapeHTML(member.status) : '—'}</td>

--- a/Javascript/navLoader.js
+++ b/Javascript/navLoader.js
@@ -3,7 +3,9 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 document.addEventListener("DOMContentLoaded", () => {
-  const NAVBAR_PATH = "/navbar.html";
+  // Fetch navbar relative to the current page so deployment under a subpath
+  // still resolves correctly
+  const NAVBAR_PATH = "navbar.html";
   const MAX_RETRIES = 3;
   const RETRY_DELAY_MS = 500;
   const target =
@@ -58,7 +60,7 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error("❌ Navbar injection failed:", err);
       target.innerHTML = `
         <div class="navbar-failover">
-          <p>⚠️ Navigation failed to load. <a href="/">Return home</a>.</p>
+          <p>⚠️ Navigation failed to load. <a href="index.html">Return home</a>.</p>
         </div>
       `;
     }

--- a/Javascript/news.js
+++ b/Javascript/news.js
@@ -69,7 +69,7 @@ function renderArticles(articles) {
       <h3>${escapeHTML(article.title)}</h3>
       <p class="news-meta">By ${escapeHTML(article.author_name || "System")} — ${formatDate(article.published_at)}</p>
       <p class="news-summary">${escapeHTML(article.summary || "")}</p>
-      <a href="news_article.html?article_id=${article.article_id}" class="action-btn">Read More</a>
+      <a href="#" class="action-btn" title="Full article page coming soon">Read More</a>
     `;
 
     container.appendChild(card);

--- a/account_settings.html
+++ b/account_settings.html
@@ -34,7 +34,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/resource_bar.css" />
 
   <!-- JS -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script defer src="Javascript/account_settings.js"></script>
@@ -43,11 +42,7 @@ Developer: Deathsgift66
 <body data-theme="parchment">
   <!-- Navigation -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => document.getElementById('navbar-container').innerHTML = html);
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Header Banner -->
   <header class="kr-top-banner" aria-label="Page banner">

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -43,7 +43,6 @@ Developer: Deathsgift66
 
   <!-- Admin Scripts -->
   <script>window.requireAdmin = true;</script>
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" defer src="Javascript/resourceBar.js"></script>
   <script type="module" defer src="Javascript/admin_alerts.js"></script>
@@ -52,13 +51,7 @@ Developer: Deathsgift66
 <body data-theme="parchment">
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Admin Panel Header">

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -42,7 +42,6 @@ Developer: Deathsgift66
   <script>window.requireAdmin = true;</script>
 
   <!-- Scripts -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script defer type="module" src="Javascript/admin_dashboard.js"></script>
@@ -51,13 +50,7 @@ Developer: Deathsgift66
 <body data-theme="parchment">
   <!-- Navigation -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Admin Dashboard Banner">

--- a/alliance_changelog.html
+++ b/alliance_changelog.html
@@ -43,7 +43,6 @@ Developer: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <!-- Scripts -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/apiHelper.js"></script>
   <script type="module" src="Javascript/allianceAppearance.js"></script>
@@ -54,13 +53,7 @@ Developer: Deathsgift66
 <body class="alliance-bg">
   <!-- Navigation -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Alliance Changelog Header">

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -44,7 +44,6 @@ Developer: Deathsgift66
 
   <!-- JS -->
   <script type="module" src="Javascript/components/authGuard.js"></script>
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/apiHelper.js"></script>
   <script type="module" src="Javascript/allianceAppearance.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
@@ -54,13 +53,7 @@ Developer: Deathsgift66
 <body class="alliance-bg">
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Header -->
   <header class="kr-top-banner" aria-label="Alliance Homepage Banner">

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -41,7 +41,6 @@ Developer: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <!-- Scripts -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/apiHelper.js"></script>
   <script type="module" src="Javascript/allianceAppearance.js"></script>
@@ -52,13 +51,7 @@ Developer: Deathsgift66
 <body class="alliance-bg">
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Alliance Members Banner">

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -41,7 +41,6 @@ Developer: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <!-- JavaScript -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/apiHelper.js"></script>
   <script type="module" src="Javascript/allianceAppearance.js"></script>
@@ -53,13 +52,7 @@ Developer: Deathsgift66
 <body class="alliance-bg">
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Alliance Projects Header">

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -42,7 +42,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/alliance_quests.css" />
 
   <!-- JS Modules -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/apiHelper.js"></script>
   <script type="module" src="Javascript/allianceAppearance.js"></script>
@@ -55,11 +54,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => { document.getElementById('navbar-container').innerHTML = html; });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Header -->
   <header class="kr-top-banner" aria-label="Alliance Quests Banner">

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -41,7 +41,6 @@ Developer: Deathsgift66
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=IM+Fell+English&display=swap" rel="stylesheet" />
 
   <!-- JS Modules -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/apiHelper.js"></script>
   <script type="module" src="Javascript/allianceAppearance.js"></script>
@@ -54,13 +53,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Alliance Treaties Page Header">

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -40,7 +40,6 @@ Developer: Deathsgift66
 
   <!-- Scripts -->
   <script>window.requireAlliance = true;</script>
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/apiHelper.js"></script>
   <script type="module" src="Javascript/allianceAppearance.js"></script>
@@ -51,13 +50,7 @@ Developer: Deathsgift66
 <body class="alliance-bg">
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Vault Management Page Header">

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -41,7 +41,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/alliance_wars.css" />
 
   <!-- Scripts -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/apiHelper.js"></script>
   <script type="module" src="Javascript/allianceAppearance.js"></script>
@@ -54,13 +53,7 @@ Developer: Deathsgift66
 
   <!-- ✅ Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- ✅ Page Header -->
   <header class="kr-top-banner" aria-label="Alliance Wars Banner">

--- a/audit_log.html
+++ b/audit_log.html
@@ -39,7 +39,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script>window.requireAdmin = true;</script>
@@ -49,13 +48,7 @@ Developer: Deathsgift66
 
   <!-- ✅ Navbar Inject -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- ✅ Page Banner -->
   <header class="kr-top-banner" aria-label="Audit Log Banner">

--- a/battle_live.html
+++ b/battle_live.html
@@ -39,7 +39,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>
@@ -48,13 +47,7 @@ Developer: Deathsgift66
 
   <!-- ✅ Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- ✅ Page Banner -->
   <header class="kr-top-banner" aria-label="Live Battle Banner">

--- a/battle_replay.html
+++ b/battle_replay.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/battle_replay.css" />
 
   <!-- JavaScript Modules -->
-  <script defer type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
@@ -50,13 +49,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Battle Replay Banner">

--- a/battle_resolution.html
+++ b/battle_resolution.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/battle_resolution.css" />
 
   <!-- Scripts -->
-  <script defer type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script defer type="module" src="Javascript/battle_resolution.js"></script>
@@ -48,13 +47,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Battle Results Banner">

--- a/black_market.html
+++ b/black_market.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/black_market.css" />
 
   <!-- JS Modules -->
-  <script defer type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script defer type="module" src="Javascript/black_market.js"></script>
@@ -48,13 +47,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Black Market Header">

--- a/buildings.html
+++ b/buildings.html
@@ -39,7 +39,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script defer type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>
@@ -48,13 +47,7 @@ Developer: Deathsgift66
 
   <!-- Inject Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Buildings Page Banner">

--- a/changelog.html
+++ b/changelog.html
@@ -39,7 +39,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script defer type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>
@@ -51,13 +50,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Changelog Banner">

--- a/compose.html
+++ b/compose.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script defer type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>
@@ -47,11 +46,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html').then(r => r.text()).then(html => {
-      document.getElementById('navbar-container').innerHTML = html;
-    });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Compose Interface">

--- a/conflicts.html
+++ b/conflicts.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script defer type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>
@@ -47,13 +46,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Conflicts Page Banner">

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/diplomacy_center.css" />
 
   <!-- Scripts -->
-  <script defer type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script defer type="module" src="Javascript/progressionBanner.js"></script>
@@ -49,11 +48,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script>
-  fetch('/navbar.html')
-    .then(res => res.text())
-    .then(html => { document.getElementById('navbar-container').innerHTML = html; });
-</script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Diplomacy Banner">

--- a/donate_vip.html
+++ b/donate_vip.html
@@ -37,7 +37,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/donate_vip.css" />
 
   <!-- JS Modules -->
-  <script defer type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script defer type="module" src="Javascript/donate_vip.js"></script>
@@ -47,13 +46,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Donate & VIP Banner">

--- a/edit_kingdom.html
+++ b/edit_kingdom.html
@@ -37,7 +37,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/edit_kingdom.css" />
 
   <!-- Scripts -->
-  <script defer type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script defer type="module" src="Javascript/edit_kingdom.js"></script>
@@ -47,13 +46,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Edit Kingdom Banner">

--- a/index.html
+++ b/index.html
@@ -35,7 +35,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script type="module" src="Javascript/apiHelper.js"></script>
@@ -49,13 +48,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script>
-  fetch("/navbar.html")
-    .then(res => res.text())
-    .then(html => {
-      document.getElementById("navbar-container").innerHTML = html;
-    });
-</script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
 <!-- Hero Banner -->
 <section class="hero-section" aria-label="Hero Introduction">

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>
@@ -47,13 +46,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script>
-  fetch("/navbar.html")
-    .then(res => res.text())
-    .then(html => {
-      document.getElementById("navbar-container").innerHTML = html;
-    });
-</script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Kingdom Achievements Banner">

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -39,7 +39,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>
@@ -48,13 +47,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script>
-  fetch('/navbar.html')
-    .then(res => res.text())
-    .then(html => {
-      document.getElementById('navbar-container').innerHTML = html;
-    });
-</script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
 <!-- Banner -->
 <header class="kr-top-banner" aria-label="Kingdom History Banner">

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -40,7 +40,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/progressionBanner.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
@@ -50,13 +49,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script>
-  fetch('/navbar.html')
-    .then(res => res.text())
-    .then(html => {
-      document.getElementById('navbar-container').innerHTML = html;
-    });
-</script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Kingdom Military Banner">

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -39,7 +39,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>
@@ -48,13 +47,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script>
-  fetch('/navbar.html')
-    .then(res => res.text())
-    .then(html => {
-      document.getElementById('navbar-container').innerHTML = html;
-    });
-</script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Leaderboard Banner">

--- a/legal.html
+++ b/legal.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>
 
@@ -46,13 +45,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script>
-  fetch('/navbar.html')
-    .then(res => res.text())
-    .then(html => {
-      document.getElementById('navbar-container').innerHTML = html;
-    });
-</script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Legal Banner">

--- a/market.html
+++ b/market.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/market.css" />
 
   <!-- Scripts -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script defer type="module" src="Javascript/market.js"></script>

--- a/message.html
+++ b/message.html
@@ -40,7 +40,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/messages.html
+++ b/messages.html
@@ -40,7 +40,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/news.html
+++ b/news.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <link rel="stylesheet" href="CSS/resource_bar.css" />
   <script defer type="module" src="Javascript/resourceBar.js"></script>
@@ -48,13 +47,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script>
-  fetch('/navbar.html')
-    .then(res => res.text())
-    .then(html => {
-      document.getElementById('navbar-container').innerHTML = html;
-    });
-</script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="News Banner">

--- a/notifications.html
+++ b/notifications.html
@@ -39,7 +39,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/play.html
+++ b/play.html
@@ -37,7 +37,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/play.css" />
 
   <!-- Scripts -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script defer type="module" src="Javascript/play.js"></script>
 </head>
 

--- a/player_management.html
+++ b/player_management.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/player_management.css" />
 
   <!-- JS Modules -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script>window.requireAdmin = true;</script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>

--- a/policies_laws.html
+++ b/policies_laws.html
@@ -36,7 +36,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/progressionBanner.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>

--- a/preplan_editor.html
+++ b/preplan_editor.html
@@ -41,7 +41,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/resource_bar.css" />
 
   <!-- Scripts -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/resourceBar.js" defer></script>
   <script type="module" src="Javascript/preplan_editor.js" defer></script>

--- a/projects.html
+++ b/projects.html
@@ -41,7 +41,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/resource_bar.css" />
 
   <!-- Scripts -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/progressionBanner.js"></script>
   <script type="module" src="Javascript/resourceBar.js" defer></script>

--- a/quests.html
+++ b/quests.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/progressionBanner.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
@@ -48,13 +47,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-  <script>
-    fetch('/navbar.html')
-      .then(res => res.text())
-      .then(html => {
-        document.getElementById('navbar-container').innerHTML = html;
-      });
-  </script>
+<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Kingdom Quests Banner">

--- a/research.html
+++ b/research.html
@@ -36,7 +36,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/resources.html
+++ b/resources.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/resource_bar.css" />
 
   <!-- JS Modules -->
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
   <script defer type="module" src="Javascript/resources.js"></script>

--- a/seasonal_effects.html
+++ b/seasonal_effects.html
@@ -36,7 +36,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/signup.html
+++ b/signup.html
@@ -35,7 +35,6 @@ Developer: Deathsgift66
   <link rel="icon" href="Assets/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
 </head>
 
 <body>

--- a/spies.html
+++ b/spies.html
@@ -35,7 +35,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/temples.html
+++ b/temples.html
@@ -36,7 +36,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/town_criers.html
+++ b/town_criers.html
@@ -36,7 +36,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/trade_logs.html
+++ b/trade_logs.html
@@ -36,7 +36,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/train_troops.html
+++ b/train_troops.html
@@ -37,7 +37,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/progressionBanner.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>

--- a/treaty_web.html
+++ b/treaty_web.html
@@ -37,7 +37,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/tutorial.html
+++ b/tutorial.html
@@ -37,7 +37,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/village.html
+++ b/village.html
@@ -36,7 +36,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/village_master.html
+++ b/village_master.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>

--- a/villages.html
+++ b/villages.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/progressionBanner.js"></script>
   <link rel="stylesheet" href="CSS/resource_bar.css" />

--- a/wars.html
+++ b/wars.html
@@ -39,7 +39,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/progressionBanner.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script type="module" src="Javascript/progressionBanner.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>

--- a/world_map.html
+++ b/world_map.html
@@ -38,7 +38,6 @@ Developer: Deathsgift66
   <link rel="stylesheet" href="CSS/root_theme.css" />
   <link rel="stylesheet" href="CSS/kr_navbar.css" />
   <link rel="stylesheet" href="CSS/resource_bar.css" />
-  <script type="module" src="Javascript/navDropdown.js"></script>
   <script type="module" src="Javascript/components/authGuard.js"></script>
   <script defer type="module" src="Javascript/resourceBar.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- load navbar relative to current page
- replace direct navbar fetch blocks with navLoader script
- update alliance member profile link
- disable news article link until feature exists

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_684d89a264c083308cbdd3783ac622d8