### PR TITLE
Fix messaging models for schema compliance

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -608,18 +608,32 @@ class Notification(Base):
 
     notification_id = Column(Integer, primary_key=True)
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.user_id"))
-    title = Column(String)
+    title = Column(Text)
     message = Column(Text)
-    category = Column(String)
-    priority = Column(String)
-    link_action = Column(String)
+    category = Column(Text)
+    priority = Column(Text)
+    link_action = Column(Text)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     is_read = Column(Boolean, default=False)
     expires_at = Column(DateTime(timezone=True))
-    source_system = Column(String)
+    source_system = Column(Text)
     last_updated = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
+
+
+class NotificationMetadata(Base):
+    """Optional key/value metadata for notifications."""
+
+    __tablename__ = "notification_metadata"
+
+    notification_id = Column(
+        Integer,
+        ForeignKey("notifications.notification_id"),
+        primary_key=True,
+    )
+    key = Column(Text, primary_key=True)
+    value = Column(Text)
 
 
 class BlackMarketListing(Base):

--- a/backend/routers/compose.py
+++ b/backend/routers/compose.py
@@ -22,7 +22,6 @@ router = APIRouter(prefix="/api/compose", tags=["compose"])
 class MessagePayload(BaseModel):
     recipient_id: str
     message: str
-    category: str | None = None
 
 
 class NoticePayload(BaseModel):
@@ -66,7 +65,6 @@ def send_message(
         recipient_id=payload.recipient_id,
         user_id=user_id,
         message=payload.message,
-        category=payload.category or "player",
     )
 
     db.add(msg)


### PR DESCRIPTION
## Summary
- add NotificationMetadata model
- correct Notification fields to Text
- drop undefined PlayerMessage.category field

## Testing
- `pytest tests/test_notifications_router.py tests/test_messages_router.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684e0aed407083309dfb83d9a0f9b267