### PR TITLE
Refactor auth helpers for frontend JS

### DIFF
--- a/Javascript/auth.js
+++ b/Javascript/auth.js
@@ -1,0 +1,47 @@
+// Project Name: Kingmakers Rise©
+// File Name: auth.js
+// Version 6.14.2025.20.45
+// Developer: Codex
+// Shared helper for retrieving authenticated user and headers
+
+import { supabase } from './supabaseClient.js';
+
+let cachedAuth = null;
+
+/**
+ * Retrieve the current user and session from Supabase.
+ * The result is cached for the lifetime of the page to avoid
+ * redundant API calls.
+ * @returns {Promise<{user: object, session: object}>}
+ * @throws {Error} if no authenticated session is available
+ */
+export async function getAuth() {
+  if (cachedAuth) return cachedAuth;
+  const [{ data: { user } }, { data: { session } }] = await Promise.all([
+    supabase.auth.getUser(),
+    supabase.auth.getSession()
+  ]);
+  if (!user || !session) throw new Error('Unauthorized');
+  cachedAuth = { user, session };
+  return cachedAuth;
+}
+
+/**
+ * Build standard headers for authenticated API requests.
+ * @returns {Promise<Record<string, string>>}
+ */
+export async function authHeaders() {
+  const { user, session } = await getAuth();
+  return {
+    'X-User-ID': user.id,
+    Authorization: `Bearer ${session.access_token}`
+  };
+}
+
+/**
+ * Clear the cached user/session data (e.g. on logout).
+ */
+export function resetAuthCache() {
+  cachedAuth = null;
+}
+

--- a/Javascript/battle_replay.js
+++ b/Javascript/battle_replay.js
@@ -5,18 +5,7 @@
 // Battle Replay module with timeline playback
 
 import { supabase } from './supabaseClient.js';
-
-async function authHeaders() {
-  const [{ data: { user } }, { data: { session } }] = await Promise.all([
-    supabase.auth.getUser(),
-    supabase.auth.getSession()
-  ]);
-  if (!user || !session) throw new Error('Unauthorized');
-  return {
-    'X-User-ID': user.id,
-    Authorization: `Bearer ${session.access_token}`
-  };
-}
+import { authHeaders } from './auth.js';
 
 const urlParams = new URLSearchParams(window.location.search);
 const warId = parseInt(urlParams.get('war_id'), 10) || 0;

--- a/Javascript/changelog.js
+++ b/Javascript/changelog.js
@@ -4,21 +4,9 @@
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
 import { escapeHTML } from './utils.js';
+import { authHeaders } from './auth.js';
 
 let realtimeSub;
-
-// ✅ Unified auth header fetch
-async function authHeaders() {
-  const [{ data: { user } }, { data: { session } }] = await Promise.all([
-    supabase.auth.getUser(),
-    supabase.auth.getSession()
-  ]);
-  if (!user || !session) throw new Error('Unauthorized');
-  return {
-    'X-User-ID': user.id,
-    Authorization: `Bearer ${session.access_token}`
-  };
-}
 
 // ✅ Entry point
 document.addEventListener("DOMContentLoaded", async () => {

--- a/Javascript/donate_vip.js
+++ b/Javascript/donate_vip.js
@@ -4,8 +4,7 @@
 // Developer: Deathsgift66
 import { supabase } from "./supabaseClient.js";
 import { escapeHTML } from './utils.js';
-
-let currentSession = null;
+import { authHeaders } from './auth.js';
 let vipTiers = [];
 let vipChannel = null;
 
@@ -19,7 +18,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
-  currentSession = session;
   await Promise.all([loadVIPStatus(), loadVIPTiers(), loadLeaderboard()]);
   setupRealtimeChannel();
   bindDonationForm();
@@ -47,7 +45,7 @@ function setupRealtimeChannel() {
 export async function loadVIPStatus() {
   try {
     const res = await fetch("/api/vip/status", {
-      headers: authHeaders()
+      headers: await authHeaders()
     });
     if (!res.ok) throw new Error("Failed to fetch VIP status");
     const status = await res.json();
@@ -82,7 +80,7 @@ function renderStatus(status) {
 export async function loadVIPTiers() {
   try {
     const res = await fetch("/api/vip/tiers", {
-      headers: authHeaders()
+      headers: await authHeaders()
     });
     if (!res.ok) throw new Error("Failed to fetch tiers");
     const { tiers } = await res.json();
@@ -137,7 +135,7 @@ export async function submitVIPDonation(tier_id) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        ...authHeaders()
+        ...(await authHeaders())
       },
       body: JSON.stringify({ tier_id })
     });
@@ -194,7 +192,7 @@ export async function loadLeaderboard() {
 
   try {
     const res = await fetch("/api/vip/leaders", {
-      headers: authHeaders()
+      headers: await authHeaders()
     });
     const { leaders = [] } = await res.json();
     renderLeaderboard(leaders);
@@ -228,10 +226,5 @@ function renderLeaderboard(leaders) {
 // ------------------------------
 // Utilities
 // ------------------------------
-function authHeaders() {
-  return {
-    Authorization: `Bearer ${currentSession.access_token}`,
-    "X-User-ID": currentSession.user.id
-  };
-}
+// authHeaders imported from auth.js
 


### PR DESCRIPTION
## Summary
- centralize authenticated header generation in `auth.js`
- reuse helpers in account settings, changelog, black market, battle replay and donate vip pages
- validate avatar/banner URLs and trim form value helpers

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dea867c1083308bf927dcd4795ad1