### PR TITLE
Fix region bonuses to match schema

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -14,10 +14,12 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Numeric,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.sql import func
 from backend.db_base import Base
+
 
 
 class Kingdom(Base):
@@ -247,6 +249,31 @@ class NobleHouse(Base):
     region = Column(String)
     description = Column(Text)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class RegionCatalogue(Base):
+    """Catalogue of regions players can choose from."""
+
+    __tablename__ = "region_catalogue"
+
+    region_code = Column(String, primary_key=True)
+    region_name = Column(String, nullable=False)
+    description = Column(Text)
+    wood_bonus = Column(Numeric, default=0)
+    iron_bonus = Column(Numeric, default=0)
+    troop_attack_bonus = Column(Numeric, default=0)
+
+
+class RegionStructure(Base):
+    __tablename__ = "region_structures"
+
+    region_code = Column(
+        String,
+        ForeignKey("region_catalogue.region_code"),
+        primary_key=True,
+    )
+    structure_type = Column(String, primary_key=True)
+    structure_level = Column(Integer)
 
 
 class ProjectPlayerCatalogue(Base):
@@ -709,11 +736,15 @@ class SpyMission(Base):
 
     __tablename__ = "spy_missions"
 
-    mission_id = Column(Integer, primary_key=True)
+    mission_id = Column(
+        Integer,
+        primary_key=True,
+        server_default=text("nextval('spy_missions_mission_id_seq'::regclass)"),
+    )
     kingdom_id = Column(Integer, ForeignKey("kingdoms.kingdom_id"))
     mission_type = Column(String)
     target_id = Column(Integer)
-    status = Column(String, default="active")
+    status = Column(String, server_default="active")
     launched_at = Column(DateTime(timezone=True), server_default=func.now())
     completed_at = Column(DateTime(timezone=True))
 

--- a/services/modifier_stack_service.py
+++ b/services/modifier_stack_service.py
@@ -59,13 +59,22 @@ def compute_modifier_stack(db: Session, kingdom_id: int) -> dict:
     if region_row:
         region_code = region_row[0]
         region_mods = db.execute(
-            text("SELECT resource_bonus, troop_bonus FROM region_catalogue WHERE region_code = :code"),
+            text(
+                "SELECT wood_bonus, iron_bonus, troop_attack_bonus FROM region_catalogue WHERE region_code = :code"
+            ),
             {"code": region_code},
         ).fetchone()
         if region_mods:
-            res_bonus, troop_bonus = region_mods
-            _merge_stack(stack, {"resource_bonus": res_bonus or {}}, "Region Bonus")
-            _merge_stack(stack, {"troop_bonus": troop_bonus or {}}, "Region Bonus")
+            wood, iron, attack = region_mods
+            res_mods = {}
+            if wood:
+                res_mods["wood"] = wood
+            if iron:
+                res_mods["iron"] = iron
+            if res_mods:
+                _merge_stack(stack, {"resource_bonus": res_mods}, "Region Bonus")
+            if attack:
+                _merge_stack(stack, {"troop_bonus": {"attack": attack}}, "Region Bonus")
 
     # --- Completed Techs ---
     load_modifier_row(

--- a/tests/test_region_router.py
+++ b/tests/test_region_router.py
@@ -34,8 +34,9 @@ def test_get_regions_success():
             "region_code": "north",
             "region_name": "North",
             "description": "cold",
-            "resource_bonus": {"iron": 10},
-            "troop_bonus": {"defense": 5},
+            "wood_bonus": 1,
+            "iron_bonus": 2,
+            "troop_attack_bonus": 3,
         }
     ]
     client = DummyClient({"region_catalogue": DummyTable(data=rows)})


### PR DESCRIPTION
## Summary
- define `RegionCatalogue` and `RegionStructure` models
- align `SpyMission` model with real sequence defaults
- update modifier services to use `wood_bonus`, `iron_bonus`, and `troop_attack_bonus`
- remove deprecated region slot bonus query
- adjust region router test data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684e0b6d5a14833094c67969dd12e3b7