### PR TITLE
Fix env loading

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -14,8 +14,8 @@ from dotenv import load_dotenv
 from supabase import create_client, Client
 import logging
 
-# Load .env variables (Render environment uses system variables by default)
-load_dotenv()
+# Load .ENV variables (Render environment uses system variables by default)
+load_dotenv(".ENV")
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- load environment vars from `.ENV` instead of default `.env`

## Testing
- `pytest tests/test_account_settings_router.py -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684d89cb80048330acf000a421e3a06d