### PR TITLE
Refactor frontend utilities and responsive styles

### DIFF
--- a/CSS/play.css
+++ b/CSS/play.css
@@ -270,3 +270,12 @@ body {
   margin-bottom: 0.25rem;
   color: var(--gold);
 }
+
+@media (max-width: 600px) {
+  .onboarding-container {
+    padding: 1rem;
+  }
+  .dashboard-panels {
+    grid-template-columns: 1fr;
+  }
+}

--- a/Javascript/alliance_home.js
+++ b/Javascript/alliance_home.js
@@ -1,9 +1,9 @@
 // Project Name: Kingmakers Rise©
 // File Name: alliance_home.js
-// Version 6.13.2025.19.49
+// Version 6.14.2025.20.12
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
-import { escapeHTML, setText, formatDate, fragmentFrom } from './utils.js';
+import { escapeHTML, setText, formatDate, fragmentFrom, jsonFetch } from './utils.js';
 
 let activityChannel = null;
 
@@ -21,13 +21,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   fetchAllianceDetails(session.user.id);
 });
 
+/**
+ * Fetch alliance details via REST then initialize realtime channel.
+ * @param {string} userId Authenticated user identifier
+ */
 async function fetchAllianceDetails(userId) {
   try {
-    const res = await fetch('/api/alliance-home/details', {
+    const data = await jsonFetch('/api/alliance-home/details', {
       headers: { 'X-User-ID': userId }
     });
-    if (!res.ok) throw new Error('Request failed');
-    const data = await res.json();
     populateAlliance(data);
     setupRealtime(data.alliance?.alliance_id);
   } catch (err) {
@@ -209,26 +211,27 @@ function renderActiveBattles(wars = []) {
     container.textContent = 'No active battles.';
     return;
   }
-
-  active.forEach(w => {
+  const frag = fragmentFrom(active, w => {
     const div = document.createElement('div');
     div.className = 'battle-entry';
     div.textContent = `War ${w.alliance_war_id} — ${w.war_status}`;
-    container.appendChild(div);
+    return div;
   });
+  container.appendChild(frag);
 }
 
 function renderWarScore(wars = []) {
   const container = document.getElementById('war-score-summary');
   if (!container) return;
   container.innerHTML = '';
-  wars.forEach(w => {
+  const frag = fragmentFrom(wars, w => {
     const div = document.createElement('div');
     const att = w.attacker_score ?? 0;
     const def = w.defender_score ?? 0;
     div.textContent = `War ${w.alliance_war_id}: Attacker ${att} vs Defender ${def}`;
-    container.appendChild(div);
+    return div;
   });
+  container.appendChild(frag);
 }
 
 // === Realtime Activity Logging ===

--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -1,9 +1,9 @@
 // Project Name: Kingmakers Rise©
 // File Name: play.js
-// Version 6.13.2025.19.49
+// Version 6.14.2025.20.12
 // Developer: Deathsgift66
 import { supabase } from './supabaseClient.js';
-import { escapeHTML, showToast, fragmentFrom } from './utils.js';
+import { escapeHTML, showToast, fragmentFrom, jsonFetch } from './utils.js';
 
 let currentUser = null;
 let authToken = '';
@@ -127,8 +127,13 @@ function validateInputs(name, village, region) {
 }
 
 
+/**
+ * POST a JSON payload using the shared `jsonFetch` helper.
+ * @param {string} url  Endpoint URL
+ * @param {object} body Body object to send
+ */
 async function postJSON(url, body) {
-  const res = await fetch(url, {
+  return jsonFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -137,21 +142,13 @@ async function postJSON(url, body) {
     },
     body: JSON.stringify(body)
   });
-  const contentType = res.headers.get('content-type') || '';
-  if (!res.ok || !contentType.includes('application/json')) {
-    const text = await res.text();
-    throw new Error(`Failed: ${res.status}, ${text}`);
-  }
-  return res.json();
 }
 
 async function loadVIPStatus() {
   try {
-    const res = await fetch('/api/kingdom/vip_status', {
+    const data = await jsonFetch('/api/kingdom/vip_status', {
       headers: { 'X-User-ID': currentUser.id }
     });
-    if (!res.ok) return;
-    const data = await res.json();
     vipLevel = data.vip_level || 0;
   } catch (err) {
     console.warn('Could not load VIP status.');
@@ -164,8 +161,7 @@ async function loadRegions() {
   if (!regionEl || !infoEl) return;
 
   try {
-    const res = await fetch('/api/kingdom/regions');
-    const regions = await res.json();
+    const regions = await jsonFetch('/api/kingdom/regions');
     regionEl.innerHTML = '<option value="">Select Region</option>';
 
     regions.forEach(region => {
@@ -202,8 +198,7 @@ async function loadAnnouncements() {
   if (!el) return;
 
   try {
-    const res = await fetch('/api/login/announcements');
-    const announcements = await res.json();
+    const announcements = await jsonFetch('/api/login/announcements');
     el.innerHTML = announcements.map(a =>
       `<div class="announcement"><h4>${escapeHTML(a.title)}</h4><p>${escapeHTML(a.content)}</p></div>`
     ).join('');

--- a/Javascript/utils.js
+++ b/Javascript/utils.js
@@ -111,6 +111,37 @@ export function formatDate(ts) {
 }
 
 /**
+ * Fetch JSON from an endpoint with sensible defaults and error handling.
+ *
+ * This helper ensures the "Accept" header is set and rejects on
+ * non-2xx responses or invalid JSON payloads.
+ *
+ * @param {string} url       Request URL
+ * @param {object} [options] fetch options
+ * @returns {Promise<any>}   Parsed JSON data
+ */
+export async function jsonFetch(url, options = {}) {
+  const opts = {
+    headers: { Accept: 'application/json', ...(options.headers || {}) },
+    ...options
+  };
+
+  const res = await fetch(url, opts);
+  const type = res.headers.get('content-type') || '';
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Request failed ${res.status}: ${text}`);
+  }
+
+  if (!type.includes('application/json')) {
+    throw new Error('Invalid JSON response');
+  }
+
+  return res.json();
+}
+
+/**
  * Build a DocumentFragment from an array of items.
  * @template T
  * @param {T[]} items Data items


### PR DESCRIPTION
## Summary
- add `jsonFetch` helper for standardized JSON requests
- use new helper across onboarding and alliance pages
- optimize DOM updates with fragments
- implement basic responsive rules for onboarding screen

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684df71766e88330aa06f931265579e1