### PR TITLE
Refactor utilities and improve service state management

### DIFF
--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML, showToast, fragmentFrom } from './utils.js';
 
 let currentUser = null;
 let authToken = '';
@@ -125,27 +126,6 @@ function validateInputs(name, village, region) {
   return true;
 }
 
-function showToast(message) {
-  let el = document.getElementById('toast');
-  if (!el) {
-    el = document.createElement('div');
-    el.id = 'toast';
-    el.className = 'toast-notification';
-    document.body.appendChild(el);
-  }
-  el.textContent = message;
-  el.classList.add('show');
-  setTimeout(() => el.classList.remove('show'), 3000);
-}
-
-function escapeHTML(str) {
-  return str?.toString()
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
 
 async function postJSON(url, body) {
   const res = await fetch(url, {
@@ -239,7 +219,7 @@ function renderAvatarOptions() {
   if (!container || !preview) return;
 
   container.innerHTML = '';
-  avatarList.forEach(src => {
+  const frag = fragmentFrom(avatarList, src => {
     const img = document.createElement('img');
     img.src = src;
     img.alt = 'Avatar Option';
@@ -250,8 +230,9 @@ function renderAvatarOptions() {
       img.classList.add('selected');
       preview.src = src;
     });
-    container.appendChild(img);
+    return img;
   });
+  container.appendChild(frag);
 
   preview.src = selectedAvatar;
   container.querySelector('.avatar-option')?.classList.add('selected');

--- a/Javascript/villages.js
+++ b/Javascript/villages.js
@@ -5,6 +5,7 @@
 // Village Management with Server-Sent Events & Real-Time Updates
 
 import { supabase } from './supabaseClient.js';
+import { escapeHTML, showToast, fragmentFrom } from './utils.js';
 
 let eventSource;
 
@@ -47,7 +48,8 @@ function renderVillages(villages) {
     listEl.innerHTML = '<li>No villages found.</li>';
     return;
   }
-  villages.forEach(v => {
+
+  const frag = fragmentFrom(villages, v => {
     const li = document.createElement('li');
     li.className = 'village-item';
     li.innerHTML = `
@@ -56,8 +58,10 @@ function renderVillages(villages) {
       <span class="village-population">${v.population.toLocaleString()} peasants</span>
       <span class="village-buildings">Buildings: ${v.building_count.toLocaleString()}</span>
     `;
-    listEl.appendChild(li);
+    return li;
   });
+
+  listEl.appendChild(frag);
 }
 
 // Setup Server-Sent Events connection for real-time updates
@@ -115,28 +119,3 @@ async function createVillage() {
   }
 }
 
-// Escape HTML entities for safety
-function escapeHTML(str) {
-  return str?.toString()
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
-
-// Toast notification helper
-function showToast(msg) {
-  let toastEl = document.getElementById('toast');
-  if (!toastEl) {
-    toastEl = document.createElement("div");
-    toastEl.id = "toast";
-    toastEl.className = "toast-notification";
-    document.body.appendChild(toastEl);
-  }
-  toastEl.textContent = msg;
-  toastEl.classList.add("show");
-  setTimeout(() => {
-    toastEl.classList.remove("show");
-  }, 3000);
-}

--- a/backend/progression_service.py
+++ b/backend/progression_service.py
@@ -1,6 +1,6 @@
 # Project Name: Kingmakers Rise©
 # File Name: progression_service.py
-# Version: 6.13.2025.19.49
+# Version: 6.14.2025.20.30
 # Developer: Deathsgift66
 
 """In-memory progression logic used primarily for tests.
@@ -115,3 +115,23 @@ def promote_knight(knight_id: str) -> int:
         new_rank = knights[knight_id]["rank"]
         logger.info("⬆️ Knight '%s' promoted to rank %s.", knight_id, new_rank)
         return new_rank
+
+# ---------------------------
+# 🔄 State Utilities
+# ---------------------------
+def get_state() -> Dict[str, object]:
+    """Return a snapshot of the current progression state."""
+    with _state_lock:
+        return {
+            "castle": castle_state.copy(),
+            "nobles": set(nobles),
+            "knights": {k: v.copy() for k, v in knights.items()},
+        }
+
+
+def reset_state() -> None:
+    """Reset all progression data. Useful for tests."""
+    with _state_lock:
+        castle_state.update({"level": 1, "xp": 0})
+        nobles.clear()
+        knights.clear()


### PR DESCRIPTION
## Summary
- centralize toast and HTML escaping utilities
- optimize avatar and village rendering with fragments
- expose state helpers for the progression service

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dca0bc0c48330b23270b9034d0556