### PR TITLE
Fix treaty and vault schema alignment

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -146,11 +146,11 @@ class AllianceVault(Base):
 
 class AllianceVaultTransactionLog(Base):
     __tablename__ = "alliance_vault_transaction_log"
-    transaction_id = Column(Integer, primary_key=True)
-    alliance_id = Column(Integer, ForeignKey("alliances.alliance_id"))
+    transaction_id = Column(BigInteger, primary_key=True)
+    alliance_id = Column(Integer, ForeignKey("alliances.alliance_id"), nullable=False)
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.user_id"))
-    action = Column(String)
-    resource_type = Column(String)
+    action = Column(Text)
+    resource_type = Column(Text)
     amount = Column(BigInteger)
     notes = Column(Text)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/routers/compose.py
+++ b/backend/routers/compose.py
@@ -35,8 +35,6 @@ class NoticePayload(BaseModel):
 class TreatyPayload(BaseModel):
     partner_alliance_id: int
     treaty_type: str
-    notes: str | None = None
-    end_date: str | None = None
 
 
 class WarPayload(BaseModel):
@@ -123,17 +121,17 @@ def propose_treaty(
         raise HTTPException(status_code=404, detail="You are not in an alliance.")
 
     db.execute(
-        text("""
+        text(
+            """
             INSERT INTO alliance_treaties
-            (alliance_id, treaty_type, partner_alliance_id, status, notes, end_date)
-            VALUES (:aid, :type, :pid, 'proposed', :notes, :ed)
-        """),
+            (alliance_id, treaty_type, partner_alliance_id, status)
+            VALUES (:aid, :type, :pid, 'proposed')
+        """
+        ),
         {
             "aid": row[0],
             "type": payload.treaty_type,
             "pid": payload.partner_alliance_id,
-            "notes": payload.notes,
-            "ed": payload.end_date,
         },
     )
 

--- a/services/alliance_vault_service.py
+++ b/services/alliance_vault_service.py
@@ -122,7 +122,7 @@ def withdraw_from_vault(
             INSERT INTO alliance_vault_transaction_log (
                 alliance_id, user_id, action, resource_type, amount, notes
             ) VALUES (
-                :aid, :uid, 'withdrawal', :res, :amt, :note
+                :aid, :uid, 'withdraw', :res, :amt, :note
             )
         """),
         {"aid": alliance_id, "uid": user_id, "res": resource_type, "amt": amount, "note": notes},

--- a/services/strategic_tick_service.py
+++ b/services/strategic_tick_service.py
@@ -111,18 +111,22 @@ def expire_treaties(db: Session) -> int:
         int: number of treaties expired
     """
     res_a = db.execute(
-        text("""
+        text(
+            """
             UPDATE alliance_treaties
                SET status = 'expired'
-             WHERE status = 'active' AND expires_at IS NOT NULL AND expires_at < now()
-        """)
+             WHERE status = 'active' AND signed_at < now() - interval '30 days'
+            """
+        )
     )
     res_k = db.execute(
-        text("""
+        text(
+            """
             UPDATE kingdom_treaties
                SET status = 'expired'
-             WHERE status = 'active' AND expires_at IS NOT NULL AND expires_at < now()
-        """)
+             WHERE status = 'active' AND signed_at < now() - interval '30 days'
+            """
+        )
     )
     db.commit()
     count = (getattr(res_a, "rowcount", 0) or 0) + (getattr(res_k, "rowcount", 0) or 0)


### PR DESCRIPTION
## Summary
- clean up alliance vault transaction action names
- update alliance vault log ORM field types
- remove unsupported treaty columns from routers and services
- update treaty expiration logic to use `signed_at`

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e09d36494833089f134530ba569be