### PR TITLE
Improve tab components and CSS utilities

### DIFF
--- a/CSS/alliance_vault.css
+++ b/CSS/alliance_vault.css
@@ -152,8 +152,6 @@ body {
   text-align: center;
 }
 
-.tab-section { display: none; }
-.tab-section.active { display: block; }
 
 @media (max-width: 600px) {
   .tab-control-bar {

--- a/CSS/alliance_wars.css
+++ b/CSS/alliance_wars.css
@@ -164,14 +164,6 @@ body {
   color: #1a1a1a;
 }
 
-.tab-section {
-  display: none;
-  margin-top: 1rem;
-}
-
-.tab-section.active {
-  display: block;
-}
 
 /* Battle Map */
 .battle-container {

--- a/CSS/root_theme.css
+++ b/CSS/root_theme.css
@@ -290,6 +290,10 @@ a:focus {
 .flex { display: flex; }
 .grid { display: grid; }
 
+/* Generic tabbed section helper */
+.tab-section { display: none; margin-top: 1rem; }
+.tab-section.active { display: block; }
+
 /* Banner */
 header.kr-top-banner {
   text-align: center;

--- a/CSS/town_criers.css
+++ b/CSS/town_criers.css
@@ -84,13 +84,6 @@ body {
   color: #1a1a1a;
 }
 
-.tab-section {
-  display: none;
-}
-
-.tab-section.active {
-  display: block;
-}
 
 .scroll-list {
   background: rgba(251, 240, 217, 0.95);

--- a/Javascript/alliance_vault.js
+++ b/Javascript/alliance_vault.js
@@ -6,6 +6,7 @@ import { supabase } from './supabaseClient.js';
 import { RESOURCE_TYPES } from './resourceTypes.js';
 import { loadCustomBoard } from './customBoard.js';
 import { escapeHTML } from './utils.js';
+import { setupTabs } from './components/tabControl.js';
 
 let currentUser = null;
 
@@ -45,7 +46,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     window.location.href = "index.html";
   });
 
-  initTabs();
+  setupTabs({ onShow: id => id === 'tab-transactions' && loadVaultHistory() });
   await Promise.all([
     loadVaultSummary(),
     loadCustomBoard({ fetchFn: authFetch }),
@@ -68,23 +69,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 });
 
 // ✅ Tab control
-function initTabs() {
-  const tabs = document.querySelectorAll('.tab-button');
-  const sections = document.querySelectorAll('.tab-section');
-
-  tabs.forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const target = btn.dataset.tab;
-      tabs.forEach(t => t.classList.remove('active'));
-      sections.forEach(sec => sec.classList.remove('active'));
-
-      btn.classList.add('active');
-      document.getElementById(target).classList.add('active');
-
-      if (target === 'tab-transactions') await loadVaultHistory();
-    });
-  });
-}
 
 // ✅ Vault total summary
 async function loadVaultSummary() {

--- a/Javascript/alliance_wars.js
+++ b/Javascript/alliance_wars.js
@@ -5,9 +5,11 @@
 import { supabase } from './supabaseClient.js';
 import { loadCustomBoard } from './customBoard.js';
 import { escapeHTML } from './utils.js';
+import { setupTabs } from './components/tabControl.js';
 
 let currentWarId = null;
 let combatInterval = null;
+let switchTab = () => {};
 
 document.addEventListener("DOMContentLoaded", async () => {
   // ✅ Logout binding
@@ -17,7 +19,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   // ✅ Init
-  initTabs();
+  switchTab = setupTabs({ onShow: id => id !== 'tab-live' && stopCombatPolling() });
   await loadCustomBoard({ altText: 'Alliance War Banner' });
   await loadAllianceWars();
   await loadPendingWars();
@@ -209,15 +211,6 @@ function stopCombatPolling() {
 }
 
 // ✅ Tab Switching
-function initTabs() {
-  document.querySelectorAll('.tab-button').forEach(btn =>
-    btn.addEventListener('click', () => switchTab(btn.dataset.tab)));
-}
-function switchTab(id) {
-  document.querySelectorAll('.tab-button, .tab-section').forEach(el =>
-    el.classList.toggle('active', el.dataset.tab === id || el.id === id));
-  if (id !== 'tab-live') stopCombatPolling();
-}
 
 // ✅ Declare War
 async function submitDeclareWar() {

--- a/Javascript/components/tabControl.js
+++ b/Javascript/components/tabControl.js
@@ -1,0 +1,37 @@
+// Project Name: Kingmakers Rise©
+// File Name: tabControl.js
+// Version 6.15.2025.21.00
+// Developer: Codex
+
+/**
+ * Simple tab controller. Adds click handlers for elements
+ * matching `buttonSelector` and toggles `active` class on
+ * both the button and the matching section by id.
+ *
+ * @param {object} options
+ * @param {string} [options.buttonSelector='.tab-button'] CSS selector for tab buttons
+ * @param {string} [options.sectionSelector='.tab-section'] CSS selector for tab sections
+ * @param {Function} [options.onShow] Callback fired after a tab is shown
+ */
+export function setupTabs({
+  buttonSelector = '.tab-button',
+  sectionSelector = '.tab-section',
+  onShow = null
+} = {}) {
+  const buttons = Array.from(document.querySelectorAll(buttonSelector));
+  const sections = Array.from(document.querySelectorAll(sectionSelector));
+  if (!buttons.length) return;
+
+  const show = id => {
+    buttons.forEach(b => b.classList.toggle('active', b.dataset.tab === id));
+    sections.forEach(s => s.classList.toggle('active', s.id === id));
+    if (onShow) onShow(id);
+  };
+
+  buttons.forEach(btn => btn.addEventListener('click', () => show(btn.dataset.tab)));
+
+  // Activate first tab if none marked active
+  const initial = buttons.find(b => b.classList.contains('active'))?.dataset.tab || buttons[0].dataset.tab;
+  show(initial);
+  return show;
+}

--- a/Javascript/leaderboard.js
+++ b/Javascript/leaderboard.js
@@ -4,6 +4,7 @@
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
 import { escapeHTML } from './utils.js';
+import { setupTabs } from './components/tabControl.js';
 
 let currentTab = "kingdoms";
 
@@ -30,7 +31,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
-  setupTabs();
+  setupTabs({ onShow: id => { currentTab = id; loadLeaderboard(id); } });
   await loadLeaderboard(currentTab);
 
   setInterval(() => {
@@ -38,19 +39,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   }, 30000);
 });
 
-// 🧭 Tab switch logic
-function setupTabs() {
-  const tabButtons = document.querySelectorAll(".tab-button");
-  tabButtons.forEach(btn => {
-    btn.addEventListener("click", async () => {
-      const target = btn.dataset.tab;
-      tabButtons.forEach(b => b.classList.remove("active"));
-      btn.classList.add("active");
-      currentTab = target;
-      await loadLeaderboard(target);
-    });
-  });
-}
+// 🧭 Tab switch logic for leaderboard page
 
 // 📊 Load leaderboard by tab type
 async function loadLeaderboard(type) {

--- a/Javascript/town_criers.js
+++ b/Javascript/town_criers.js
@@ -4,11 +4,12 @@
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
 import { escapeHTML } from './utils.js';
+import { setupTabs } from './components/tabControl.js';
 
 let scrollChannel = null;
 
 document.addEventListener("DOMContentLoaded", async () => {
-  initTabs();
+  setupTabs();
   await Promise.all([
     loadBoard(),
     loadYourScrolls()
@@ -23,17 +24,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 });
 
 // ✅ UI Tabs Handler
-function initTabs() {
-  document.querySelectorAll('.tab-button').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const target = btn.getAttribute('data-tab');
-      document.querySelectorAll('.tab-button').forEach(b => b.classList.remove('active'));
-      document.querySelectorAll('.tab-section').forEach(s => s.classList.remove('active'));
-      btn.classList.add('active');
-      document.getElementById(target)?.classList.add('active');
-    });
-  });
-}
 
 // ✅ Load Global Bulletin
 async function loadBoard() {

--- a/Javascript/trade_logs.js
+++ b/Javascript/trade_logs.js
@@ -5,11 +5,12 @@
 import { supabase } from './supabaseClient.js';
 import { escapeHTML } from './utils.js';
 import { RESOURCE_TYPES } from './resourceTypes.js';
+import { setupTabs } from './components/tabControl.js';
 
 let realtimeChannel = null;
 
 document.addEventListener("DOMContentLoaded", async () => {
-  initTabs();
+  setupTabs({ onShow: loadTradeLogs });
   initFilters();
   populateResourceOptions();
   await loadTradeLogs();
@@ -18,23 +19,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 });
 
 // ✅ Initialize tab switching logic
-function initTabs() {
-  const tabs = document.querySelectorAll('.tab-button');
-  const sections = document.querySelectorAll('.tab-section');
-
-  tabs.forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const target = btn.dataset.target;
-
-      tabs.forEach(b => b.classList.remove('active'));
-      sections.forEach(s => s.classList.remove('active'));
-
-      btn.classList.add('active');
-      document.getElementById(target)?.classList.add('active');
-      await loadTradeLogs();
-    });
-  });
-}
 
 // ✅ Setup filters
 function initFilters() {


### PR DESCRIPTION
## Summary
- centralize tab behaviour into a reusable `setupTabs` helper
- consolidate repeated `.tab-section` styles into `root_theme.css`
- refactor pages using tabbed sections to the new helper
- clean up redundant CSS rules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684de09bd8ec833087d8859458e0e769