### PR TITLE
Optimize frontend rendering utilities

### DIFF
--- a/CSS/black_market.css
+++ b/CSS/black_market.css
@@ -130,17 +130,3 @@ body {
   }
 }
 
-.btn {
-  background: var(--accent);
-  color: #fff;
-  border: 1px solid var(--gold);
-  border-radius: 6px;
-  padding: 0.5rem 1rem;
-  cursor: pointer;
-  font-family: 'Cinzel', serif;
-}
-
-.btn:hover {
-  background: var(--gold);
-  color: var(--ink);
-}

--- a/Javascript/alliance_home.js
+++ b/Javascript/alliance_home.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML, setText, formatDate, fragmentFrom } from './utils.js';
 
 let activityChannel = null;
 
@@ -70,23 +71,30 @@ function populateAlliance(data) {
 
 // === Render Functions ===
 
+/**
+ * Render active alliance projects with progress bars.
+ * @param {Array} projects Project list
+ */
 function renderProjects(projects = []) {
   const container = document.getElementById('project-progress-bars');
   if (!container) return;
-  container.innerHTML = '';
-  projects.forEach(p => {
+  const frag = fragmentFrom(projects, p => {
     const div = document.createElement('div');
     div.className = 'project-bar';
     div.innerHTML = `<label>${escapeHTML(p.name)}</label><progress value="${p.progress}" max="100"></progress> <span>${p.progress}%</span>`;
-    container.appendChild(div);
+    return div;
   });
+  container.replaceChildren(frag);
 }
 
+/**
+ * Render alliance member table.
+ * @param {Array} members Member list
+ */
 function renderMembers(members = []) {
   const body = document.getElementById('members-list');
   if (!body) return;
-  body.innerHTML = '';
-  members.forEach(m => {
+  const frag = fragmentFrom(members, m => {
     const row = document.createElement('tr');
     row.innerHTML = `
       <td><img src="../images/crests/${escapeHTML(m.crest || 'default.png')}" alt="Crest" class="crest"></td>
@@ -94,8 +102,9 @@ function renderMembers(members = []) {
       <td>${escapeHTML(m.rank)}</td>
       <td>${m.contribution ?? 0}</td>
       <td>${escapeHTML(m.status)}</td>`;
-    body.appendChild(row);
+    return row;
   });
+  body.replaceChildren(frag);
 }
 
 function renderTopContributors(members = []) {
@@ -157,16 +166,20 @@ function renderAchievements(achievements = []) {
   });
 }
 
+/**
+ * Render recent alliance activity feed.
+ * @param {Array} entries Activity log entries
+ */
 function renderActivity(entries = []) {
   const list = document.getElementById('activity-log');
   if (!list) return;
-  list.innerHTML = '';
-  entries.forEach(e => {
+  const frag = fragmentFrom(entries, e => {
     const li = document.createElement('li');
     li.className = 'activity-log-entry';
     li.textContent = `[${formatDate(e.created_at)}] ${e.username}: ${e.description}`;
-    list.appendChild(li);
+    return li;
   });
+  list.replaceChildren(frag);
 }
 
 function renderDiplomacy(treaties = []) {
@@ -211,28 +224,6 @@ function renderWarScore(wars = []) {
     div.textContent = `War ${w.alliance_war_id}: Attacker ${att} vs Defender ${def}`;
     container.appendChild(div);
   });
-}
-
-// === Utility Functions ===
-
-function setText(id, text) {
-  const el = document.getElementById(id);
-  if (el) el.textContent = text;
-}
-
-function formatDate(str) {
-  if (!str) return '';
-  return new Date(str).toLocaleString();
-}
-
-function escapeHTML(str) {
-  if (!str) return '';
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
 }
 
 // === Realtime Activity Logging ===

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -95,3 +95,29 @@ export function setText(id, value) {
   if (el) el.textContent = value;
 }
 
+/**
+ * Format a timestamp using the user's locale.
+ * @param {string|number|Date} ts Date or timestamp
+ * @returns {string} Locale formatted string
+ */
+export function formatDate(ts) {
+  const date = ts instanceof Date ? ts : new Date(ts);
+  return Number.isNaN(date.getTime()) ? '' : date.toLocaleString();
+}
+
+/**
+ * Build a DocumentFragment from an array of items.
+ * @template T
+ * @param {T[]} items Data items
+ * @param {(item:T)=>HTMLElement} builder Function to create an element
+ * @returns {DocumentFragment} Fragment with all built elements
+ */
+export function fragmentFrom(items, builder) {
+  const frag = document.createDocumentFragment();
+  for (const item of items) {
+    const el = builder(item);
+    if (el) frag.appendChild(el);
+  }
+  return frag;
+}
+


### PR DESCRIPTION
## Summary
- centralize date formatting and DOM helpers in `utils.js`
- refactor alliance home and messages scripts to use shared utilities
- improve rendering with document fragments and add inline docs
- remove duplicate button styles from black market CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684db04c4fd08330bd5114df1495092c