### PR TITLE
Fix onboarding record inserts

### DIFF
--- a/backend/routers/progression_router.py
+++ b/backend/routers/progression_router.py
@@ -152,12 +152,16 @@ def upgrade_castle(user_id: str = Depends(require_user_id), db: Session = Depend
 
     # Upgrade or insert castle level
     db.execute(
-        text("""
+        text(
+            """
             INSERT INTO kingdom_castle_progression (kingdom_id, castle_level, xp)
             VALUES (:kid, 1, 0)
-            ON CONFLICT (kingdom_id) DO UPDATE SET castle_level = castle_level + 1
-        """),
-        {"kid": kid}
+            ON CONFLICT (kingdom_id) DO UPDATE
+                SET castle_level = kingdom_castle_progression.castle_level + 1,
+                    xp = 0
+            """
+        ),
+        {"kid": kid},
     )
 
     # Ensure troop slots record exists

--- a/backend/routers/signup.py
+++ b/backend/routers/signup.py
@@ -9,6 +9,8 @@ from typing import Optional
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from backend.models import Notification
+
 from ..supabase_client import get_supabase_client
 from ..database import get_db
 
@@ -123,6 +125,27 @@ def create_user(payload: CreateUserPayload, db: Session = Depends(get_db)):
                 "email": payload.email,
             },
         )
+
+        db.execute(
+            text(
+                """
+                INSERT INTO user_setting_entries (user_id, setting_key, setting_value)
+                VALUES (:uid, 'theme', 'default')
+                ON CONFLICT DO NOTHING
+                """
+            ),
+            {"uid": payload.user_id},
+        )
+
+        db.add(
+            Notification(
+                user_id=payload.user_id,
+                title="Welcome to Kingmaker’s Rise!",
+                message="Your kingdom awaits.",
+                category="system",
+            )
+        )
+
         db.commit()
         return {"status": "created"}
     except Exception as e:
@@ -173,6 +196,27 @@ def register(payload: RegisterPayload, db: Session = Depends(get_db)):
                 "email": payload.email,
             },
         )
+
+        db.execute(
+            text(
+                """
+                INSERT INTO user_setting_entries (user_id, setting_key, setting_value)
+                VALUES (:uid, 'theme', 'default')
+                ON CONFLICT DO NOTHING
+                """
+            ),
+            {"uid": uid},
+        )
+
+        db.add(
+            Notification(
+                user_id=uid,
+                title="Welcome to Kingmaker’s Rise!",
+                message="Your kingdom awaits.",
+                category="system",
+            )
+        )
+
         db.commit()
     except Exception as exc:
         raise HTTPException(status_code=500, detail="Failed to save user profile") from exc

--- a/services/kingdom_setup_service.py
+++ b/services/kingdom_setup_service.py
@@ -103,6 +103,14 @@ def create_kingdom_transaction(
             {"kid": kingdom_id},
         )
 
+        db.execute(
+            text(
+                "INSERT INTO kingdom_castle_progression (kingdom_id, castle_level, xp)"
+                " VALUES (:kid, 1, 0)"
+            ),
+            {"kid": kingdom_id},
+        )
+
         # Insert the first noble so progression can begin immediately
         db.execute(
             text(


### PR DESCRIPTION
## Summary
- create default user settings and welcome notification during signup
- populate initial castle progression row when a kingdom is created
- reset XP on castle upgrade

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684dfbc77a508330b104bc8b268fe3f6