### PR TITLE
Align alliance achievements with schema

### DIFF
--- a/Javascript/alliance_home.js
+++ b/Javascript/alliance_home.js
@@ -166,7 +166,7 @@ function renderAchievements(achievements = []) {
     const li = document.createElement('li');
     const badge = document.createElement('span');
     badge.className = 'achievement-badge';
-    if (a.icon_url) badge.style.backgroundImage = `url(${a.icon_url})`;
+    if (a.badge_icon_url) badge.style.backgroundImage = `url(${a.badge_icon_url})`;
     li.appendChild(badge);
     li.insertAdjacentText('beforeend', ` ${a.name}`);
     list.appendChild(li);

--- a/backend/routers/alliance_home.py
+++ b/backend/routers/alliance_home.py
@@ -171,13 +171,15 @@ def alliance_details(
     # 🏅 Achievements
     # --------------------
     achievements = db.execute(
-        text("""
-            SELECT a.achievement_code, c.name, c.description, c.icon_url, a.awarded_at
+        text(
+            """
+            SELECT a.achievement_code, c.name, c.description, c.badge_icon_url, a.awarded_at
             FROM alliance_achievements a
             JOIN alliance_achievement_catalogue c ON a.achievement_code = c.achievement_code
             WHERE a.alliance_id = :aid
             ORDER BY a.awarded_at DESC
-        """),
+            """
+        ),
         {"aid": aid},
     ).fetchall()
     achievements = [
@@ -185,7 +187,7 @@ def alliance_details(
             "achievement_code": r[0],
             "name": r[1],
             "description": r[2],
-            "icon_url": r[3],
+            "badge_icon_url": r[3],
             "awarded_at": r[4].isoformat() if r[4] else None,
         }
         for r in achievements


### PR DESCRIPTION
## Summary
- query alliance achievement icons with `badge_icon_url`
- return `badge_icon_url` field in alliance home API
- update alliance achievements front-end code to read `badge_icon_url`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_684e0708a0b48330afd60cb22bb43bb8