### PR TITLE
Align models and services with provided schema

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -810,6 +810,8 @@ class QuestKingdomCatalogue(Base):
     last_updated = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
+    objective_type = Column(String)
+    reward_gold = Column(Integer, default=0)
 
 
 class QuestAllianceContribution(Base):
@@ -855,15 +857,26 @@ class QuestKingdomTracking(Base):
     )
     status = Column(String)
     progress = Column(Integer, default=0)
-    progress_details = Column(JSONB, default=dict)
+    progress_details = Column(JSONB, default={})
     ends_at = Column(DateTime(timezone=True))
     started_at = Column(DateTime(timezone=True), server_default=func.now())
     last_updated = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
     attempt_count = Column(Integer, default=1)
-
     started_by = Column(UUID(as_uuid=True), ForeignKey("users.user_id"))
+    objective_progress = Column(Integer, default=0)
+    is_complete = Column(Boolean, default=False)
+
+
+class RegionBonus(Base):
+    """Bonus modifiers attached to specific world regions."""
+
+    __tablename__ = "region_bonuses"
+
+    region_code = Column(String, ForeignKey("region_catalogue.region_code"), primary_key=True)
+    bonus_type = Column(String, primary_key=True)
+    bonus_value = Column(Numeric)
 
 
 class KingdomTemple(Base):

--- a/services/modifier_stack_service.py
+++ b/services/modifier_stack_service.py
@@ -58,14 +58,12 @@ def compute_modifier_stack(db: Session, kingdom_id: int) -> dict:
     ).fetchone()
     if region_row:
         region_code = region_row[0]
-        region_mods = db.execute(
-            text("SELECT resource_bonus, troop_bonus FROM region_catalogue WHERE region_code = :code"),
+        rows = db.execute(
+            text("SELECT bonus_type, bonus_value FROM region_bonuses WHERE region_code = :code"),
             {"code": region_code},
-        ).fetchone()
-        if region_mods:
-            res_bonus, troop_bonus = region_mods
-            _merge_stack(stack, {"resource_bonus": res_bonus or {}}, "Region Bonus")
-            _merge_stack(stack, {"troop_bonus": troop_bonus or {}}, "Region Bonus")
+        ).fetchall()
+        for btype, val in rows:
+            _merge_stack(stack, {btype: {"value": val}}, "Region Bonus")
 
     # --- Completed Techs ---
     load_modifier_row(

--- a/services/strategic_tick_service.py
+++ b/services/strategic_tick_service.py
@@ -88,11 +88,15 @@ def update_quest_progress(db: Session) -> int:
         int: total number of affected quests
     """
     completed = db.execute(
-        text("""
+        text(
+            """
             UPDATE quest_kingdom_tracking
-               SET status = 'completed', last_updated = now()
+               SET status = 'completed',
+                   is_complete = true,
+                   last_updated = now()
              WHERE status = 'active' AND progress >= 100
-        """)
+        """
+        )
     )
     expired = expire_quests(db)
     db.commit()


### PR DESCRIPTION
## Summary
- sync quest models with schema columns
- add region bonuses model
- use region_bonuses in modifier and progression services
- include completion flags in strategic quest updates

## Testing
- `pytest -q` *(fails: Supabase client library not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e0b5d4e448330b75940863d91ce3d