### PR TITLE
Improve messaging utilities

### DIFF
--- a/Javascript/fetchJson.js
+++ b/Javascript/fetchJson.js
@@ -1,7 +1,17 @@
 // Project Name: Kingmakers Rise©
 // File Name: fetchJson.js
-// Version 6.13.2025.19.49
-// Developer: Deathsgift66
+// Version 6.15.2025.20.12
+// Developer: Codex
+
+/**
+ * Perform a fetch request expecting a JSON response.
+ * The request is automatically aborted after `timeoutMs` milliseconds.
+ *
+ * @param {string} url            Target URL
+ * @param {RequestInit} options   Fetch options
+ * @param {number} timeoutMs      Timeout before aborting the request
+ * @returns {Promise<any>}        Parsed JSON data
+ */
 export async function fetchJson(url, options = {}, timeoutMs = 8000) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -30,4 +40,25 @@ export async function fetchJson(url, options = {}, timeoutMs = 8000) {
   } finally {
     clearTimeout(timeout);
   }
+}
+
+/**
+ * Convenience wrapper for authenticated API requests.
+ * Adds Authorization and X-User-ID headers using the provided session.
+ *
+ * @param {string} url            API endpoint
+ * @param {object} session        Supabase session with `access_token` and `user.id`
+ * @param {RequestInit} [options] Additional fetch options
+ * @param {number} [timeoutMs]    Optional timeout override
+ * @returns {Promise<any>}        Parsed JSON data
+ */
+export async function authFetchJson(url, session, options = {}, timeoutMs = 8000) {
+  const headers = {
+    ...(options.headers || {}),
+    'Authorization': `Bearer ${session.access_token}`,
+    'X-User-ID': session.user.id,
+    'Content-Type': 'application/json'
+  };
+
+  return fetchJson(url, { ...options, headers }, timeoutMs);
 }

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -121,3 +121,17 @@ export function fragmentFrom(items, builder) {
   return frag;
 }
 
+/**
+ * Remove dangerous elements from an HTML string.
+ * This is a lightweight sanitizer for user-generated content.
+ *
+ * @param {string} html Raw HTML
+ * @returns {string} Clean HTML safe for insertion into the DOM
+ */
+export function sanitizeHTML(html = '') {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  template.content.querySelectorAll('script, iframe').forEach(el => el.remove());
+  return template.innerHTML;
+}
+


### PR DESCRIPTION
## Summary
- add authFetchJson helper and usage across messaging page
- sanitize rendered HTML in message view
- expose sanitizeHTML utility for lightweight filtering

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684db3528b508330bd2a5647bf64b2b7