### PR TITLE
Fix placeholders and path issues

### DIFF
--- a/CSS/news.css
+++ b/CSS/news.css
@@ -93,3 +93,48 @@ body {
     padding: 1rem;
   }
 }
+
+/* Article Modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: var(--panel-bg);
+  border: var(--border);
+  border-radius: var(--border-radius);
+  box-shadow: 0 8px 16px var(--shadow);
+  padding: 2rem;
+  width: 90%;
+  max-width: 600px;
+  color: var(--ink);
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.article-body {
+  margin-top: 1rem;
+  line-height: 1.5;
+}

--- a/Javascript/news.js
+++ b/Javascript/news.js
@@ -69,8 +69,13 @@ function renderArticles(articles) {
       <h3>${escapeHTML(article.title)}</h3>
       <p class="news-meta">By ${escapeHTML(article.author_name || "System")} — ${formatDate(article.published_at)}</p>
       <p class="news-summary">${escapeHTML(article.summary || "")}</p>
-      <a href="#" class="action-btn" title="Full article page coming soon">Read More</a>
+      <a href="#" class="action-btn read-more">Read More</a>
     `;
+
+    card.querySelector('.read-more')?.addEventListener('click', e => {
+      e.preventDefault();
+      openArticleModal(article);
+    });
 
     container.appendChild(card);
   });
@@ -135,3 +140,18 @@ function escapeHTML(str) {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#039;");
 }
+
+// ✅ Modal viewer for full article
+function openArticleModal(article) {
+  const modal = document.getElementById('article-modal');
+  if (!modal) return;
+  modal.querySelector('#article-title').textContent = article.title || 'Untitled';
+  modal.querySelector('#article-meta').textContent =
+    `By ${article.author_name || 'System'} — ${formatDate(article.published_at)}`;
+  modal.querySelector('#article-body').textContent = article.content || 'Full article coming soon.';
+  modal.classList.remove('hidden');
+}
+
+document.getElementById('close-article-btn')?.addEventListener('click', () => {
+  document.getElementById('article-modal')?.classList.add('hidden');
+});

--- a/Javascript/resources.js
+++ b/Javascript/resources.js
@@ -126,13 +126,20 @@ function renderSimulators() {
     <h3>Resource Simulators</h3>
     <p class="text-muted">Estimate production rates, trade values, and net efficiency.</p>
     <ul>
-      <li><a href="#">🔧 Production Efficiency Simulator</a></li>
-      <li><a href="#">📈 Market Value Calculator</a></li>
-      <li><a href="#">⚖️ Trade Ratio Evaluator</a></li>
+      <li><a href="#" class="sim-link">🔧 Production Efficiency Simulator</a></li>
+      <li><a href="#" class="sim-link">📈 Market Value Calculator</a></li>
+      <li><a href="#" class="sim-link">⚖️ Trade Ratio Evaluator</a></li>
     </ul>
   `;
 
   el.appendChild(panel);
+
+  panel.querySelectorAll('.sim-link').forEach(a =>
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      alert('🛠️ Simulator tools are coming soon.');
+    })
+  );
 }
 
 // ✅ Format resource keys to display-friendly names

--- a/account_settings.html
+++ b/account_settings.html
@@ -42,7 +42,7 @@ Developer: Deathsgift66
 <body data-theme="parchment">
   <!-- Navigation -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Header Banner -->
   <header class="kr-top-banner" aria-label="Page banner">

--- a/admin_alerts.html
+++ b/admin_alerts.html
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 <body data-theme="parchment">
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Admin Panel Header">

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -50,7 +50,7 @@ Developer: Deathsgift66
 <body data-theme="parchment">
   <!-- Navigation -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Admin Dashboard Banner">

--- a/alliance_changelog.html
+++ b/alliance_changelog.html
@@ -53,7 +53,7 @@ Developer: Deathsgift66
 <body class="alliance-bg">
   <!-- Navigation -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Alliance Changelog Header">

--- a/alliance_home.html
+++ b/alliance_home.html
@@ -53,7 +53,7 @@ Developer: Deathsgift66
 <body class="alliance-bg">
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Header -->
   <header class="kr-top-banner" aria-label="Alliance Homepage Banner">

--- a/alliance_members.html
+++ b/alliance_members.html
@@ -51,7 +51,7 @@ Developer: Deathsgift66
 <body class="alliance-bg">
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Alliance Members Banner">

--- a/alliance_projects.html
+++ b/alliance_projects.html
@@ -52,7 +52,7 @@ Developer: Deathsgift66
 <body class="alliance-bg">
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Alliance Projects Header">

--- a/alliance_quests.html
+++ b/alliance_quests.html
@@ -54,7 +54,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Header -->
   <header class="kr-top-banner" aria-label="Alliance Quests Banner">

--- a/alliance_treaties.html
+++ b/alliance_treaties.html
@@ -53,7 +53,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Alliance Treaties Page Header">

--- a/alliance_vault.html
+++ b/alliance_vault.html
@@ -50,7 +50,7 @@ Developer: Deathsgift66
 <body class="alliance-bg">
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Vault Management Page Header">

--- a/alliance_wars.html
+++ b/alliance_wars.html
@@ -53,7 +53,7 @@ Developer: Deathsgift66
 
   <!-- ✅ Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- ✅ Page Header -->
   <header class="kr-top-banner" aria-label="Alliance Wars Banner">

--- a/audit_log.html
+++ b/audit_log.html
@@ -48,7 +48,7 @@ Developer: Deathsgift66
 
   <!-- ✅ Navbar Inject -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- ✅ Page Banner -->
   <header class="kr-top-banner" aria-label="Audit Log Banner">

--- a/battle_live.html
+++ b/battle_live.html
@@ -47,7 +47,7 @@ Developer: Deathsgift66
 
   <!-- ✅ Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- ✅ Page Banner -->
   <header class="kr-top-banner" aria-label="Live Battle Banner">

--- a/battle_replay.html
+++ b/battle_replay.html
@@ -49,7 +49,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Battle Replay Banner">

--- a/battle_resolution.html
+++ b/battle_resolution.html
@@ -47,7 +47,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Battle Results Banner">

--- a/black_market.html
+++ b/black_market.html
@@ -47,7 +47,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Black Market Header">

--- a/buildings.html
+++ b/buildings.html
@@ -47,7 +47,7 @@ Developer: Deathsgift66
 
   <!-- Inject Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Buildings Page Banner">

--- a/changelog.html
+++ b/changelog.html
@@ -50,7 +50,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Changelog Banner">

--- a/compose.html
+++ b/compose.html
@@ -46,7 +46,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Banner -->
   <header class="kr-top-banner" aria-label="Compose Interface">

--- a/conflicts.html
+++ b/conflicts.html
@@ -46,7 +46,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Conflicts Page Banner">

--- a/diplomacy_center.html
+++ b/diplomacy_center.html
@@ -48,7 +48,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Diplomacy Banner">

--- a/donate_vip.html
+++ b/donate_vip.html
@@ -46,7 +46,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Donate & VIP Banner">

--- a/edit_kingdom.html
+++ b/edit_kingdom.html
@@ -46,7 +46,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Header -->
   <header class="kr-top-banner" aria-label="Edit Kingdom Banner">

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
 <!-- Hero Banner -->
 <section class="hero-section" aria-label="Hero Introduction">

--- a/kingdom_achievements.html
+++ b/kingdom_achievements.html
@@ -46,7 +46,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Kingdom Achievements Banner">

--- a/kingdom_history.html
+++ b/kingdom_history.html
@@ -47,7 +47,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
 <!-- Banner -->
 <header class="kr-top-banner" aria-label="Kingdom History Banner">

--- a/kingdom_military.html
+++ b/kingdom_military.html
@@ -49,7 +49,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Kingdom Military Banner">

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -47,7 +47,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Leaderboard Banner">

--- a/legal.html
+++ b/legal.html
@@ -45,7 +45,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="Legal Banner">

--- a/news.html
+++ b/news.html
@@ -47,7 +47,7 @@ Developer: Deathsgift66
 
 <!-- Navbar -->
 <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
 <!-- Page Banner -->
 <header class="kr-top-banner" aria-label="News Banner">
@@ -74,12 +74,22 @@ Developer: Deathsgift66
     <p id="no-results-message" class="hidden text-warning">No news found. Try another search term.</p>
 
     <!-- Articles Grid -->
-    <div id="articles" class="articles-grid">
+  <div id="articles" class="articles-grid">
       <!-- Populated dynamically by news.js -->
-    </div>
+  </div>
 
   </section>
 </main>
+
+<!-- Article Modal -->
+<div id="article-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="article-title">
+  <div class="modal-content">
+    <button id="close-article-btn" class="modal-close" aria-label="Close article">&times;</button>
+    <h3 id="article-title"></h3>
+    <p id="article-meta" class="news-meta"></p>
+    <div id="article-body" class="article-body"></div>
+  </div>
+</div>
 
 <!-- Footer -->
 <footer class="site-footer">

--- a/quests.html
+++ b/quests.html
@@ -47,7 +47,7 @@ Developer: Deathsgift66
 
   <!-- Navbar -->
   <div id="navbar-container"></div>
-<script type=\"module\" src=\"Javascript/navLoader.js\"></script>
+<script type="module" src="Javascript/navLoader.js"></script>
 
   <!-- Page Banner -->
   <header class="kr-top-banner" aria-label="Kingdom Quests Banner">


### PR DESCRIPTION
## Summary
- correct `navLoader.js` script tag escaping across pages
- add article modal and open logic in News page
- show placeholder alerts for resource simulators
- style modal for news

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684da0ce02e48330a6dba1ed0dfd5539