### PR TITLE
Refactor JS escape HTML handling

### DIFF
--- a/Javascript/admin_dashboard.js
+++ b/Javascript/admin_dashboard.js
@@ -3,16 +3,10 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 const REFRESH_MS = 30000;
 
-// 🔐 Prevent XSS via innerHTML
-function escapeHTML(str) {
-  return String(str ?? '')
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;').replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
 
 // 📊 Dashboard Stats
 async function loadDashboardStats() {

--- a/Javascript/alliance_changelog.js
+++ b/Javascript/alliance_changelog.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let changelogData = [];
 let latestTimestamp = null;
@@ -108,15 +109,6 @@ function renderChangelog(list) {
 }
 
 // Basic HTML escaping to prevent XSS injection
-function escapeHTML(str) {
-  if (!str) return '';
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
 
 // ✅ Initialize changelog on DOM load
 document.addEventListener('DOMContentLoaded', () => {

--- a/Javascript/alliance_members.js
+++ b/Javascript/alliance_members.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 const RANK_TOOLTIPS = {
   Leader: 'Alliance leader with full authority',
@@ -228,12 +229,3 @@ function setupLogout() {
 }
 
 // 🛡 Escape user-generated content
-function escapeHTML(str) {
-  if (!str) return '';
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/Javascript/alliance_projects.js
+++ b/Javascript/alliance_projects.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 const RESOURCE_KEYS = [
   'wood', 'stone', 'iron_ore', 'gold', 'gems', 'food', 'coal', 'livestock',
@@ -246,12 +247,3 @@ function formatCostFromColumns(obj) {
     .join(', ') || 'N/A';
 }
 
-function escapeHTML(str) {
-  if (!str) return '';
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/Javascript/alliance_quests.js
+++ b/Javascript/alliance_quests.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let currentFilter = 'active';
 let questChannel = null;
@@ -232,9 +233,3 @@ function openQuestModal(q) {
 }
 
 // ✅ Safe string escape
-function escapeHTML(str) {
-  return String(str || '')
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;').replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/Javascript/alliance_treaties.js
+++ b/Javascript/alliance_treaties.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 const TREATY_INFO = {
   'NAP': 'Non-Aggression Pact',
@@ -176,11 +177,3 @@ async function respondToTreaty(treatyId, action) {
 }
 
 // ✅ Safe text rendering
-function escapeHTML(str) {
-  return String(str || '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/Javascript/audit_log.js
+++ b/Javascript/audit_log.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 // Hardened Admin Audit Log Page — with Supabase auth, loading, error handling, and formatting
+import { escapeHTML } from './utils.js';
 
 import { supabase } from './supabaseClient.js';
 let eventSource;
@@ -131,12 +132,3 @@ function formatTimestamp(timestamp) {
 }
 
 // ✅ Basic HTML escape (to prevent injection)
-function escapeHTML(str) {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/Javascript/buildings.js
+++ b/Javascript/buildings.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 // Keys to check for cost display
 const RESOURCE_KEYS = [
@@ -230,12 +231,6 @@ async function showBuildingInfo(buildingId) {
 }
 
 // ========== Helpers ==========
-function escapeHTML(str) {
-  return str ? String(str)
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;').replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;') : '';
-}
 
 function formatCostFromColumns(obj) {
   return RESOURCE_KEYS

--- a/Javascript/changelog.js
+++ b/Javascript/changelog.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let realtimeSub;
 
@@ -118,13 +119,3 @@ function formatDate(dateStr) {
 }
 
 // ✅ HTML sanitization
-function escapeHTML(str) {
-  return str
-    ? String(str)
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;")
-    : "";
-}

--- a/Javascript/conflicts.js
+++ b/Javascript/conflicts.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let accessToken = null;
 let userId = null;
@@ -154,12 +155,3 @@ function renderRows(rows) {
 }
 
 // ✅ Safe HTML Escape
-function escapeHTML(str) {
-  if (!str) return '';
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/Javascript/diplomacy_center.js
+++ b/Javascript/diplomacy_center.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let treatyChannel = null;
 let userId = null;
@@ -176,14 +177,6 @@ async function respondTreaty(treatyId, action) {
 }
 
 // ✅ Helpers
-function escapeHTML(str) {
-  return String(str || '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
 
 function formatDate(val) {
   return val ? new Date(val).toLocaleDateString() : '';

--- a/Javascript/donate_vip.js
+++ b/Javascript/donate_vip.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from "./supabaseClient.js";
+import { escapeHTML } from './utils.js';
 
 let currentSession = null;
 let vipTiers = [];
@@ -234,9 +235,3 @@ function authHeaders() {
   };
 }
 
-function escapeHTML(str) {
-  return String(str || "")
-    .replace(/&/g, "&amp;").replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;").replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/Javascript/index.js
+++ b/Javascript/index.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 document.addEventListener("DOMContentLoaded", async () => {
   enableSmoothScroll();        // ✅ Smooth scrolling behavior
@@ -137,12 +138,3 @@ function formatDate(dateStr) {
 // =============================
 // 🛡️ Basic HTML Escaping
 // =============================
-function escapeHTML(str) {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/Javascript/kingdom_achievements.js
+++ b/Javascript/kingdom_achievements.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let allAchievements = [];
 let filteredAchievements = [];
@@ -232,10 +233,3 @@ function subscribeToUpdates(kingdomId) {
 }
 
 // ✅ Safe text
-function escapeHTML(str) {
-  if (!str) return '';
-  return String(str)
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;').replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/Javascript/kingdom_history.js
+++ b/Javascript/kingdom_history.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let kingdomId = null;
 let userId = null;
@@ -138,12 +139,3 @@ function formatDate(dateStr) {
   return new Date(dateStr).toLocaleDateString();
 }
 
-function escapeHTML(str) {
-  if (!str) return '';
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/Javascript/kingdom_military.js
+++ b/Javascript/kingdom_military.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let currentUserId = null;
 let realtimeChannel = null;
@@ -186,15 +187,6 @@ function formatCost(costObj) {
 }
 
 // 🧼 Sanitize display text
-function escapeHTML(str) {
-  if (!str) return "";
-  return String(str)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}
 
 // ⏱ Format timestamps to readable string
 function formatTimestamp(ts) {

--- a/Javascript/leaderboard.js
+++ b/Javascript/leaderboard.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let currentTab = "kingdoms";
 
@@ -186,12 +187,3 @@ function openApplyModal(allianceId, allianceName) {
 }
 
 // 🧼 Basic HTML escape
-function escapeHTML(str) {
-  if (!str) return "";
-  return String(str)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/Javascript/legal.js
+++ b/Javascript/legal.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let docs = [];
 let realtimeSub = null;
@@ -79,12 +80,3 @@ function renderDocuments(list) {
 }
 
 // 🧼 Escape HTML output to prevent XSS
-function escapeHTML(str) {
-  if (!str) return '';
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/Javascript/market.js
+++ b/Javascript/market.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let currentUserId = null;
 let isAdmin = false;
@@ -238,9 +239,6 @@ function formatTimestamp(ts) {
   return d.toLocaleString();
 }
 
-function escapeHTML(str) {
-  return str ? String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\"/g, "&quot;").replace(/'/g, "&#039;") : "";
-}
 
 function startAutoRefresh() {
   setInterval(() => loadMarketListings(), 30000);

--- a/Javascript/news.js
+++ b/Javascript/news.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let currentUser = null;
 let newsChannel = null;
@@ -131,15 +132,6 @@ function formatDate(ts) {
 }
 
 // ✅ Basic HTML Escape
-function escapeHTML(str) {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}
 
 // ✅ Modal viewer for full article
 function openArticleModal(article) {

--- a/Javascript/notificationBell.js
+++ b/Javascript/notificationBell.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const bell = document.getElementById('nav-bell-icon');
@@ -88,12 +89,3 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 
 // Escape HTML utility
-function escapeHTML(str) {
-  if (!str) return '';
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/Javascript/notifications.js
+++ b/Javascript/notifications.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let currentSession;
 let notificationChannel;
@@ -217,12 +218,3 @@ function formatDate(ts) {
 }
 
 // ✅ Escape dangerous input
-function escapeHTML(str) {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/Javascript/overview.js
+++ b/Javascript/overview.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 // Kingdom Overview — Summary + Resources + Military + Quests + Modifiers
+import { escapeHTML } from './utils.js';
 
 import { supabase } from './supabaseClient.js';
 import { loadPlayerProgressionFromStorage, fetchAndStorePlayerProgression } from './progressionGlobal.js';
@@ -152,13 +153,6 @@ async function loadOverview() {
 }
 
 // Escape dangerous HTML
-function escapeHTML(str) {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;").replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;").replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}
 
 // Live update for kingdom resources
 function subscribeToResourceUpdates() {

--- a/Javascript/player_management.js
+++ b/Javascript/player_management.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let playerChannel;
 
@@ -157,13 +158,6 @@ async function showModalConfirm(title, userId, action) {
 }
 
 // ✅ Escape HTML
-function escapeHTML(str) {
-  return str?.replace(/&/g, "&amp;")
-             .replace(/</g, "&lt;")
-             .replace(/>/g, "&gt;")
-             .replace(/"/g, "&quot;")
-             .replace(/'/g, "&#039;");
-}
 
 function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);

--- a/Javascript/policies_laws.js
+++ b/Javascript/policies_laws.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadPoliciesAndLaws();
@@ -174,10 +175,3 @@ function updateSummary(activePolicyId, activeLawsIds, policies, laws) {
 }
 
 // ✅ HTML Escape
-function escapeHTML(str) {
-  return str?.replace(/&/g, "&amp;")
-             .replace(/</g, "&lt;")
-             .replace(/>/g, "&gt;")
-             .replace(/"/g, "&quot;")
-             .replace(/'/g, "&#039;");
-}

--- a/Javascript/profile.js
+++ b/Javascript/profile.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 document.addEventListener("DOMContentLoaded", async () => {
   await loadPlayerProfile();
@@ -185,13 +186,3 @@ function formatTimestamp(timestamp) {
   });
 }
 
-// ✅ HTML Escape Utility
-function escapeHTML(str) {
-  if (!str) return '';
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/Javascript/projects_kingdom.js
+++ b/Javascript/projects_kingdom.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 const RESOURCE_KEYS = [
   'wood',
@@ -281,12 +282,3 @@ function formatTime(seconds) {
 }
 
 // ✅ Basic HTML escape
-function escapeHTML(str) {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/Javascript/quests.js
+++ b/Javascript/quests.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let questChannel = null;
 
@@ -209,13 +210,6 @@ function showToast(msg) {
   }, 100);
 }
 
-function escapeHTML(str) {
-  return str?.replace(/&/g, "&amp;")
-             .replace(/</g, "&lt;")
-             .replace(/>/g, "&gt;")
-             .replace(/"/g, "&quot;")
-             .replace(/'/g, "&#039;") || "";
-}
 
 function formatJsonList(json) {
   try {

--- a/Javascript/research.js
+++ b/Javascript/research.js
@@ -3,17 +3,12 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let currentSession = null;
 let researchChannel = null;
 
 // Utility to escape HTML from strings to prevent XSS
-function escapeHTML(str) {
-  return str ? String(str)
-    .replace(/&/g, "&amp;").replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;").replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;") : '';
-}
 
 // Format seconds into human-readable string
 function formatTime(seconds) {

--- a/Javascript/seasonal_effects.js
+++ b/Javascript/seasonal_effects.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 document.addEventListener("DOMContentLoaded", async () => {
   const { data: { session } } = await supabase.auth.getSession();
@@ -192,12 +193,3 @@ function showToast(msg) {
 }
 
 // ✅ Escape HTML to prevent injection
-function escapeHTML(str) {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/Javascript/temples.js
+++ b/Javascript/temples.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let currentSession = null;
 let currentKingdomId = null;
@@ -213,12 +214,3 @@ function showToast(msg) {
 }
 
 // ✅ HTML Escaper
-function escapeHTML(str) {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/Javascript/town_criers.js
+++ b/Javascript/town_criers.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let scrollChannel = null;
 
@@ -174,12 +175,3 @@ function showToast(message) {
 }
 
 // ✅ Escape HTML
-function escapeHTML(str) {
-  return str
-    ? str.replace(/&/g, "&amp;")
-         .replace(/</g, "&lt;")
-         .replace(/>/g, "&gt;")
-         .replace(/"/g, "&quot;")
-         .replace(/'/g, "&#039;")
-    : "";
-}

--- a/Javascript/trade_logs.js
+++ b/Javascript/trade_logs.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 import { RESOURCE_TYPES } from './resourceTypes.js';
 
 let realtimeChannel = null;
@@ -189,13 +190,6 @@ function showToast(msg) {
 }
 
 // ✅ Escape input to prevent XSS
-function escapeHTML(str) {
-  return str ? str.replace(/&/g, "&amp;")
-              .replace(/</g, "&lt;")
-              .replace(/>/g, "&gt;")
-              .replace(/"/g, "&quot;")
-              .replace(/'/g, "&#039;") : "";
-}
 
 // ✅ Auto Refresh every 30s
 function startAutoRefresh() {

--- a/Javascript/tutorial.js
+++ b/Javascript/tutorial.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
+import { escapeHTML } from './utils.js';
 
 let currentUser = null;
 let tutorialChannel;
@@ -102,12 +103,3 @@ function setupProgressBar() {
 }
 
 // ✅ Safe HTML escape
-function escapeHTML(str) {
-  if (!str) return '';
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}

--- a/Javascript/wars.js
+++ b/Javascript/wars.js
@@ -3,6 +3,7 @@
 // Version 6.13.2025.19.49
 // Developer: Deathsgift66
 // Unified War Command Center — Page Controller
+import { escapeHTML } from './utils.js';
 
 import { supabase } from './supabaseClient.js';
 
@@ -234,12 +235,3 @@ function showToast(msg) {
 }
 
 // ✅ Basic HTML Escape
-function escapeHTML(str) {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}


### PR DESCRIPTION
## Summary
- deduplicate escapeHTML implementations across the JS files
- import shared escapeHTML helper from `utils.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dcd14ffe88330b29f451ba30148ff