### PR TITLE
Align progression models with schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,18 +124,11 @@ runtime.
 
 This will create all tables referenced by the frontend.
 
-After loading the base schema, apply the SQL files in the `migrations/` folder
-to keep your database up to date. These scripts also seed initial data.
-For example, run the regions migration to populate the `region_catalogue`
-table used on **play.html**:
-
-```bash
-psql -f migrations/2025_06_08_add_regions.sql
-```
-
-Without this migration the `/api/kingdom/regions` request will fall back to
-sample regions bundled with the backend, so the dropdown will work but won't
-reflect any custom data you expected.
+If your deployment requires additional data seeding or custom tables, load any
+project-specific SQL migrations after `full_schema.sql`. Example documentation
+references a `2025_06_08_add_regions.sql` script used to populate the
+`region_catalogue` table, but the migrations directory is not included in this
+repository.
 
 ---
 

--- a/full_schema.sql
+++ b/full_schema.sql
@@ -519,6 +519,50 @@ CREATE TABLE public.kingdom_history_log (
   CONSTRAINT kingdom_history_log_pkey PRIMARY KEY (log_id),
   CONSTRAINT kingdom_history_log_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id)
 );
+
+-- Table added to align with progression models
+CREATE TABLE public.kingdom_castle_progression (
+  kingdom_id integer PRIMARY KEY REFERENCES public.kingdoms(kingdom_id),
+  castle_level integer DEFAULT 1,
+  castle_xp integer DEFAULT 0,
+  xp_for_next integer DEFAULT 100,
+  last_updated timestamp with time zone DEFAULT now()
+);
+
+CREATE SEQUENCE IF NOT EXISTS kingdom_nobles_noble_id_seq;
+CREATE TABLE public.kingdom_nobles (
+  noble_id integer NOT NULL DEFAULT nextval('kingdom_nobles_noble_id_seq'::regclass),
+  kingdom_id integer,
+  noble_name text NOT NULL,
+  title text,
+  level integer DEFAULT 1,
+  experience integer DEFAULT 0,
+  loyalty integer DEFAULT 50,
+  specialization text DEFAULT 'general',
+  assigned_village_id integer,
+  is_active boolean DEFAULT true,
+  created_at timestamp with time zone DEFAULT now(),
+  CONSTRAINT kingdom_nobles_pkey PRIMARY KEY (noble_id),
+  CONSTRAINT kingdom_nobles_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id),
+  CONSTRAINT kingdom_nobles_assigned_village_id_fkey FOREIGN KEY (assigned_village_id) REFERENCES public.kingdom_villages(village_id)
+);
+
+CREATE SEQUENCE IF NOT EXISTS kingdom_knights_knight_id_seq;
+CREATE TABLE public.kingdom_knights (
+  knight_id integer NOT NULL DEFAULT nextval('kingdom_knights_knight_id_seq'::regclass),
+  kingdom_id integer,
+  knight_name text NOT NULL,
+  rank text DEFAULT 'Squire',
+  level integer DEFAULT 1,
+  experience integer DEFAULT 0,
+  leadership integer DEFAULT 10,
+  tactics integer DEFAULT 10,
+  morale_aura integer DEFAULT 0,
+  is_active boolean DEFAULT true,
+  created_at timestamp with time zone DEFAULT now(),
+  CONSTRAINT kingdom_knights_pkey PRIMARY KEY (knight_id),
+  CONSTRAINT kingdom_knights_kingdom_id_fkey FOREIGN KEY (kingdom_id) REFERENCES public.kingdoms(kingdom_id)
+);
 CREATE TABLE public.kingdom_religion (
   kingdom_id integer NOT NULL,
   religion_name text,

--- a/models/progression.py
+++ b/models/progression.py
@@ -38,7 +38,7 @@ class KingdomNoble(Base):
 
     noble_id = Column(Integer, primary_key=True)
     kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'))
-    name = Column(String, nullable=False)
+    noble_name = Column(String, nullable=False)
     title = Column(String, nullable=False)
     level = Column(Integer, default=1)
     experience = Column(Integer, default=0)
@@ -59,7 +59,7 @@ class KingdomKnight(Base):
 
     knight_id = Column(Integer, primary_key=True)
     kingdom_id = Column(Integer, ForeignKey('kingdoms.kingdom_id'))
-    name = Column(String, nullable=False)
+    knight_name = Column(String, nullable=False)
     rank = Column(String, default='Squire')  # e.g., 'Squire', 'Knight', 'Champion', 'Paladin'
     level = Column(Integer, default=1)
     experience = Column(Integer, default=0)


### PR DESCRIPTION
## Summary
- add missing tables `kingdom_castle_progression`, `kingdom_nobles`, and `kingdom_knights` to `full_schema.sql`
- match ORM models to use `noble_name` and `knight_name`
- clarify README about optional migrations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f78b047d88330893cf19b0f1e658d