### PR TITLE
Fix combat log and settings DB usage

### DIFF
--- a/backend/data.py
+++ b/backend/data.py
@@ -145,9 +145,11 @@ def load_game_settings() -> None:
 
     query = text(
         """
-        SELECT setting_key, setting_value
-        FROM game_settings
-        WHERE is_active = true
+        SELECT gs.setting_key, gsv.setting_value
+        FROM game_settings gs
+        LEFT JOIN game_setting_values gsv
+            ON gs.setting_key = gsv.setting_key
+        WHERE gs.is_active = true
         """
     )
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Numeric,
+    Float,
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.sql import func
@@ -402,9 +403,12 @@ class CombatLog(Base):
     position_x = Column(Integer)
     position_y = Column(Integer)
     damage_dealt = Column(Integer, default=0)
-    morale_shift = Column(Integer)
+    morale_shift = Column(Float)
     notes = Column(Text)
     timestamp = Column(DateTime(timezone=True), server_default=func.now())
+    treaty_trigger_context = Column(JSONB, default=dict)
+    triggered_by_treaty = Column(Boolean, default=False)
+    treaty_name = Column(Text)
 
 
 class AllianceWar(Base):
@@ -733,6 +737,17 @@ class GameSetting(Base):
     setting_string = Column(String)
     setting_number = Column(Numeric)
     setting_boolean = Column(Boolean, default=False)
+
+
+class GameSettingValue(Base):
+    __tablename__ = "game_setting_values"
+
+    setting_key = Column(
+        String,
+        ForeignKey("game_settings.setting_key", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    setting_value = Column(Text)
 
 
 class KingdomHistoryLog(Base):

--- a/services/combat_log_service.py
+++ b/services/combat_log_service.py
@@ -20,16 +20,18 @@ except ImportError:  # pragma: no cover - fallback when SQLAlchemy isn't install
 def log_combat_event(
     db: Session,
     war_id: int,
-    tick: int,
-    acting_unit_id: int,
-    target_unit_id: int,
-    action_type: str,
-    result_summary: str,
-    damage: int = 0,
-    morale_shift: int = 0,
-    terrain_effect: str | None = None,
-    weather_effect: str | None = None,
-    special_notes: str | None = None,
+    tick_number: int,
+    attacker_unit_id: int,
+    defender_unit_id: int,
+    event_type: str,
+    damage_dealt: int = 0,
+    morale_shift: float = 0.0,
+    position_x: int | None = None,
+    position_y: int | None = None,
+    notes: str | None = None,
+    treaty_trigger_context: dict | None = None,
+    triggered_by_treaty: bool = False,
+    treaty_name: str | None = None,
 ) -> int:
     """
     Logs a single combat event in the combat log table.
@@ -39,28 +41,32 @@ def log_combat_event(
         text(
             """
             INSERT INTO combat_logs (
-                war_id, tick, acting_unit_id, target_unit_id, action_type,
-                result_summary, damage, morale_shift, terrain_effect, weather_effect,
-                special_notes, occurred_at
+                war_id, tick_number, event_type, attacker_unit_id,
+                defender_unit_id, position_x, position_y, damage_dealt,
+                morale_shift, notes, treaty_trigger_context, triggered_by_treaty,
+                treaty_name, timestamp
             ) VALUES (
-                :war_id, :tick, :acting_uid, :target_uid, :atype,
-                :summary, :dmg, :morale, :terrain, :weather,
-                :notes, NOW()
-            ) RETURNING log_id
+                :war_id, :tick_number, :event_type, :attacker_unit_id,
+                :defender_unit_id, :position_x, :position_y, :damage_dealt,
+                :morale_shift, :notes, :treaty_context, :triggered,
+                :treaty_name, NOW()
+            ) RETURNING combat_id
             """
         ),
         {
             "war_id": war_id,
-            "tick": tick,
-            "acting_uid": acting_unit_id,
-            "target_uid": target_unit_id,
-            "atype": action_type,
-            "summary": result_summary,
-            "dmg": damage,
-            "morale": morale_shift,
-            "terrain": terrain_effect,
-            "weather": weather_effect,
-            "notes": special_notes,
+            "tick_number": tick_number,
+            "event_type": event_type,
+            "attacker_unit_id": attacker_unit_id,
+            "defender_unit_id": defender_unit_id,
+            "position_x": position_x,
+            "position_y": position_y,
+            "damage_dealt": damage_dealt,
+            "morale_shift": morale_shift,
+            "notes": notes,
+            "treaty_context": treaty_trigger_context or {},
+            "triggered": triggered_by_treaty,
+            "treaty_name": treaty_name,
         },
     )
     row = result.fetchone()
@@ -76,12 +82,13 @@ def fetch_logs_for_war(db: Session, war_id: int, limit: int = 500) -> list[dict]
     rows = db.execute(
         text(
             """
-            SELECT log_id, tick, acting_unit_id, target_unit_id,
-                   action_type, result_summary, damage, morale_shift,
-                   terrain_effect, weather_effect, special_notes, occurred_at
+            SELECT combat_id, tick_number, event_type, attacker_unit_id,
+                   defender_unit_id, position_x, position_y, damage_dealt,
+                   morale_shift, notes, timestamp,
+                   treaty_trigger_context, triggered_by_treaty, treaty_name
             FROM combat_logs
             WHERE war_id = :wid
-            ORDER BY tick ASC, log_id ASC
+            ORDER BY tick_number ASC, combat_id ASC
             LIMIT :lim
             """
         ),
@@ -90,24 +97,26 @@ def fetch_logs_for_war(db: Session, war_id: int, limit: int = 500) -> list[dict]
 
     return [
         {
-            "log_id": r[0],
-            "tick": r[1],
-            "acting_unit_id": r[2],
-            "target_unit_id": r[3],
-            "action_type": r[4],
-            "result_summary": r[5],
-            "damage": r[6],
-            "morale_shift": r[7],
-            "terrain_effect": r[8],
-            "weather_effect": r[9],
-            "special_notes": r[10],
-            "occurred_at": r[11],
+            "combat_id": r[0],
+            "tick_number": r[1],
+            "event_type": r[2],
+            "attacker_unit_id": r[3],
+            "defender_unit_id": r[4],
+            "position_x": r[5],
+            "position_y": r[6],
+            "damage_dealt": r[7],
+            "morale_shift": r[8],
+            "notes": r[9],
+            "timestamp": r[10],
+            "treaty_trigger_context": r[11],
+            "triggered_by_treaty": r[12],
+            "treaty_name": r[13],
         }
         for r in rows
     ]
 
 
-def fetch_logs_by_tick(db: Session, war_id: int, tick: int) -> list[dict]:
+def fetch_logs_by_tick(db: Session, war_id: int, tick_number: int) -> list[dict]:
     """
     Returns all combat events for a specific tick in a war.
     Useful for visual tick-based replay rendering.
@@ -115,30 +124,33 @@ def fetch_logs_by_tick(db: Session, war_id: int, tick: int) -> list[dict]:
     rows = db.execute(
         text(
             """
-            SELECT log_id, acting_unit_id, target_unit_id,
-                   action_type, result_summary, damage, morale_shift,
-                   terrain_effect, weather_effect, special_notes, occurred_at
+            SELECT combat_id, attacker_unit_id, defender_unit_id,
+                   event_type, damage_dealt, morale_shift, position_x,
+                   position_y, notes, timestamp,
+                   treaty_trigger_context, triggered_by_treaty, treaty_name
             FROM combat_logs
-            WHERE war_id = :wid AND tick = :tick
-            ORDER BY log_id ASC
+            WHERE war_id = :wid AND tick_number = :tick
+            ORDER BY combat_id ASC
             """
         ),
-        {"wid": war_id, "tick": tick},
+        {"wid": war_id, "tick": tick_number},
     ).fetchall()
 
     return [
         {
-            "log_id": r[0],
-            "acting_unit_id": r[1],
-            "target_unit_id": r[2],
-            "action_type": r[3],
-            "result_summary": r[4],
-            "damage": r[5],
-            "morale_shift": r[6],
-            "terrain_effect": r[7],
-            "weather_effect": r[8],
-            "special_notes": r[9],
-            "occurred_at": r[10],
+            "combat_id": r[0],
+            "attacker_unit_id": r[1],
+            "defender_unit_id": r[2],
+            "event_type": r[3],
+            "damage_dealt": r[4],
+            "morale_shift": r[5],
+            "position_x": r[6],
+            "position_y": r[7],
+            "notes": r[8],
+            "timestamp": r[9],
+            "treaty_trigger_context": r[10],
+            "triggered_by_treaty": r[11],
+            "treaty_name": r[12],
         }
         for r in rows
     ]
@@ -153,7 +165,7 @@ def summarize_combat_outcome(db: Session, war_id: int) -> dict:
         text(
             """
             SELECT COUNT(*) as total_events,
-                   SUM(damage) as total_damage,
+                   SUM(damage_dealt) as total_damage,
                    SUM(morale_shift) as total_morale_shift
             FROM combat_logs
             WHERE war_id = :wid


### PR DESCRIPTION
## Summary
- add missing game_setting_values model
- correct combat_logs model fields
- fix queries using game_setting_values
- update settings router to upsert values
- sync combat_log_service with schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684e0a4717c08330a94eedcd360375a4