### PR TITLE
Fix models against schema

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Numeric,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.sql import func
@@ -627,9 +628,9 @@ class BlackMarketListing(Base):
 
     __tablename__ = "black_market_listings"
 
-    listing_id = Column(Integer, primary_key=True)
-    seller_id = Column(UUID(as_uuid=True), ForeignKey("users.user_id"))
-    item = Column(String)
+    listing_id = Column(Integer, primary_key=True, autoincrement=True)
+    seller_id = Column(UUID(as_uuid=True))
+    item = Column(Text)
     price = Column(Numeric)
     quantity = Column(Integer)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
@@ -912,4 +913,72 @@ class KingdomResources(Base):
     spear = Column(BigInteger, default=0)
     horses = Column(BigInteger, default=0)
     pitchforks = Column(BigInteger, default=0)
+
+
+class BuildingCatalogue(Base):
+    __tablename__ = "building_catalogue"
+
+    building_id = Column(Integer, primary_key=True, autoincrement=True)
+    building_name = Column(Text, nullable=False)
+    description = Column(Text)
+    production_type = Column(Text)
+    production_rate = Column(Integer)
+    upkeep = Column(Integer)
+    modifiers = Column(JSONB, server_default=text("'{}'::jsonb"))
+    category = Column(Text)
+    build_time_seconds = Column(Integer, server_default=text("3600"))
+    prerequisites = Column(JSONB, server_default=text("'{}'::jsonb"))
+    max_level = Column(Integer, server_default=text("10"))
+    special_effects = Column(JSONB, server_default=text("'{}'::jsonb"))
+    is_unique = Column(Boolean, server_default=text("false"))
+    is_repeatable = Column(Boolean, server_default=text("true"))
+    unlock_at_level = Column(Integer, server_default=text("1"))
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    last_updated = Column(DateTime(timezone=True), server_default=func.now())
+    cost_to_produce = Column(JSONB, server_default=text("'{}'::jsonb"))
+    efficiency_multiplier = Column(Numeric, server_default=text("1.0"))
+    wood_cost = Column(Integer, server_default=text("0"))
+    stone_cost = Column(Integer, server_default=text("0"))
+    iron_cost = Column(Integer, server_default=text("0"))
+    gold_cost = Column(Integer, server_default=text("0"))
+    wood_plan_cost = Column(Integer, server_default=text("0"))
+    iron_ingot_cost = Column(Integer, server_default=text("0"))
+    requires_tech_id = Column(Integer)
+    build_time = Column(Integer, server_default=text("0"))
+    effect_description = Column(Text)
+    wood = Column(Integer, server_default=text("0"))
+    stone = Column(Integer, server_default=text("0"))
+    iron_ore = Column(Integer, server_default=text("0"))
+    gold = Column(Integer, server_default=text("0"))
+    gems = Column(Integer, server_default=text("0"))
+    food = Column(Integer, server_default=text("0"))
+    coal = Column(Integer, server_default=text("0"))
+    livestock = Column(Integer, server_default=text("0"))
+    clay = Column(Integer, server_default=text("0"))
+    flax = Column(Integer, server_default=text("0"))
+    tools = Column(Integer, server_default=text("0"))
+    wood_planks = Column(Integer, server_default=text("0"))
+    refined_stone = Column(Integer, server_default=text("0"))
+    iron_ingots = Column(Integer, server_default=text("0"))
+    charcoal = Column(Integer, server_default=text("0"))
+    leather = Column(Integer, server_default=text("0"))
+    arrows = Column(Integer, server_default=text("0"))
+    swords = Column(Integer, server_default=text("0"))
+    axes = Column(Integer, server_default=text("0"))
+    shields = Column(Integer, server_default=text("0"))
+    armour = Column(Integer, server_default=text("0"))
+    wagon = Column(Integer, server_default=text("0"))
+    siege_weapons = Column(Integer, server_default=text("0"))
+    jewelry = Column(Integer, server_default=text("0"))
+    spear = Column(Integer, server_default=text("0"))
+    horses = Column(Integer, server_default=text("0"))
+    pitchforks = Column(Integer, server_default=text("0"))
+
+
+class BuildingCost(Base):
+    __tablename__ = "building_costs"
+
+    building_id = Column(Integer, ForeignKey("building_catalogue.building_id"), primary_key=True)
+    resource_type = Column(Text, primary_key=True)
+    amount = Column(Integer, nullable=False)
 

--- a/backend/routers/alliance_vault.py
+++ b/backend/routers/alliance_vault.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import Session
 from ..database import get_db
 from backend.models import AllianceVault, AllianceVaultTransactionLog, User
 from services.audit_service import log_action
-from services.trade_log_service import record_trade
 from ..security import require_user_id
 
 # Primary and alternative API routes
@@ -74,15 +73,6 @@ def deposit_resource(payload: VaultTransaction, user_id: str = Depends(require_u
     ))
     db.commit()
 
-    record_trade(
-        db,
-        resource=payload.resource,
-        quantity=payload.amount,
-        trade_type="alliance_trade",
-        seller_id=user_id,
-        buyer_alliance_id=alliance_id
-    )
-
     log_action(db, user_id, "deposit_vault", f"Deposited {payload.amount} {payload.resource}")
     return {"message": "Deposited"}
 
@@ -116,15 +106,6 @@ def withdraw_resource(payload: VaultTransaction, user_id: str = Depends(require_
         notes='Player withdrawal'
     ))
     db.commit()
-
-    record_trade(
-        db,
-        resource=payload.resource,
-        quantity=payload.amount,
-        trade_type="alliance_trade",
-        buyer_id=user_id,
-        seller_alliance_id=alliance_id
-    )
 
     log_action(db, user_id, "withdraw_vault", f"Withdrew {payload.amount} {payload.resource}")
     return {"message": "Withdrawn"}

--- a/tests/test_alliance_vault_router.py
+++ b/tests/test_alliance_vault_router.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from backend.db_base import Base
-from backend.models import Alliance, AllianceVault, AllianceVaultTransactionLog, TradeLog, User
+from backend.models import Alliance, AllianceVault, AllianceVaultTransactionLog, User
 from backend.routers.alliance_vault import VaultTransaction, deposit, withdraw, summary
 
 
@@ -50,8 +50,6 @@ def test_deposit_and_withdraw():
     assert vault.wood == 100
     tx = db.query(AllianceVaultTransactionLog).first()
     assert tx.action == "deposit" and tx.amount == 100
-    tlog = db.query(TradeLog).first()
-    assert tlog.quantity == 100 and tlog.trade_type == "alliance_trade"
 
     withdraw(
         VaultTransaction(alliance_id=1, resource="wood", amount=40),
@@ -64,10 +62,6 @@ def test_deposit_and_withdraw():
         AllianceVaultTransactionLog.transaction_id.desc()
     ).first()
     assert tx2.action == "withdraw" and tx2.amount == 40
-    tlog2 = (
-        db.query(TradeLog).order_by(TradeLog.trade_id.desc()).first()
-    )
-    assert tlog2.quantity == 40 and tlog2.trade_type == "alliance_trade"
 
 
 def test_summary_totals():


### PR DESCRIPTION
## Summary
- correct `BlackMarketListing` to remove user dependency
- align `BuildingCatalogue` and `BuildingCost` ORM models to schema
- simplify black market router
- drop trade log use from alliance vault
- update related tests

## Testing
- `pytest -q` *(fails: RuntimeError Supabase client library...)*

------
https://chatgpt.com/codex/tasks/task_e_684e0a336e6083309eb70eaaf1620012