### PR TITLE
Fix kingdom resource & temple models

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Numeric,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.sql import func
@@ -869,7 +870,11 @@ class QuestKingdomTracking(Base):
 class KingdomTemple(Base):
     __tablename__ = "kingdom_temples"
 
-    temple_id = Column(Integer, primary_key=True)
+    temple_id = Column(
+        Integer,
+        primary_key=True,
+        server_default=text("nextval('kingdom_temples_temple_id_seq'::regclass)")
+    )
     kingdom_id = Column(Integer, ForeignKey("kingdoms.kingdom_id"))
     temple_name = Column(String)
     temple_type = Column(String)
@@ -884,7 +889,7 @@ class KingdomTemple(Base):
 class KingdomResources(Base):
     __tablename__ = 'kingdom_resources'
 
-    kingdom_id = Column(Integer, primary_key=True)
+    kingdom_id = Column(Integer, ForeignKey("kingdoms.kingdom_id"), primary_key=True)
     wood = Column(BigInteger, default=0)
     stone = Column(BigInteger, default=0)
     iron_ore = Column(BigInteger, default=0)


### PR DESCRIPTION
## Summary
- add `text` import to models
- ensure `kingdom_resources.kingdom_id` has a foreign key to `kingdoms`
- enforce sequence default for `kingdom_temples.temple_id`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements.txt` *(fails to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_684e0aa80c84833081edc302f6ad1cec