### PR TITLE
Fix announcement fetch

### DIFF
--- a/Javascript/login.js
+++ b/Javascript/login.js
@@ -167,8 +167,8 @@ async function loadAnnouncements() {
       console.debug(text.slice(0, 150));
       return;
     }
-    const announcements = await res.json();
-    announcements.forEach((a) => {
+    const { announcements } = await res.json();
+    announcements.forEach(a => {
       const li = document.createElement('li');
       li.textContent = `${a.title} - ${a.content}`;
       announcementList.appendChild(li);

--- a/Javascript/play.js
+++ b/Javascript/play.js
@@ -198,7 +198,7 @@ async function loadAnnouncements() {
   if (!el) return;
 
   try {
-    const announcements = await jsonFetch('/api/login/announcements');
+    const { announcements } = await jsonFetch('/api/login/announcements');
     el.innerHTML = announcements.map(a =>
       `<div class="announcement"><h4>${escapeHTML(a.title)}</h4><p>${escapeHTML(a.content)}</p></div>`
     ).join('');


### PR DESCRIPTION
## Summary
- fix announcement JSON handling in login and play scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684e36c59bc0833093411133c6d29ff3