### PR TITLE
Fix messages pagination

### DIFF
--- a/CSS/messages.css
+++ b/CSS/messages.css
@@ -147,3 +147,12 @@ body {
   vertical-align: middle;
 }
 
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 1rem;
+  gap: 0.5rem;
+  color: var(--parchment);
+}
+

--- a/messages.html
+++ b/messages.html
@@ -90,6 +90,11 @@ Developer: Deathsgift66
     <div id="message-list" class="messages-container" aria-live="polite">
       <!-- JS dynamically inserts messages here -->
     </div>
+    <div class="pagination">
+      <button id="prev-page" class="royal-button" aria-label="Previous page">Prev</button>
+      <span id="page-info"></span>
+      <button id="next-page" class="royal-button" aria-label="Next page">Next</button>
+    </div>
 
   </section>
 </main>


### PR DESCRIPTION
## Summary
- implement actual pagination for inbox messages
- expose previous/next page controls in messages UI
- adjust styles for pagination controls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_684da9c94d348330a21d6137c7de24a3