### PR TITLE
Fix TradeLog defaults and type hints

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Numeric,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.sql import func
@@ -172,8 +173,8 @@ class TradeLog(Base):
     seller_alliance_id = Column(Integer)
     buyer_name = Column(Text)
     seller_name = Column(Text)
-    trade_type = Column(String)
-    trade_status = Column(String, default="completed")
+    trade_type = Column(String, server_default=text("'player_trade'"))
+    trade_status = Column(String, server_default=text("'completed'"))
     initiated_by_system = Column(Boolean, default=False)
     last_updated = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/services/training_catalog_service.py
+++ b/services/training_catalog_service.py
@@ -40,12 +40,12 @@ def list_units(db: Session) -> list[dict]:
         return []
 
 
-def get_unit_by_code(db: Session, unit_id: str) -> Optional[dict]:
+def get_unit_by_code(db: Session, unit_id: int) -> Optional[dict]:
     """
     Fetch a single unit definition by unit_id.
 
     Args:
-        unit_id: The internal ID/code of the unit to retrieve
+        unit_id: The numerical ID of the unit to retrieve
 
     Returns:
         dict | None: Unit definition if found


### PR DESCRIPTION
## Summary
- set schema defaults on `TradeLog` ORM
- expose SQLAlchemy `text()` utility
- enforce integer id in training catalog service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684e0b8e75c08330829214f73ed661a0