### PR TITLE
Add global event tables

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -913,3 +913,51 @@ class KingdomResources(Base):
     horses = Column(BigInteger, default=0)
     pitchforks = Column(BigInteger, default=0)
 
+
+class GlobalEvent(Base):
+    """Representation of a global event."""
+
+    __tablename__ = "global_events"
+
+    event_id = Column(Integer, primary_key=True)
+    name = Column(Text)
+    description = Column(Text)
+    start_time = Column(DateTime)
+    end_time = Column(DateTime)
+    is_active = Column(Boolean, default=False)
+    impact_type = Column(Text)
+    magnitude = Column(Numeric)
+
+
+class GlobalEventCondition(Base):
+    """Conditions required for a global event."""
+
+    __tablename__ = "global_event_conditions"
+
+    event_id = Column(Integer, ForeignKey("global_events.event_id"), primary_key=True)
+    condition_type = Column(Text, primary_key=True)
+    condition_target = Column(Text, primary_key=True)
+    condition_value = Column(Text)
+
+
+class GlobalEventEffect(Base):
+    """Effects applied by a global event."""
+
+    __tablename__ = "global_event_effects"
+
+    event_id = Column(Integer, ForeignKey("global_events.event_id"), primary_key=True)
+    effect_type = Column(Text, primary_key=True)
+    target = Column(Text, primary_key=True)
+    magnitude = Column(Numeric)
+
+
+class GlobalEventReward(Base):
+    """Rewards granted upon global event completion."""
+
+    __tablename__ = "global_event_rewards"
+
+    event_id = Column(Integer, ForeignKey("global_events.event_id"), primary_key=True)
+    reward_type = Column(Text, primary_key=True)
+    reward_target = Column(Text, primary_key=True)
+    reward_amount = Column(Numeric, nullable=False)
+


### PR DESCRIPTION
## Summary
- add models for global event tables with correct columns and foreign keys

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy and jose)*

------
https://chatgpt.com/codex/tasks/task_e_684e0a5ad8108330a865ae97bdf585fd