### PR TITLE
Improve frontend utilities and battle performance

### DIFF
--- a/Javascript/account_settings.js
+++ b/Javascript/account_settings.js
@@ -3,6 +3,14 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import {
+  showToast,
+  validateEmail,
+  escapeHTML,
+  setValue,
+  setSrc,
+  setText
+} from './utils.js';
 
 /**
  * Retrieve headers for authenticated Supabase API calls.
@@ -232,61 +240,5 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 });
 
+
 export { loadUserProfile, loadKingdomDetails, saveUserSettings, logoutSession, uploadAvatar, subscribeSessions };
-
-/**
- * Validates if an email address is in a correct format.
- */
-function validateEmail(email) {
-  const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return regex.test(email);
-}
-
-/**
- * Shows a temporary toast notification.
- */
-function showToast(msg) {
-  const toastEl = document.getElementById('toast');
-  toastEl.textContent = msg;
-  toastEl.classList.add('show');
-  setTimeout(() => {
-    toastEl.classList.remove('show');
-  }, 3000);
-}
-
-/**
- * Escapes special HTML characters in dynamic content to prevent XSS.
- */
-function escapeHTML(str) {
-  if (!str) return '';
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
-
-/**
- * Sets the value of a form input by ID.
- */
-function setValue(id, value) {
-  const el = document.getElementById(id);
-  if (el) el.value = value;
-}
-
-/**
- * Sets the src of an image element by ID.
- */
-function setSrc(id, value) {
-  const el = document.getElementById(id);
-  if (el) el.src = value;
-}
-
-/**
- * Sets the text content of an element by ID.
- */
-function setText(id, value) {
-  const el = document.getElementById(id);
-  if (el) el.textContent = value;
-}

--- a/Javascript/battle_live.js
+++ b/Javascript/battle_live.js
@@ -192,13 +192,15 @@ let mapWidth = 60;
 let mapHeight = 20;
 let currentMapColumns = 60;
 let scoreboardChannel = null;
+// Cache tile DOM nodes for efficient updates
+let tileElements = [];
 
 function renderBattleMap(tileMap) {
   const battleMap = document.getElementById('battle-map');
   battleMap.innerHTML = '';
-
   battleMap.style.gridTemplateColumns = `repeat(${mapWidth}, 1fr)`;
-
+  const frag = document.createDocumentFragment();
+  tileElements = [];
   for (let row = 0; row < mapHeight; row++) {
     for (let col = 0; col < mapWidth; col++) {
       const tile = document.createElement('div');
@@ -209,34 +211,32 @@ function renderBattleMap(tileMap) {
       else if (type === 'hill') tile.style.backgroundColor = '#8B4513';
       else tile.style.backgroundColor = 'var(--stone-panel)';
       tile.title = `${type.charAt(0).toUpperCase() + type.slice(1)}: ${TERRAIN_EFFECTS[type] || ''}`;
-      battleMap.appendChild(tile);
+      frag.appendChild(tile);
+      tileElements.push(tile);
     }
   }
+  battleMap.appendChild(frag);
 }
 
 function renderUnits(units) {
-  const battleMap = document.getElementById('battle-map');
-  const tiles = battleMap.children;
-
-  for (const tile of tiles) {
-    tile.innerHTML = '';
-  }
-
+  if (!tileElements.length) return;
+  tileElements.forEach(t => (t.innerHTML = ''));
   units.forEach(unit => {
     const index = unit.position_y * mapWidth + unit.position_x;
-    if (!tiles[index]) return;
+    const tile = tileElements[index];
+    if (!tile) return;
     const unitDiv = document.createElement('div');
     unitDiv.className = 'unit-icon';
     unitDiv.textContent = unit.unit_type.charAt(0).toUpperCase();
     const counter = UNIT_COUNTERS[unit.unit_type] || 'none';
     unitDiv.title = `HP: ${unit.hp ?? '?'}  Morale: ${unit.morale ?? '?'}%  Counters: ${counter}`;
     unitDiv.addEventListener('click', () => openOrderPanel(unit));
-    tiles[index].appendChild(unitDiv);
+    tile.appendChild(unitDiv);
     if (unit.morale !== undefined) {
       const morale = document.createElement('div');
       morale.className = 'morale-bar';
       morale.style.width = unit.morale + '%';
-      tiles[index].appendChild(morale);
+      tile.appendChild(morale);
     }
   });
 

--- a/Javascript/edit_kingdom.js
+++ b/Javascript/edit_kingdom.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { showToast, isValidURL, setValue, getValue } from './utils.js';
 
 let userId = null;
 let authToken = '';
@@ -155,39 +156,9 @@ function bindInputPreview() {
   }
 }
 
-// ------------------------------
-// Utility Functions
-// ------------------------------
-function setValue(id, val) {
-  const el = document.getElementById(id);
-  if (el) el.value = val || '';
-}
-
-function getValue(id, allowNull = false) {
-  const val = (document.getElementById(id)?.value || '').trim();
-  return allowNull && val === '' ? null : val;
-}
-
 function setImagePreview(id, url) {
   const img = document.getElementById(id);
   if (img && isValidURL(url)) img.src = url;
-}
-
-function isValidURL(str) {
-  try {
-    new URL(str);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function showToast(msg) {
-  const toast = document.getElementById('toast');
-  if (!toast) return;
-  toast.textContent = msg;
-  toast.classList.add('show');
-  setTimeout(() => toast.classList.remove('show'), 3000);
 }
 
 function redirectToLogin() {

--- a/Javascript/signup.js
+++ b/Javascript/signup.js
@@ -1,7 +1,8 @@
 // Project Name: Kingmakers Rise©
 // File Name: signup.js
-// Version 6.13.2025.19.49
+// Version 6.14.2025.20.12
 // Developer: Deathsgift66
+import { showToast, validateEmail } from './utils.js';
 document.addEventListener("DOMContentLoaded", () => {
   const form = document.getElementById('signup-form');
   const kingdomNameEl = document.getElementById('kingdomName');
@@ -71,30 +72,6 @@ async function handleSignup() {
     console.error("❌ Sign-Up error:", err);
     showToast("Sign-Up failed. Please try again.");
   }
-}
-
-// ✅ Email validation
-function validateEmail(email) {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-}
-
-// ✅ Password must have all character classes
-function validatePasswordComplexity(password) {
-  const sets = [
-    /[a-z]/,  // lowercase
-    /[A-Z]/,  // uppercase
-    /[0-9]/,  // digits
-    /[!@#$%^&*()_+\-=[\]{};':"\\|<>?,./`~]/  // special
-  ];
-  return sets.every(regex => regex.test(password));
-}
-
-// ✅ Visual toast alert
-function showToast(msg) {
-  const toast = document.getElementById('toast');
-  toast.textContent = msg;
-  toast.classList.add("show");
-  setTimeout(() => toast.classList.remove("show"), 3000);
 }
 
 // ✅ Debounce helper

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -1,0 +1,97 @@
+// Project Name: Kingmakers Rise©
+// File Name: utils.js
+// Version 6.14.2025.20.12
+// Developer: Codex
+// Shared frontend utilities for DOM helpers and validation.
+
+/**
+ * Escape HTML special characters to prevent injection.
+ * @param {string} str Potentially unsafe text
+ * @returns {string} Sanitized text
+ */
+export function escapeHTML(str = '') {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * Display a temporary toast notification.
+ * Requires an element with id="toast" in the DOM.
+ * @param {string} msg Message to display
+ */
+export function showToast(msg) {
+  const toast = document.getElementById('toast');
+  if (!toast) return;
+  toast.textContent = msg;
+  toast.classList.add('show');
+  setTimeout(() => toast.classList.remove('show'), 3000);
+}
+
+/**
+ * Simple email format validation.
+ * @param {string} email Email address
+ * @returns {boolean} True if valid
+ */
+export function validateEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+/**
+ * Determine if a string is a valid URL.
+ * @param {string} str Input string
+ * @returns {boolean} True if valid URL
+ */
+export function isValidURL(str) {
+  try {
+    new URL(str);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Set an element's value by id.
+ * @param {string} id Element id
+ * @param {string} value New value
+ */
+export function setValue(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.value = value;
+}
+
+/**
+ * Get a trimmed value from an input.
+ * @param {string} id Element id
+ * @param {boolean} allowNull Return null if empty when true
+ * @returns {string|null}
+ */
+export function getValue(id, allowNull = false) {
+  const val = (document.getElementById(id)?.value || '').trim();
+  return allowNull && val === '' ? null : val;
+}
+
+/**
+ * Update the src attribute of an image element.
+ * @param {string} id Element id
+ * @param {string} value Image URL
+ */
+export function setSrc(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.src = value;
+}
+
+/**
+ * Update the text content of an element.
+ * @param {string} id Element id
+ * @param {string} value Text to set
+ */
+export function setText(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = value;
+}
+


### PR DESCRIPTION
## Summary
- add shared `utils.js` with common helpers
- refactor account settings, signup and kingdom editing to use utilities
- optimize battle map rendering with cached tile elements

## Testing
- `pytest` *(fails: Supabase library missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684daed68d0483309baa852a2ae46dcd