### PR TITLE
Implement war persistence and bulk village API

### DIFF
--- a/Javascript/village_master.js
+++ b/Javascript/village_master.js
@@ -128,28 +128,49 @@ function setupAmbientToggle() {
   });
 }
 
-// ✅ Mass Action: Bulk Upgrade All buildings (stub async example)
+// ✅ Mass Action: Bulk Upgrade All buildings
 async function bulkUpgradeAll() {
   showToast("Initiating bulk upgrade of all buildings...");
-  // TODO: Replace with real API call
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  showToast("Bulk upgrade complete!");
+  try {
+    const res = await fetch('/api/village-master/bulk_upgrade', {
+      method: 'POST'
+    });
+    if (!res.ok) throw new Error('Failed');
+    showToast("Bulk upgrade complete!");
+  } catch (err) {
+    console.error('❌ Bulk upgrade failed:', err);
+    showToast('Bulk upgrade failed');
+  }
 }
 
-// ✅ Mass Action: Queue Troops in all villages (stub async example)
+// ✅ Mass Action: Queue Troops in all villages
 async function bulkQueueTraining() {
   showToast("Queuing troops in all villages...");
-  // TODO: Replace with real API call
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  showToast("Troop training queues started!");
+  try {
+    const res = await fetch('/api/village-master/bulk_queue_training', {
+      method: 'POST'
+    });
+    if (!res.ok) throw new Error('Failed');
+    showToast("Troop training queues started!");
+  } catch (err) {
+    console.error('❌ Bulk queue failed:', err);
+    showToast('Bulk queue failed');
+  }
 }
 
-// ✅ Mass Action: Harvest all village resources (stub async example)
+// ✅ Mass Action: Harvest all village resources
 async function bulkHarvest() {
   showToast("Harvesting resources from all villages...");
-  // TODO: Replace with real API call
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  showToast("Resources harvested!");
+  try {
+    const res = await fetch('/api/village-master/bulk_harvest', {
+      method: 'POST'
+    });
+    if (!res.ok) throw new Error('Failed');
+    showToast("Resources harvested!");
+  } catch (err) {
+    console.error('❌ Bulk harvest failed:', err);
+    showToast('Bulk harvest failed');
+  }
 }
 
 // ✅ Filter villages by empty state toggle

--- a/Javascript/wars.js
+++ b/Javascript/wars.js
@@ -150,7 +150,7 @@ async function submitDeclareWar() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        target_kingdom_id: parseInt(targetId, 10),
+        target: parseInt(targetId, 10),
         war_reason: reason
       })
     });

--- a/tests/test_village_master_bulk.py
+++ b/tests/test_village_master_bulk.py
@@ -1,0 +1,50 @@
+from backend.routers.village_master import (
+    bulk_upgrade_all,
+    bulk_queue_training,
+    bulk_harvest,
+)
+
+
+class DummyResult:
+    def __init__(self, row=None):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class DummyDB:
+    def __init__(self):
+        self.calls = []
+
+    def execute(self, query, params=None):
+        q = str(query)
+        self.calls.append((q, params))
+        if "FROM kingdoms" in q:
+            return DummyResult((1,))
+        return DummyResult()
+
+    def commit(self):
+        pass
+
+
+def test_bulk_upgrade_executes_update():
+    db = DummyDB()
+    bulk_upgrade_all(user_id="u1", db=db)
+    executed = " ".join(db.calls[1][0].split()).lower()
+    assert "update village_buildings" in executed
+    assert db.calls[1][1]["kid"] == 1
+
+
+def test_bulk_queue_training_inserts():
+    db = DummyDB()
+    bulk_queue_training(user_id="u1", db=db)
+    executed = " ".join(db.calls[1][0].split()).lower()
+    assert "insert into training_queue" in executed
+
+
+def test_bulk_harvest_updates_resources():
+    db = DummyDB()
+    bulk_harvest(user_id="u1", db=db)
+    executed = " ".join(db.calls[1][0].split()).lower()
+    assert "update village_resources" in executed

--- a/tests/test_wars_router.py
+++ b/tests/test_wars_router.py
@@ -1,0 +1,34 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.db_base import Base
+from backend.models import User, Kingdom, War
+from models.progression import KingdomKnight
+from backend.routers.wars import declare_war, DeclarePayload
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(engine)
+    return Session
+
+
+def test_declare_war_persists_record():
+    Session = setup_db()
+    db = Session()
+
+    db.add_all([
+        User(user_id="a1", username="A", email="a@example.com", kingdom_id=1),
+        User(user_id="d1", username="D", email="d@example.com", kingdom_id=2),
+        Kingdom(kingdom_id=1, user_id="a1", kingdom_name="Aking"),
+        Kingdom(kingdom_id=2, user_id="d1", kingdom_name="Dking"),
+        KingdomKnight(kingdom_id=1, name="Sir A"),
+    ])
+    db.commit()
+
+    res = declare_war(DeclarePayload(target="d1", war_reason="testing"), user_id="a1", db=db)
+    war = db.query(War).first()
+    assert war is not None
+    assert war.defender_id == "d1"
+    assert res["war_id"] == war.war_id


### PR DESCRIPTION
## Summary
- persist wars in `/api/wars/declare`
- add bulk village management endpoints
- hook bulk actions from village master UI
- send proper target data when declaring wars
- tests for war declaration and new bulk endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684d97a22d248330ab0e7674e3aae7c9