### PR TITLE
Fix treaty modifier queries

### DIFF
--- a/services/modifier_stack_service.py
+++ b/services/modifier_stack_service.py
@@ -117,16 +117,26 @@ def compute_modifier_stack(db: Session, kingdom_id: int) -> dict:
     )
 
     # --- Active Treaties ---
-    treaties = db.execute(
-        text("""
-            SELECT modifiers FROM kingdom_treaties
-            WHERE (kingdom_id = :kid OR partner_kingdom_id = :kid)
-            AND status = 'active' AND modifiers IS NOT NULL
-        """),
+    treaty_rows = db.execute(
+        text(
+            """
+            SELECT tm.effect_type, tm.target, tm.magnitude
+              FROM kingdom_treaties kt
+              JOIN treaty_modifiers tm ON tm.treaty_id = kt.treaty_id
+             WHERE (kt.kingdom_id = :kid OR kt.partner_kingdom_id = :kid)
+               AND kt.status = 'active'
+            """
+        ),
         {"kid": kingdom_id},
     ).fetchall()
-    for (mods,) in treaties:
-        _merge_stack(stack, mods or {}, "Treaty")
+    treaty_mods: dict = {}
+    for eff, tgt, mag in treaty_rows:
+        if mag is None:
+            continue
+        bucket = treaty_mods.setdefault(eff, {})
+        bucket[tgt] = bucket.get(tgt, 0) + float(mag)
+    if treaty_mods:
+        _merge_stack(stack, treaty_mods, "Treaty")
 
     # --- Spy Effects ---
     spy_row = db.execute(


### PR DESCRIPTION
## Summary
- update `_treaty_modifiers` to read from treaty_modifiers table
- compute modifier stacks using treaty_modifiers instead of obsolete JSON column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684e0b9ee6bc833088305215158a2868