### PR TITLE
Enhance resource handling

### DIFF
--- a/services/resource_service.py
+++ b/services/resource_service.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 import logging
+from .text_utils import sanitize_plain_text
 
 logger = logging.getLogger(__name__)
 
@@ -202,6 +203,8 @@ def transfer_resource(
     if amount <= 0:
         raise ValueError("Transfer amount must be positive.")
 
+    clean_reason = sanitize_plain_text(reason, 255)
+
     current = get_kingdom_resources(db, from_kingdom_id)
     if current.get(resource, 0) < amount:
         raise HTTPException(status_code=400, detail="Not enough resources to transfer.")
@@ -229,7 +232,7 @@ def transfer_resource(
                     "to_id": to_kingdom_id,
                     "res": resource,
                     "amt": amount,
-                    "reason": reason or "unlogged",
+                    "reason": clean_reason or "unlogged",
                 },
             )
             db.commit()

--- a/services/text_utils.py
+++ b/services/text_utils.py
@@ -1,0 +1,12 @@
+import re
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def sanitize_plain_text(text: str, max_length: int = 255) -> str:
+    """Strip HTML tags, truncate to ``max_length`` and return clean text."""
+    cleaned = _TAG_RE.sub("", text or "").strip()
+    if len(cleaned) > max_length:
+        cleaned = cleaned[:max_length]
+    return cleaned
+


### PR DESCRIPTION
## Summary
- sanitize plain text fields
- apply sanitization to resource transfer reason logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684df44c854c833098b5e96dfdd9a0d4