### PR TITLE
Add treaty schema models

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -14,8 +14,9 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Numeric,
+    text,
 )
-from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.dialects.postgresql import UUID, JSONB, ARRAY
 from sqlalchemy.sql import func
 from backend.db_base import Base
 
@@ -912,4 +913,47 @@ class KingdomResources(Base):
     spear = Column(BigInteger, default=0)
     horses = Column(BigInteger, default=0)
     pitchforks = Column(BigInteger, default=0)
+
+
+class TreatyNegotiationLog(Base):
+    __tablename__ = "treaty_negotiation_log"
+
+    log_id = Column(Integer, primary_key=True)
+    treaty_id = Column(Integer, ForeignKey("alliance_treaties.treaty_id"))
+    acting_alliance_id = Column(Integer)
+    action = Column(Text)
+    message = Column(Text)
+    created_at = Column(DateTime(timezone=False), server_default=func.now())
+
+
+class TreatyTerms(Base):
+    __tablename__ = "treaty_terms"
+
+    treaty_id = Column(Integer, ForeignKey("alliance_treaties.treaty_id"), primary_key=True)
+    term_type = Column(Text, primary_key=True)
+    value = Column(Text)
+
+
+class TreatyTypeCatalogue(Base):
+    __tablename__ = "treaty_type_catalogue"
+
+    treaty_type = Column(Text, primary_key=True)
+    display_name = Column(Text, nullable=False)
+    description = Column(Text)
+    duration_days = Column(Integer, default=0)
+    is_mutual = Column(Boolean, default=True)
+    triggers_war_support = Column(Boolean, default=False)
+    allows_cancelation = Column(Boolean, default=True)
+    cancel_notice_days = Column(Integer, default=0)
+    is_exclusive = Column(Boolean, default=False)
+    treaty_group = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    last_updated = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    join_wars = Column(Boolean, default=False)
+    blocks_war = Column(Boolean, default=False)
+    blocks_spy_ops = Column(Boolean, default=False)
+    enables_shared_chat = Column(Boolean, default=False)
+    enables_trade_bonus = Column(Boolean, default=False)
+    auto_renew = Column(Boolean, default=False)
+    exclusive_with = Column(ARRAY(Text), server_default=text("'{}'::text[]"))
 


### PR DESCRIPTION
## Summary
- implement models for treaty_negotiation_log, treaty_terms, treaty_type_catalogue
- add ARRAY import for Postgres

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy and jose)*

------
https://chatgpt.com/codex/tasks/task_e_684e0bad4390833099109cb48b57b39e