### PR TITLE
Fix models and queries for schema tables

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -593,12 +593,23 @@ class UnitStat(Base):
 
 class KingdomTroop(Base):
     __tablename__ = "kingdom_troops"
+
     kingdom_id = Column(Integer, ForeignKey("kingdoms.kingdom_id"), primary_key=True)
     unit_type = Column(String, ForeignKey("unit_stats.unit_type"), primary_key=True)
+    unit_level = Column(Integer, primary_key=True, default=1)
     quantity = Column(Integer, default=0)
     last_updated = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
+    in_training = Column(Integer, default=0)
+    wounded = Column(Integer, default=0)
+    unit_xp = Column(Integer, default=0)
+    active_modifiers = Column(JSONB, default=dict)
+    last_modified_by = Column(UUID(as_uuid=True))
+    last_combat_at = Column(DateTime(timezone=True))
+    last_morale = Column(Integer, default=100)
+    morale_bonus = Column(Numeric, default=0)
+    damage_bonus = Column(Numeric, default=0)
 
 
 class Notification(Base):
@@ -912,4 +923,23 @@ class KingdomResources(Base):
     spear = Column(BigInteger, default=0)
     horses = Column(BigInteger, default=0)
     pitchforks = Column(BigInteger, default=0)
+
+
+class KingdomVillage(Base):
+    __tablename__ = "kingdom_villages"
+
+    village_id = Column(Integer, primary_key=True)
+    kingdom_id = Column(Integer, ForeignKey("kingdoms.kingdom_id"))
+    village_name = Column(Text, nullable=False)
+    village_type = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class KingdomVipStatus(Base):
+    __tablename__ = "kingdom_vip_status"
+
+    user_id = Column(UUID(as_uuid=True), primary_key=True)
+    vip_level = Column(Integer, default=0)
+    expires_at = Column(DateTime(timezone=True))
+    founder = Column(Boolean, default=False)
 

--- a/backend/routers/villages_router.py
+++ b/backend/routers/villages_router.py
@@ -31,9 +31,7 @@ def _fetch_villages(db: Session, kid: int):
     rows = db.execute(
         text(
             """
-            SELECT v.village_id, v.village_name, v.village_type, v.is_capital,
-                   v.population, v.defense_level, v.prosperity,
-                   v.created_at, v.last_updated,
+            SELECT v.village_id, v.village_name, v.village_type, v.created_at,
                    COUNT(b.building_id) AS building_count
             FROM kingdom_villages v
             LEFT JOIN village_buildings b ON b.village_id = v.village_id
@@ -50,13 +48,8 @@ def _fetch_villages(db: Session, kid: int):
             "village_id": r[0],
             "village_name": r[1],
             "village_type": r[2],
-            "is_capital": r[3],
-            "population": r[4],
-            "defense_level": r[5],
-            "prosperity": r[6],
-            "created_at": r[7],
-            "last_updated": r[8],
-            "building_count": r[9],
+            "created_at": r[3],
+            "building_count": r[4],
         }
         for r in rows
     ]
@@ -145,8 +138,7 @@ def get_village_summary(
     village = db.execute(
         text(
             """
-            SELECT village_id, village_name, village_type, is_capital, population,
-                   defense_level, prosperity
+            SELECT village_id, village_name, village_type, created_at
             FROM kingdom_villages
             WHERE village_id = :vid
             """
@@ -181,7 +173,7 @@ async def stream_villages(user_id: str = Depends(require_user_id), db: Session =
         while True:
             villages = _fetch_villages(db, kid)
             if villages:
-                latest = str(max(v["last_updated"] for v in villages))
+                latest = str(max(v["created_at"] for v in villages))
                 if latest != last_update:
                     last_update = latest
                     data = json.dumps(villages, default=str)

--- a/services/kingdom_setup_service.py
+++ b/services/kingdom_setup_service.py
@@ -82,8 +82,8 @@ def create_kingdom_transaction(
         vil_row = db.execute(
             text(
                 """
-                INSERT INTO kingdom_villages (kingdom_id, village_name, village_type, is_capital)
-                VALUES (:kid, :vname, 'capital', TRUE)
+                INSERT INTO kingdom_villages (kingdom_id, village_name, village_type)
+                VALUES (:kid, :vname, 'capital')
                 RETURNING village_id
                 """
             ),

--- a/tests/test_villages_summary_router.py
+++ b/tests/test_villages_summary_router.py
@@ -28,10 +28,7 @@ class DummyDB:
                 "village_id": 1,
                 "village_name": "Rivertown",
                 "village_type": "economic",
-                "is_capital": False,
-                "population": 100,
-                "defense_level": 1,
-                "prosperity": 50,
+                "created_at": 0,
             }])
         if "FROM village_resources" in str(query):
             return DummyResult([{"village_id": 1, "wood": 100}])


### PR DESCRIPTION
## Summary
- complete `KingdomTroop` columns
- define `KingdomVillage` and `KingdomVipStatus`
- remove non-existent fields from village queries
- fix initial kingdom village insert
- update village summary test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684e0ac9ba3c8330a603db7393ab6c06