### PR TITLE
Fix router inclusion paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ from backend.routers import progression_router
 app = FastAPI(
     title="Kingmaker's Rise API",
     version="6.14.2025.20.12",
-    description="Backend services for Kingmaker's Rise — resource systems, announcements, region data, and progression."
+    description="Backend services for Kingmaker's Rise — resource systems, announcements, region data, and progression.",
 )
 
 # Configure CORS
@@ -46,12 +46,14 @@ app.add_middleware(
 )
 
 # Register all route modules
-app.include_router(resources.router, prefix="/api/resources", tags=["resources"])
-app.include_router(announcements.router, prefix="/api/announcements", tags=["announcements"])
-app.include_router(region.router, prefix="/api/regions", tags=["regions"])
-app.include_router(progression_router.router, prefix="/api/progression", tags=["progression"])
+# Each router already defines its API prefix and tags.
+app.include_router(resources.router)
+app.include_router(announcements.router)
+app.include_router(region.router)
+app.include_router(progression_router.router)
 
 # Manual launch for `python main.py` use
 if __name__ == "__main__":  # pragma: no cover
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- avoid duplicating route prefixes in main.py so dev mode mirrors prod configuration

## Testing
- `black main.py`
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684dac488ff483308ac7079749307cd0