### PR TITLE
Fix router exports and kingdom overview

### DIFF
--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -2,7 +2,24 @@
 # File Name: __init__.py
 # Version 6.13.2025.19.49
 # Developer: Deathsgift66
-from . import village_master
+"""Router package with lazy module loading."""
 
-__all__ = ["village_master"]
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+__all__ = [
+    name
+    for _, name, _ in pkgutil.iter_modules(__path__)
+    if not name.startswith("_")
+]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        module = importlib.import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__} has no attribute {name}")
 


### PR DESCRIPTION
## Summary
- implement dynamic router package loader
- flesh out the `kingdom` overview endpoint
- remove unused start_project stub

## Testing
- `pytest -q` *(fails: Supabase client library missing)*
- `npm run lint` *(fails: eslint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684da4b4857c8330a202c94107886f0a