### PR TITLE
Resolve placeholder in achievement test

### DIFF
--- a/tests/test_kingdom_achievement_service.py
+++ b/tests/test_kingdom_achievement_service.py
@@ -63,7 +63,7 @@ def test_list_achievements_filters_hidden():
     db = DummyDB()
     db.list_rows = [
         ("first_gold", "First Gold", "Earn 1000", "economic", {"gold": 100}, 5, False, None),
-        ("secret", "Secret", "???", "exploration", {}, 0, True, None),
+        ("secret", "Secret", "Hidden details", "exploration", {}, 0, True, None),
         ("battle", "Battle", "Win", "military", {}, 10, False, "2025-01-01"),
     ]
     results = list_achievements(db, 1)


### PR DESCRIPTION
## Summary
- remove placeholder text from test data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError because dependencies aren't installed)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dadc1f04c83308bd05d4e12699237