### PR TITLE
Fix placeholder URLs and add fallback logger

### DIFF
--- a/account_settings.html
+++ b/account_settings.html
@@ -65,7 +65,7 @@ Developer: Deathsgift66
             <legend>Profile</legend>
             <img id="avatar-preview" src="Assets/avatars/default_avatar_emperor.png" alt="Avatar Preview" width="80" height="80" />
             <label for="avatar_url">Avatar URL</label>
-            <input type="url" id="avatar_url" name="avatar_url" placeholder="https://..." />
+            <input type="url" id="avatar_url" name="avatar_url" placeholder="https://cdn.kingmakersrise.com/images/avatar.png" />
 
             <label for="display_name">Display Name</label>
             <input type="text" id="display_name" name="display_name" required />
@@ -91,7 +91,7 @@ Developer: Deathsgift66
           <fieldset>
             <legend>Appearance & Theme</legend>
             <label for="profile_banner">Profile Banner URL</label>
-            <input type="url" id="profile_banner" name="profile_banner" placeholder="https://..." />
+            <input type="url" id="profile_banner" name="profile_banner" placeholder="https://cdn.kingmakersrise.com/images/banner.png" />
 
             <label for="theme_preference">Theme</label>
             <select id="theme_preference" name="theme_preference">

--- a/edit_kingdom.html
+++ b/edit_kingdom.html
@@ -98,10 +98,10 @@ Developer: Deathsgift66
           <select id="region" name="region" aria-label="Select Kingdom Region"></select>
 
           <label for="banner_url">Banner Image URL</label>
-          <input type="url" id="banner_url" name="banner_url" placeholder="https://..." />
+          <input type="url" id="banner_url" name="banner_url" placeholder="https://cdn.kingmakersrise.com/images/banner.png" />
 
           <label for="emblem_url">Emblem Image URL</label>
-          <input type="url" id="emblem_url" name="emblem_url" placeholder="https://..." />
+          <input type="url" id="emblem_url" name="emblem_url" placeholder="https://cdn.kingmakersrise.com/images/emblem.png" />
 
           <img id="emblem-preview" src="Assets/icon-scroll.svg" alt="Emblem Preview" class="emblem-img" />
         </fieldset>

--- a/play.html
+++ b/play.html
@@ -87,7 +87,7 @@ Developer: Deathsgift66
           <!-- Custom Avatar Entry -->
           <div id="custom-avatar-container" class="hidden">
             <label for="custom-avatar-url">Custom Avatar URL</label>
-            <input type="url" id="custom-avatar-url" placeholder="https://example.com/avatar.png" />
+            <input type="url" id="custom-avatar-url" placeholder="https://cdn.kingmakersrise.com/avatars/custom.png" />
           </div>
 
           <!-- Preview -->

--- a/services/notification_service.py
+++ b/services/notification_service.py
@@ -18,8 +18,12 @@ except ImportError:  # pragma: no cover
 
 try:
     from backend.supabase_channels import broadcast_notification  # Optional live update support
-except ImportError:
-    def broadcast_notification(*args, **kwargs): pass  # fallback
+except ImportError:  # pragma: no cover - fallback when realtime is unavailable
+    def broadcast_notification(channel: str, target: str, message: str) -> None:
+        """Fallback notifier when Supabase channels are missing."""
+        logging.getLogger("KingmakersRise.NotificationFallback").info(
+            "[Fallback] %s -> %s: %s", channel, target, message
+        )
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- implement logging fallback for realtime notifications
- replace placeholder image URLs in account settings page
- replace placeholder image URLs in kingdom editor
- replace placeholder image URL for custom avatar

## Testing
- `python -m py_compile $(git ls-files "*.py")`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684da778fdf48330a2141d9ce9df51c5