### PR TITLE
Optimize and modularize frontend styles

### DIFF
--- a/CSS/donate_vip.css
+++ b/CSS/donate_vip.css
@@ -25,37 +25,6 @@ body {
 }
 
 /* Customization Section */
-.alliance-customization-area {
-  background: rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(5px);
-  border-radius: 12px;
-  border: 1px solid var(--gold);
-  box-shadow: 0 4px 12px var(--shadow);
-  padding: 2rem;
-  width: 100%;
-  margin-bottom: 2rem;
-  text-align: center;
-}
-
-.alliance-customization-area h2 {
-  font-family: "Cinzel", serif;
-  color: var(--gold);
-  text-shadow: 1px 1px 3px black;
-  margin-bottom: 1rem;
-}
-
-#custom-image-slot img {
-  max-width: 100%;
-  height: auto;
-  border-radius: 8px;
-  margin-bottom: 1rem;
-}
-
-#custom-text-slot {
-  font-size: 1.1rem;
-  color: var(--parchment);
-  padding: 1rem;
-}
 
 /* Core Panel */
 .alliance-members-container {

--- a/CSS/player_management.css
+++ b/CSS/player_management.css
@@ -14,38 +14,6 @@ body {
 }
 
 
-/* Customization Section */
-.alliance-customization-area {
-  background: rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(5px);
-  border-radius: 12px;
-  border: 1px solid var(--gold);
-  box-shadow: 0 4px 12px var(--shadow);
-  padding: 2rem;
-  width: 100%;
-  margin-bottom: 2rem;
-  text-align: center;
-}
-
-.alliance-customization-area h2 {
-  font-family: 'Cinzel', serif;
-  color: var(--gold);
-  text-shadow: 1px 1px 3px black;
-  margin-bottom: 1rem;
-}
-
-#custom-image-slot img {
-  max-width: 100%;
-  height: auto;
-  border-radius: 8px;
-  margin-bottom: 1rem;
-}
-
-#custom-text-slot {
-  font-size: 1.1rem;
-  color: var(--parchment);
-  padding: 1rem;
-}
 
 /* Core Panel */
 .alliance-members-container {

--- a/CSS/root_theme.css
+++ b/CSS/root_theme.css
@@ -435,3 +435,38 @@ body[data-theme="parchment"] {
 .toast-notification.show {
   opacity: 1;
 }
+
+/* -----------------------------------------------
+   Custom Board Shared Styles
+------------------------------------------------ */
+#custom-image-slot img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+#custom-text-slot {
+  font-size: 1.1rem;
+  color: var(--parchment);
+  padding: 1rem;
+}
+
+.alliance-customization-area {
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(5px);
+  border-radius: 12px;
+  border: 1px solid var(--gold);
+  box-shadow: 0 4px 12px var(--shadow);
+  padding: 2rem;
+  width: 100%;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.alliance-customization-area h2 {
+  font-family: var(--font-header);
+  color: var(--gold);
+  text-shadow: 1px 1px 3px black;
+  margin-bottom: 1rem;
+}

--- a/CSS/tutorial.css
+++ b/CSS/tutorial.css
@@ -14,38 +14,6 @@ body {
 }
 
 
-/* Customization Section */
-.alliance-customization-area {
-  background: rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(5px);
-  border-radius: 12px;
-  border: 1px solid var(--gold);
-  box-shadow: 0 4px 12px var(--shadow);
-  padding: 2rem;
-  width: 100%;
-  margin-bottom: 2rem;
-  text-align: center;
-}
-
-.alliance-customization-area h2 {
-  font-family: 'Cinzel', serif;
-  color: var(--gold);
-  text-shadow: 1px 1px 3px black;
-  margin-bottom: 1rem;
-}
-
-#custom-image-slot img {
-  max-width: 100%;
-  height: auto;
-  border-radius: 8px;
-  margin-bottom: 1rem;
-}
-
-#custom-text-slot {
-  font-size: 1.1rem;
-  color: var(--parchment);
-  padding: 1rem;
-}
 
 /* Core Panel */
 .alliance-members-container {

--- a/Javascript/alliance_vault.js
+++ b/Javascript/alliance_vault.js
@@ -4,6 +4,8 @@
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
 import { RESOURCE_TYPES } from './resourceTypes.js';
+import { loadCustomBoard } from './customBoard.js';
+import { escapeHTML } from './utils.js';
 
 let currentUser = null;
 
@@ -46,7 +48,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   initTabs();
   await Promise.all([
     loadVaultSummary(),
-    loadCustomBoard(),
+    loadCustomBoard({ fetchFn: authFetch }),
     loadDepositForm(),
     loadWithdrawForm(),
     loadVaultHistory()
@@ -118,29 +120,6 @@ async function loadVaultSummary() {
   }
 }
 
-// ✅ Load image & text board
-async function loadCustomBoard() {
-  try {
-    const res = await authFetch("/api/alliance-vault/custom-board");
-    const data = await res.json();
-
-    const imgSlot = document.getElementById("custom-image-slot");
-    const textSlot = document.getElementById("custom-text-slot");
-
-    imgSlot.innerHTML = data.image_url
-      ? `<img src="${escapeHTML(data.image_url)}" alt="Vault Banner" class="vault-banner-image">`
-      : "<p>No custom image set.</p>";
-
-    textSlot.innerHTML = data.custom_text
-      ? `<p>${escapeHTML(data.custom_text)}</p>`
-      : "<p>No custom text set.</p>";
-
-  } catch (err) {
-    console.error("❌ Custom Board:", err);
-    document.getElementById("custom-image-slot").innerHTML = "<p>Error loading image.</p>";
-    document.getElementById("custom-text-slot").innerHTML = "<p>Error loading text.</p>";
-  }
-}
 
 // ✅ Deposit interface
 async function loadDepositForm() {
@@ -254,12 +233,3 @@ async function loadVaultHistory() {
   }
 }
 
-// ✅ HTML Escape Utility
-function escapeHTML(str) {
-  return String(str || '')
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/Javascript/alliance_wars.js
+++ b/Javascript/alliance_wars.js
@@ -3,6 +3,8 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { loadCustomBoard } from './customBoard.js';
+import { escapeHTML } from './utils.js';
 
 let currentWarId = null;
 let combatInterval = null;
@@ -16,30 +18,13 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ✅ Init
   initTabs();
-  await loadCustomBoard();
+  await loadCustomBoard({ altText: 'Alliance War Banner' });
   await loadAllianceWars();
   await loadPendingWars();
 
   document.getElementById('declare-alliance-war-btn')?.addEventListener('click', submitDeclareWar);
 });
 
-// ✅ Load Alliance War Banner and Lore
-async function loadCustomBoard() {
-  try {
-    const res = await fetch("/api/alliance-vault/custom-board");
-    const data = await res.json();
-
-    document.getElementById("custom-image-slot").innerHTML = data.image_url
-      ? `<img src="${escapeHTML(data.image_url)}" alt="Alliance War Banner" class="war-board-image">`
-      : "<p>No custom image set.</p>";
-
-    document.getElementById("custom-text-slot").innerHTML = data.custom_text
-      ? `<p>${escapeHTML(data.custom_text)}</p>`
-      : "<p>No custom text set.</p>";
-  } catch (err) {
-    console.error("❌ Error loading custom board:", err);
-  }
-}
 
 // ✅ Load All Active and Completed Wars
 async function loadAllianceWars() {
@@ -293,11 +278,3 @@ async function surrenderWar() {
 }
 
 // ✅ Escape
-function escapeHTML(str) {
-  return String(str || '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/Javascript/customBoard.js
+++ b/Javascript/customBoard.js
@@ -1,0 +1,40 @@
+import { escapeHTML } from './utils.js';
+
+/**
+ * Fetch and display the alliance custom board image and text.
+ *
+ * @param {object} options
+ * @param {string} [options.endpoint] API endpoint returning image_url and custom_text
+ * @param {string} [options.imageSelector] CSS selector for the image container
+ * @param {string} [options.textSelector] CSS selector for the text container
+ * @param {string} [options.altText] Alt text for the inserted image
+ * @param {function} [options.fetchFn] Custom fetch function for authenticated requests
+ */
+export async function loadCustomBoard({
+  endpoint = '/api/alliance-vault/custom-board',
+  imageSelector = '#custom-image-slot',
+  textSelector = '#custom-text-slot',
+  altText = 'Custom Banner',
+  fetchFn = fetch
+} = {}) {
+  const imgSlot = document.querySelector(imageSelector);
+  const textSlot = document.querySelector(textSelector);
+  if (!imgSlot || !textSlot) return;
+
+  try {
+    const res = await fetchFn(endpoint);
+    const data = await res.json();
+
+    imgSlot.innerHTML = data.image_url
+      ? `<img src="${escapeHTML(data.image_url)}" alt="${escapeHTML(altText)}">`
+      : '<p>No custom image set.</p>';
+
+    textSlot.innerHTML = data.custom_text
+      ? `<p>${escapeHTML(data.custom_text)}</p>`
+      : '<p>No custom text set.</p>';
+  } catch (err) {
+    console.error('❌ Error loading custom board:', err);
+    imgSlot.innerHTML = '<p>Error loading image.</p>';
+    textSlot.innerHTML = '<p>Error loading text.</p>';
+  }
+}


### PR DESCRIPTION
## Summary
- share custom board CSS rules in `root_theme.css`
- create reusable `customBoard.js` helper
- refactor alliance pages to use new helper and shared utils
- expose `init_engine()` for database initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run lint` *(fails: Invalid option '--ignore-path' and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684dc275c028833081e61b695e029197